### PR TITLE
Actually execute update-theme.py

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,8 +5,12 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    rust: latest
+    python: "3.12"
   commands:
+    # Generate "book/theme/index.hbs" as "skeleton" of the generated pages.
+    - book/update-theme.py
+    # Install mdbook.
     - mkdir -p $HOME/bin
     - curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-quickinstall/releases/download/mdbook-0.4.40/mdbook-0.4.40-x86_64-unknown-linux-gnu.tar.gz | tar -xzvvf - -C $HOME/bin
+    # Convert the book to HTML.
     - $HOME/bin/mdbook build book --dest-dir $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
Darn it, sorry! Hopefully this is the last PR to generate the docs. The hook works fine and the docs are rendered and deployed: <https://rinja.readthedocs.io/en/latest/>. But the index.hbs template is not generated, so the version selector is in it's default place and partially overlaps the text.