### PR TITLE
Add support for `..` in let pattern matching for structs

### DIFF
--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -870,8 +870,8 @@ impl<'a> Generator<'a> {
                 }
                 Ok(false)
             }
-            Target::Struct(_, named_targets) => {
-                for (_, target) in named_targets {
+            Target::Struct { targets, .. } => {
+                for (_, target) in targets {
                     match self.is_shadowing_variable(ctx, target, l) {
                         Ok(false) => continue,
                         outcome => return outcome,
@@ -1818,7 +1818,11 @@ impl<'a> Generator<'a> {
                 }
                 buf.write(")");
             }
-            Target::Struct(path, targets) => {
+            Target::Struct {
+                path,
+                targets,
+                has_rest_pattern,
+            } => {
                 buf.write(SeparatedPath(path));
                 buf.write(" { ");
                 for (name, target) in targets {
@@ -1826,6 +1830,9 @@ impl<'a> Generator<'a> {
                     buf.write(": ");
                     self.visit_target(buf, initialized, false, target);
                     buf.write(",");
+                }
+                if *has_rest_pattern {
+                    buf.write("..");
                 }
                 buf.write(" }");
             }

--- a/testing/tests/let_destructoring.rs
+++ b/testing/tests/let_destructoring.rs
@@ -119,3 +119,29 @@ fn test_let_destruct_with_path_and_with_keyword() {
     };
     assert_eq!(t.render().unwrap(), "hello");
 }
+
+#[derive(Template)]
+#[template(
+    source = "
+{%- if let RestPattern2 { a, b } = x -%}hello {{ a }}{%- endif -%}
+{%- if let RestPattern2 { a, b, } = x -%}hello {{ b }}{%- endif -%}
+{%- if let RestPattern2 { a, .. } = x -%}hello {{ a }}{%- endif -%}
+",
+    ext = "html"
+)]
+struct RestPattern {
+    x: RestPattern2,
+}
+
+struct RestPattern2 {
+    a: u32,
+    b: u32,
+}
+
+#[test]
+fn test_has_rest_pattern() {
+    let t = RestPattern {
+        x: RestPattern2 { a: 0, b: 1 },
+    };
+    assert_eq!(t.render().unwrap(), "hello 0hello 1hello 0");
+}

--- a/testing/tests/ui/let_destructuring_has_rest.rs
+++ b/testing/tests/ui/let_destructuring_has_rest.rs
@@ -1,0 +1,24 @@
+use rinja::Template;
+
+struct X {
+    a: u32,
+    b: u32,
+}
+
+#[derive(Template)]
+#[template(source = "
+{%- if let X { a, .., } = x -%}hello {{ a }}{%- endif -%}
+", ext = "html")]
+struct Y {
+    x: X,
+}
+
+#[derive(Template)]
+#[template(source = "
+{%- if let X { a .. } = x -%}hello {{ a }}{%- endif -%}
+", ext = "html")]
+struct Z {
+    x: X,
+}
+
+fn main() {}

--- a/testing/tests/ui/let_destructuring_has_rest.stderr
+++ b/testing/tests/ui/let_destructuring_has_rest.stderr
@@ -1,0 +1,19 @@
+error: unexpected `,` character after `..`
+       failed to parse template source at row 2, column 16 near:
+       ", .., } = x -%}hello {{ a }}{%- endif -%"...
+ --> tests/ui/let_destructuring_has_rest.rs:8:10
+  |
+8 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected `,` character before `..`
+       failed to parse template source at row 2, column 16 near:
+       " .. } = x -%}hello {{ a }}{%- endif -%}\n"
+  --> tests/ui/let_destructuring_has_rest.rs:16:10
+   |
+16 | #[derive(Template)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This PR adds support for:

```jinja
{% if let X { a, .. } = x %}
```

So only for structs for now. Planning to add them for tuples and eventually arrays too.

I'm not super happy with the parser code changes. I find the code very ugly but couldn't find a better way to do it. If you have ideas on how to improve it, I'd love to hear them!