### PR TITLE
Make JSON prettifying optional

### DIFF
--- a/book/src/filters.md
+++ b/book/src/filters.md
@@ -468,6 +468,18 @@ Ugly: <script>var data = "{{data|json}}";</script>
 Ugly: <script>var data = '{{data|json|safe}}';</script>
 ```
 
+By default, a compact representation of the data is generated, i.e. no whitespaces are generated
+between individual values. To generate a readable representation, you can either pass an integer
+how many spaces to use as indentation, or you can pass a string that gets used as prefix:
+
+```jinja2
+Prefix with four spaces:
+<textarea>{{data|tojson(4)}}</textarea>
+
+Prefix with two &nbsp; characters:
+<p>{{data|tojson("\u{a0}\u{a0}")}}</p>
+```
+
 ## Custom Filters
 [#custom-filters]: #custom-filters
 

--- a/rinja/benches/to-json.rs
+++ b/rinja/benches/to-json.rs
@@ -13,7 +13,7 @@ fn functions(c: &mut Criterion) {
 fn escape_json(b: &mut criterion::Bencher<'_>) {
     b.iter(|| {
         for &s in STRINGS {
-            format!("{}", json(s).unwrap());
+            format!("{}", json(s, ()).unwrap());
         }
     });
 }
@@ -21,7 +21,7 @@ fn escape_json(b: &mut criterion::Bencher<'_>) {
 fn escape_json_for_html(b: &mut criterion::Bencher<'_>) {
     b.iter(|| {
         for &s in STRINGS {
-            format!("{}", MarkupDisplay::new_unsafe(json(s).unwrap(), Html));
+            format!("{}", MarkupDisplay::new_unsafe(json(s, ()).unwrap(), Html));
         }
     });
 }

--- a/rinja/benches/to-json.rs
+++ b/rinja/benches/to-json.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use rinja::filters::json;
+use rinja::filters::{json, json_pretty};
 use rinja_escape::{Html, MarkupDisplay};
 
 criterion_main!(benches);
@@ -7,13 +7,24 @@ criterion_group!(benches, functions);
 
 fn functions(c: &mut Criterion) {
     c.bench_function("escape JSON", escape_json);
+    c.bench_function("escape JSON (pretty)", escape_json_pretty);
     c.bench_function("escape JSON for HTML", escape_json_for_html);
+    c.bench_function("escape JSON for HTML (pretty)", escape_json_for_html);
+    c.bench_function("escape JSON for HTML (pretty)", escape_json_for_html_pretty);
 }
 
 fn escape_json(b: &mut criterion::Bencher<'_>) {
     b.iter(|| {
         for &s in STRINGS {
-            format!("{}", json(s, ()).unwrap());
+            format!("{}", json(s).unwrap());
+        }
+    });
+}
+
+fn escape_json_pretty(b: &mut criterion::Bencher<'_>) {
+    b.iter(|| {
+        for &s in STRINGS {
+            format!("{}", json_pretty(s, 2).unwrap());
         }
     });
 }
@@ -21,7 +32,18 @@ fn escape_json(b: &mut criterion::Bencher<'_>) {
 fn escape_json_for_html(b: &mut criterion::Bencher<'_>) {
     b.iter(|| {
         for &s in STRINGS {
-            format!("{}", MarkupDisplay::new_unsafe(json(s, ()).unwrap(), Html));
+            format!("{}", MarkupDisplay::new_unsafe(json(s).unwrap(), Html));
+        }
+    });
+}
+
+fn escape_json_for_html_pretty(b: &mut criterion::Bencher<'_>) {
+    b.iter(|| {
+        for &s in STRINGS {
+            format!(
+                "{}",
+                MarkupDisplay::new_unsafe(json_pretty(s, 2).unwrap(), Html),
+            );
         }
     });
 }

--- a/rinja/src/filters/mod.rs
+++ b/rinja/src/filters/mod.rs
@@ -10,7 +10,7 @@ use std::fmt::{self, Write};
 #[cfg(feature = "serde_json")]
 mod json;
 #[cfg(feature = "serde_json")]
-pub use self::json::{json, AsIndent};
+pub use self::json::{json, json_pretty, AsIndent};
 
 #[cfg(feature = "humansize")]
 use humansize::{ISizeFormatter, ToF64, DECIMAL};

--- a/rinja/src/filters/mod.rs
+++ b/rinja/src/filters/mod.rs
@@ -10,7 +10,7 @@ use std::fmt::{self, Write};
 #[cfg(feature = "serde_json")]
 mod json;
 #[cfg(feature = "serde_json")]
-pub use self::json::json;
+pub use self::json::{json, AsIndent};
 
 #[cfg(feature = "humansize")]
 use humansize::{ISizeFormatter, ToF64, DECIMAL};

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -1364,14 +1364,14 @@ impl<'a> Generator<'a> {
             ));
         }
 
-        buf.write(CRATE);
-        buf.write("::filters::json(");
-        self._visit_args(ctx, buf, args)?;
-        match args.len() {
-            1 => buf.write(", ()"),
-            2 => {}
+        let filter = match args.len() {
+            1 => "json",
+            2 => "json_pretty",
             _ => return Err(ctx.generate_error("unexpected argument(s) in `json` filter", node)),
-        }
+        };
+
+        buf.write(format_args!("{CRATE}::filters::{filter}("));
+        self._visit_args(ctx, buf, args)?;
         buf.write(")?");
         Ok(DisplayWrap::Unwrapped)
     }

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -1364,12 +1364,14 @@ impl<'a> Generator<'a> {
             ));
         }
 
-        if args.len() != 1 {
-            return Err(ctx.generate_error("unexpected argument(s) in `json` filter", node));
-        }
         buf.write(CRATE);
         buf.write("::filters::json(");
         self._visit_args(ctx, buf, args)?;
+        match args.len() {
+            1 => buf.write(", ()"),
+            2 => {}
+            _ => return Err(ctx.generate_error("unexpected argument(s) in `json` filter", node)),
+        }
         buf.write(")?");
         Ok(DisplayWrap::Unwrapped)
     }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -17,6 +17,7 @@ phf = { version = "0.11", features = ["macros" ]}
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
+rinja = { path = "../rinja", version = "0.13", features = ["serde_json"] }
 criterion = "0.5"
 trybuild = "1.0.76"
 

--- a/testing/templates/allow-whitespaces.html
+++ b/testing/templates/allow-whitespaces.html
@@ -25,11 +25,11 @@
 {% let hash = &nested_1.nested_2.hash %}
 #}
 
-{{ array| json }}
-{{ array[..]| json }}{{ array [ .. ]| json }}
-{{ array[1..2]| json }}{{ array [ 1 .. 2 ]| json }}
-{{ array[1..=2]| json }}{{ array [ 1 ..= 2 ]| json }}
-{{ array[(0+1)..(3-1)]| json }}{{ array [ ( 0 + 1 ) .. ( 3 - 1 ) ]| json }}
+{{ array| json(2) }}
+{{ array[..]| json(2) }}{{ array [ .. ]| json(2) }}
+{{ array[1..2]| json(2) }}{{ array [ 1 .. 2 ]| json(2) }}
+{{ array[1..=2]| json(2) }}{{ array [ 1 ..= 2 ]| json(2) }}
+{{ array[(0+1)..(3-1)]| json(2) }}{{ array [ ( 0 + 1 ) .. ( 3 - 1 ) ]| json(2) }}
 
 {{-1}}{{ -1 }}{{ - 1 }}
 {{1+2}}{{ 1+2 }}{{ 1 +2 }}{{ 1+ 2 }} {{ 1 + 2 }}

--- a/testing/templates/json.html
+++ b/testing/templates/json.html
@@ -1,4 +1,0 @@
-{
-  "foo": "{{ foo }}",
-  "bar": {{ bar|json|safe }}
-}

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -237,7 +237,7 @@ fn test_pretty_json() {
 #[template(source = r#"{{ bar|json(indent)|safe }}"#, ext = "txt")]
 struct DynamicJsonTemplate<'a> {
     bar: &'a Value,
-    indent: Option<&'a str>,
+    indent: &'a str,
 }
 
 #[cfg(feature = "serde-json")]
@@ -246,7 +246,7 @@ fn test_dynamic_json() {
     let val = json!({"arr": ["one", 2]});
     let t = DynamicJsonTemplate {
         bar: &val,
-        indent: Some("?"),
+        indent: "?",
     };
     assert_eq!(
         t.render().unwrap(),
@@ -257,12 +257,6 @@ fn test_dynamic_json() {
 ?]
 }"#
     );
-
-    let t = DynamicJsonTemplate {
-        bar: &val,
-        indent: None,
-    };
-    assert_eq!(t.render().unwrap(), r#"{"arr":["one",2]}"#);
 }
 
 #[derive(Template)]

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -164,7 +164,13 @@ fn test_vec_join() {
 
 #[cfg(feature = "serde_json")]
 #[derive(Template)]
-#[template(path = "json.html")]
+#[template(
+    source = r#"{
+  "foo": "{{ foo }}",
+  "bar": {{ bar|json|safe }}
+}"#,
+    ext = "txt"
+)]
 struct JsonTemplate<'a> {
     foo: &'a str,
     bar: &'a Value,
@@ -175,6 +181,37 @@ struct JsonTemplate<'a> {
 fn test_json() {
     let val = json!({"arr": [ "one", 2, true, null ]});
     let t = JsonTemplate {
+        foo: "a",
+        bar: &val,
+    };
+    assert_eq!(
+        t.render().unwrap(),
+        r#"{
+  "foo": "a",
+  "bar": {"arr":["one",2,true,null]}
+}"#
+    );
+}
+
+#[cfg(feature = "serde-json")]
+#[derive(Template)]
+#[template(
+    source = r#"{
+  "foo": "{{ foo }}",
+  "bar": {{ bar|json(2)|safe }}
+}"#,
+    ext = "txt"
+)]
+struct PrettyJsonTemplate<'a> {
+    foo: &'a str,
+    bar: &'a Value,
+}
+
+#[cfg(feature = "serde-json")]
+#[test]
+fn test_pretty_json() {
+    let val = json!({"arr": [ "one", 2, true, null ]});
+    let t = PrettyJsonTemplate {
         foo: "a",
         bar: &val,
     };
@@ -193,6 +230,39 @@ fn test_json() {
 }
 }"#
     );
+}
+
+#[cfg(feature = "serde-json")]
+#[derive(Template)]
+#[template(source = r#"{{ bar|json(indent)|safe }}"#, ext = "txt")]
+struct DynamicJsonTemplate<'a> {
+    bar: &'a Value,
+    indent: Option<&'a str>,
+}
+
+#[cfg(feature = "serde-json")]
+#[test]
+fn test_dynamic_json() {
+    let val = json!({"arr": ["one", 2]});
+    let t = DynamicJsonTemplate {
+        bar: &val,
+        indent: Some("?"),
+    };
+    assert_eq!(
+        t.render().unwrap(),
+        r#"{
+?"arr": [
+??"one",
+??2
+?]
+}"#
+    );
+
+    let t = DynamicJsonTemplate {
+        bar: &val,
+        indent: None,
+    };
+    assert_eq!(t.render().unwrap(), r#"{"arr":["one",2]}"#);
 }
 
 #[derive(Template)]

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -193,7 +193,7 @@ fn test_json() {
     );
 }
 
-#[cfg(feature = "serde-json")]
+#[cfg(feature = "serde_json")]
 #[derive(Template)]
 #[template(
     source = r#"{
@@ -207,7 +207,7 @@ struct PrettyJsonTemplate<'a> {
     bar: &'a Value,
 }
 
-#[cfg(feature = "serde-json")]
+#[cfg(feature = "serde_json")]
 #[test]
 fn test_pretty_json() {
     let val = json!({"arr": [ "one", 2, true, null ]});
@@ -232,7 +232,7 @@ fn test_pretty_json() {
     );
 }
 
-#[cfg(feature = "serde-json")]
+#[cfg(feature = "serde_json")]
 #[derive(Template)]
 #[template(source = r#"{{ bar|json(indent)|safe }}"#, ext = "txt")]
 struct DynamicJsonTemplate<'a> {
@@ -240,7 +240,7 @@ struct DynamicJsonTemplate<'a> {
     indent: &'a str,
 }
 
-#[cfg(feature = "serde-json")]
+#[cfg(feature = "serde_json")]
 #[test]
 fn test_dynamic_json() {
     let val = json!({"arr": ["one", 2]});

--- a/testing/tests/ui/json-too-many-args.rs
+++ b/testing/tests/ui/json-too-many-args.rs
@@ -1,0 +1,10 @@
+#![cfg(feature = "serde_json")]
+
+use rinja::Template;
+
+#[derive(Template)]
+#[template(ext = "txt", source = "{{ 1|json(2, 3) }}")]
+struct OneTwoThree;
+
+fn main() {
+}

--- a/testing/tests/ui/json-too-many-args.stderr
+++ b/testing/tests/ui/json-too-many-args.stderr
@@ -1,0 +1,9 @@
+error: unexpected argument(s) in `json` filter
+ --> OneTwoThree.txt:1:3
+       "1|json(2, 3) }}"
+ --> tests/ui/json-too-many-args.rs:5:10
+  |
+5 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This PR adds an optional argument to the `|tojson` filter, which controls if the serialized JSON data gets prettified or not. The arguments works the same as flask's [`|tojson`][flask] filter, which passes the argument to python's [`json.dumps()`][python]:

* Omitting the argument, providing a negative integer, or `None`, then compact JSON data is generated.
* Providing a non-negative integer, then this amount of ASCII spaces is used to indent the data. (Capped to 16 characters.)
* Providing a string, then this string is used as prefix. I attempts are made to ensure that the prefix actually consists of whitespaces, because chances are, that if you provide e.g. `&nsbp;`, then you are doing it intentionally.

This is a breaking change, because it changes the default behavior to not prettify the data. This is done intentionally, because this is how it works in flask.

[flask]: https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.tojson
[python]: https://docs.python.org/3/library/json.html#json.dump