### PR TITLE
Prevent jinja macros to move variables

### DIFF
--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -687,6 +687,9 @@ impl<'a> Generator<'a> {
                     names.write(arg);
 
                     values.write("(");
+                    if !is_copyable(expr) {
+                        values.write("&");
+                    }
                     values.write(self.visit_expr_root(ctx, expr)?);
                     values.write(")");
                     self.locals.insert_with_default(Cow::Borrowed(arg));

--- a/testing/tests/calls.rs
+++ b/testing/tests/calls.rs
@@ -99,3 +99,31 @@ fn test_double_attr_arg() {
     let t = DoubleAttrArg { x: (10,) };
     assert_eq!(t.render().unwrap(), "156");
 }
+
+// Ensures that fields are not moved when calling a jinja macro.
+#[derive(Template)]
+#[template(
+    source = "
+{%- macro package_navigation(title, show) -%}
+{%- if show -%}
+{{title}}
+{%- else -%}
+no show
+{%- endif -%}
+{%- endmacro -%}
+
+{%- call package_navigation(title=title, show=true) -%}
+",
+    ext = "html"
+)]
+struct DoNotMoveFields {
+    title: String,
+}
+
+#[test]
+fn test_do_not_move_fields() {
+    let x = DoNotMoveFields {
+        title: "a".to_string(),
+    };
+    assert_eq!(x.render().unwrap(), "a");
+}


### PR DESCRIPTION
Another bug I found. :)