### PR TITLE
Don't capture `std::fmt::Error` in `rinja::Error`

### DIFF
--- a/rinja/src/error.rs
+++ b/rinja/src/error.rs
@@ -1,7 +1,7 @@
 use std::convert::Infallible;
 use std::fmt::{self, Display};
 
-pub type Result<I, E = Error> = ::std::result::Result<I, E>;
+pub type Result<I, E = Error> = std::result::Result<I, E>;
 
 /// rinja error type
 ///
@@ -28,13 +28,11 @@ pub type Result<I, E = Error> = ::std::result::Result<I, E>;
 pub enum Error {
     /// formatting error
     Fmt(fmt::Error),
-
     /// an error raised by using `?` in a template
     Custom(Box<dyn std::error::Error + Send + Sync>),
-
     /// json conversion error
     #[cfg(feature = "serde_json")]
-    Json(::serde_json::Error),
+    Json(serde_json::Error),
 }
 
 impl std::error::Error for Error {
@@ -66,8 +64,8 @@ impl From<fmt::Error> for Error {
 }
 
 #[cfg(feature = "serde_json")]
-impl From<::serde_json::Error> for Error {
-    fn from(err: ::serde_json::Error) -> Self {
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
         Error::Json(err)
     }
 }

--- a/rinja/src/error.rs
+++ b/rinja/src/error.rs
@@ -27,7 +27,7 @@ pub type Result<I, E = Error> = std::result::Result<I, E>;
 #[derive(Debug)]
 pub enum Error {
     /// formatting error
-    Fmt(fmt::Error),
+    Fmt,
     /// an error raised by using `?` in a template
     Custom(Box<dyn std::error::Error + Send + Sync>),
     /// json conversion error
@@ -38,7 +38,7 @@ pub enum Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
-            Error::Fmt(ref err) => Some(err),
+            Error::Fmt => None,
             Error::Custom(ref err) => Some(err.as_ref()),
             #[cfg(feature = "serde_json")]
             Error::Json(ref err) => Some(err),
@@ -49,7 +49,7 @@ impl std::error::Error for Error {
 impl Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Fmt(err) => write!(formatter, "formatting error: {err}"),
+            Error::Fmt => write!(formatter, "formatting error"),
             Error::Custom(err) => write!(formatter, "{err}"),
             #[cfg(feature = "serde_json")]
             Error::Json(err) => write!(formatter, "json conversion error: {err}"),
@@ -58,13 +58,15 @@ impl Display for Error {
 }
 
 impl From<fmt::Error> for Error {
-    fn from(err: fmt::Error) -> Self {
-        Error::Fmt(err)
+    #[inline]
+    fn from(_: fmt::Error) -> Self {
+        Error::Fmt
     }
 }
 
 #[cfg(feature = "serde_json")]
 impl From<serde_json::Error> for Error {
+    #[inline]
     fn from(err: serde_json::Error) -> Self {
         Error::Json(err)
     }

--- a/rinja/src/filters/mod.rs
+++ b/rinja/src/filters/mod.rs
@@ -22,9 +22,7 @@ use dep_num_traits::{cast::NumCast, Signed};
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use rinja_escape::{Escaper, MarkupDisplay};
 
-use super::Result;
-#[allow(unused_imports)]
-use crate::error::Error::Fmt;
+use crate::{Error, Result};
 
 #[cfg(feature = "percent-encoding")]
 // Urlencode char encoding set. Only the characters in the unreserved set don't
@@ -401,7 +399,7 @@ pub fn into_f64<T>(number: T) -> Result<f64>
 where
     T: NumCast,
 {
-    number.to_f64().ok_or(Fmt(fmt::Error))
+    number.to_f64().ok_or(Error::Fmt)
 }
 
 #[cfg(feature = "num-traits")]
@@ -410,7 +408,7 @@ pub fn into_isize<T>(number: T) -> Result<isize>
 where
     T: NumCast,
 {
-    number.to_isize().ok_or(Fmt(fmt::Error))
+    number.to_isize().ok_or(Error::Fmt)
 }
 
 /// Joins iterable into a string separated by provided argument
@@ -728,8 +726,8 @@ mod tests {
         assert_eq!(into_isize(1.5_f64).unwrap(), 1_isize);
         assert_eq!(into_isize(-1.5_f64).unwrap(), -1_isize);
         match into_isize(f64::INFINITY) {
-            Err(Fmt(fmt::Error)) => {}
-            _ => panic!("Should return error of type Err(Fmt(fmt::Error))"),
+            Err(Error::Fmt) => {}
+            _ => panic!("Should return error of type Err(Error::Fmt)"),
         };
     }
 

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -1599,9 +1599,9 @@ impl<'a> Generator<'a> {
                         buf.writeln(");");
                         buf.writeln("let _len = _cycle.len();");
                         buf.writeln("if _len == 0 {");
-                        buf.write("return ::core::result::Result::Err(");
-                        buf.write(CRATE);
-                        buf.writeln("::Error::Fmt(::core::fmt::Error));");
+                        buf.writeln(format_args!(
+                            "return ::core::result::Result::Err({CRATE}::Error::Fmt);"
+                        ));
                         buf.writeln("}");
                         buf.writeln("_cycle[_loop_item.index % _len]");
                         buf.writeln("})");


### PR DESCRIPTION
`std::fmt::Error` does not know why it failed, only that it failed, as it has a single value. This PR removes the captured value, to make the code a bit more dense.