### PR TITLE
derive: add benchmark

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         package: [
-          rinja, rinja_actix, rinja_axum, rinja_derive, rinja_escape,
+          rinja, rinja_actix, rinja_axum, rinja_derive, rinja_derive_standalone, rinja_escape,
           rinja_parser, rinja_rocket, rinja_warp, testing,
         ]
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "rinja_actix",
     "rinja_axum",
     "rinja_derive",
+    "rinja_derive_standalone",
     "rinja_escape",
     "rinja_parser",
     "rinja_rocket",

--- a/rinja_derive/src/heritage.rs
+++ b/rinja_derive/src/heritage.rs
@@ -2,10 +2,11 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::rc::Rc;
 
-use crate::config::Config;
-use crate::{CompileError, FileInfo};
 use parser::node::{BlockDef, Macro};
 use parser::{Node, Parsed, WithSpan};
+
+use crate::config::Config;
+use crate::{CompileError, FileInfo};
 
 pub(crate) struct Heritage<'a> {
     pub(crate) root: &'a Context<'a>,

--- a/rinja_derive/src/input.rs
+++ b/rinja_derive/src/input.rs
@@ -4,12 +4,12 @@ use std::rc::Rc;
 use std::str::FromStr;
 
 use mime::Mime;
+use parser::{Node, Parsed, Syntax};
 use quote::ToTokens;
 use syn::punctuated::Punctuated;
 
 use crate::config::{get_template_source, Config};
 use crate::CompileError;
-use parser::{Node, Parsed, Syntax};
 
 pub(crate) struct TemplateInput<'a> {
     pub(crate) ast: &'a syn::DeriveInput,

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -1,7 +1,8 @@
-// Files containing tests for generated code.
+//! Files containing tests for generated code.
+
+use std::fmt::Write;
 
 use crate::build_template;
-use std::fmt::Write;
 
 #[test]
 fn check_if_let() {

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "rinja_derive_standalone"
+version = "0.13.0"
+description = "Procedural macro package for Rinja"
+homepage = "https://github.com/rinja-rs/rinja"
+repository = "https://github.com/rinja-rs/rinja"
+license = "MIT/Apache-2.0"
+workspace = ".."
+readme = "README.md"
+edition = "2021"
+rust-version = "1.65"
+
+[features]
+default = ["__standalone"]
+__standalone = []
+config = ["dep:serde", "dep:basic-toml"]
+humansize = []
+urlencode = []
+serde_json = []
+num-traits = []
+with-actix-web = []
+with-axum = []
+with-rocket = []
+with-warp = []
+
+[dependencies]
+parser = { package = "rinja_parser", version = "0.3", path = "../rinja_parser" }
+mime = "0.3"
+mime_guess = "2"
+proc-macro2 = "1"
+quote = "1"
+serde = { version = "1.0", optional = true, features = ["derive"] }
+syn = "2"
+basic-toml = { version = "0.1.1", optional = true }
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "derive-template"
+harness = false
+required-features = ["__standalone"]

--- a/rinja_derive_standalone/LICENSE-APACHE
+++ b/rinja_derive_standalone/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/rinja_derive_standalone/LICENSE-MIT
+++ b/rinja_derive_standalone/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/rinja_derive_standalone/README.md
+++ b/rinja_derive_standalone/README.md
@@ -1,0 +1,5 @@
+This crate embeds the source of `rinja_derive`, but is not a `proc_macro`.
+This way we can more easily access the internals of the crate.
+
+To run the benchmark, execute `cargo bench` in this folder, or
+`cargo bench -p rinja_derive_standalone` in the project root.

--- a/rinja_derive_standalone/benches/derive-template.rs
+++ b/rinja_derive_standalone/benches/derive-template.rs
@@ -1,0 +1,25 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use quote::quote;
+
+criterion_main!(benches);
+criterion_group!(benches, functions);
+
+fn functions(c: &mut Criterion) {
+    c.bench_function("hello_world", hello_world);
+}
+
+fn hello_world(b: &mut criterion::Bencher<'_>) {
+    let ts = quote! {
+        #[derive(Template)]
+        #[template(
+            source = "<html><body><h1>Hello, {{user}}!</h1></body></html>",
+            ext = "html"
+        )]
+        struct Hello<'a> {
+            user: &'a str,
+        }
+    };
+    b.iter(|| {
+        rinja_derive_standalone::derive_template2(black_box(&ts).clone());
+    })
+}

--- a/rinja_derive_standalone/src
+++ b/rinja_derive_standalone/src
@@ -1,0 +1,1 @@
+../rinja_derive/src/

--- a/rinja_derive_standalone/templates
+++ b/rinja_derive_standalone/templates
@@ -1,0 +1,1 @@
+../rinja_derive/templates/


### PR DESCRIPTION
This PR adds the crate "rinja_derive_standalone", which is just like "rinja_derive", though not a "proc_macro". This way we can easily expose it's internals for testing and benchmarking.

Right now, the PR is more or less a prove of concept, and it probably needs a handful more useful benchmark use cases to be worth the hassle. 

Resolves #12.