### PR TITLE
Allow to use `*` and `&` in expressions

### DIFF
--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -510,6 +510,29 @@ of matches surrounded by curly braces instead (`{ field }`).  New names
 for the fields can be specified after a colon in the list of matches
 (`{ field: val }`).
 
+### Referencing and dereferencing variables
+
+If you need to put something behind a reference or to dereference it, you
+can use `&` and `*` operators:
+
+```jinja
+{% let x = &"bla" %}
+{% if *x == "bla" %}
+Just talking
+{% else if x == &"another" %}
+Another?!
+{% endif %}
+```
+
+They have the same effect as in Rust and you can put multiple of them:
+
+```jinja
+{% let x = &&"bla" %}
+{% if *&**x == "bla" %}
+You got it
+{% endif %}
+```
+
 ### Include
 
 The *include* statement lets you split large or repetitive blocks into

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -207,9 +207,10 @@ impl<'a> Expr<'a> {
     fn prefix(i: &'a str, mut level: Level) -> ParseResult<'a, WithSpan<'a, Self>> {
         let (_, nested) = level.nest(i)?;
         let start = i;
-        let (i, (ops, mut expr)) = pair(many0(ws(alt((tag("!"), tag("-"))))), |i| {
-            Suffix::parse(i, nested)
-        })(i)?;
+        let (i, (ops, mut expr)) = pair(
+            many0(ws(alt((tag("!"), tag("-"), tag("*"), tag("&"))))),
+            |i| Suffix::parse(i, nested),
+        )(i)?;
 
         for op in ops.iter().rev() {
             // This is a rare place where we create recursion in the parsed AST

--- a/testing/tests/ref_deref.rs
+++ b/testing/tests/ref_deref.rs
@@ -1,0 +1,62 @@
+use rinja::Template;
+
+#[derive(Template)]
+#[template(
+    source = r#"
+{%- if *title == "something" -%}
+something1
+{%- elif title == &"another" -%}
+another2
+{%- elif &*title == &&*"yep" -%}
+yep3
+{%- else -%}
+{{title}}
+{%- endif -%}
+"#,
+    ext = "html"
+)]
+struct RefDeref {
+    title: &'static &'static str,
+}
+
+#[test]
+fn test_ref_deref() {
+    let x = RefDeref {
+        title: &"something",
+    };
+    assert_eq!(x.render().unwrap(), "something1");
+
+    let x = RefDeref { title: &"another" };
+    assert_eq!(x.render().unwrap(), "another2");
+
+    let x = RefDeref { title: &"yep" };
+    assert_eq!(x.render().unwrap(), "yep3");
+
+    let x = RefDeref { title: &"bla" };
+    assert_eq!(x.render().unwrap(), "bla");
+}
+
+#[derive(Template)]
+#[template(
+    source = r#"
+{%- let x = *title -%}
+{%- if x == "another" -%}
+another2
+{%- else -%}
+{{x}}
+{%- endif -%}
+"#,
+    ext = "html"
+)]
+struct RefDerefAssignment {
+    title: &'static &'static str,
+}
+
+#[test]
+fn test_ref_deref_assign() {
+    let x = RefDerefAssignment { title: &"another" };
+    assert_eq!(x.render().unwrap(), "another2");
+
+    let x = RefDerefAssignment { title: &"two" };
+    assert_eq!(x.render().unwrap(), "two");
+}

--- a/testing/tests/ui/ref_deref.rs
+++ b/testing/tests/ui/ref_deref.rs
@@ -1,0 +1,8 @@
+use rinja::Template;
+
+#[derive(Template)]
+#[template(source = "{% let *x = 2 %}", ext = "html")]
+struct WrongRefDeref;
+
+fn main() {
+}

--- a/testing/tests/ui/ref_deref.stderr
+++ b/testing/tests/ui/ref_deref.stderr
@@ -1,0 +1,8 @@
+error: failed to parse template source at row 1, column 7 near:
+       "*x = 2 %}"
+ --> tests/ui/ref_deref.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Quite useful. I'm currently blocked because it's missing and `as_ref`/`deref` filters cannot be used in this context.