### PR TITLE
Rename `as_ref` filter into `ref`

### DIFF
--- a/book/src/filters.md
+++ b/book/src/filters.md
@@ -22,7 +22,6 @@ Enable it with Cargo features (see below for more information).
 * **[Built-in filters][#built-in-filters]:**  
 
   * [`abs`][#abs]
-  * [`as_ref`][#as_ref]
   * [`capitalize`][#capitalize]
   * [`center`][#center]
   * [`deref`][#deref]
@@ -35,6 +34,7 @@ Enable it with Cargo features (see below for more information).
   * [`linebreaks`][#linebreaks]
   * [`linebreaksbr`][#linebreaksbr]
   * [`lower|lowercase`][#lower]
+  * [`ref`][#ref]
   * [`safe`][#safe]
   * [`title`][#title]
   * [`trim`][#trim]
@@ -64,23 +64,6 @@ Output:
 
 ```text
 2
-```
-
-### as_ref
-[#as_ref]: #as_ref
-
-Creates a reference to the given argument.
-
-```jinja
-{{ "a"|as_ref }}
-{{ self.x|as_ref }}
-```
-
-will become:
-
-```rust
-&"a"
-&self.x
 ```
 
 ### capitalize
@@ -321,6 +304,23 @@ Output:
 
 ```text
 hello
+```
+
+### ref
+[#ref]: #ref
+
+Creates a reference to the given argument.
+
+```jinja
+{{ "a"|ref }}
+{{ self.x|ref }}
+```
+
+will become:
+
+```rust
+&"a"
+&self.x
 ```
 
 ### safe

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -1297,13 +1297,13 @@ impl<'a> Generator<'a> {
         filter: &WithSpan<'_, T>,
     ) -> Result<DisplayWrap, CompileError> {
         match name {
-            "as_ref" => return self._visit_as_ref_filter(ctx, buf, args, filter),
             "deref" => return self._visit_deref_filter(ctx, buf, args, filter),
             "escape" | "e" => return self._visit_escape_filter(ctx, buf, args, filter),
             "fmt" => return self._visit_fmt_filter(ctx, buf, args, filter),
             "format" => return self._visit_format_filter(ctx, buf, args, filter),
             "join" => return self._visit_join_filter(ctx, buf, args),
             "json" | "tojson" => return self._visit_json_filter(ctx, buf, args, filter),
+            "ref" => return self._visit_ref_filter(ctx, buf, args, filter),
             "safe" => return self._visit_safe_filter(ctx, buf, args, filter),
             _ => {}
         }
@@ -1318,7 +1318,7 @@ impl<'a> Generator<'a> {
         Ok(DisplayWrap::Unwrapped)
     }
 
-    fn _visit_as_ref_filter<T>(
+    fn _visit_ref_filter<T>(
         &mut self,
         ctx: &Context<'_>,
         buf: &mut Buffer,

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -376,7 +376,7 @@ fn test_json_script() {
 
 #[derive(rinja::Template)]
 #[template(
-    source = r#"{% let word = s|as_ref %}{{ word }}
+    source = r#"{% let word = s|ref %}{{ word }}
 {%- let hello = String::from("hello") %}
 {%- if word|deref == hello %}1{% else %}2{% endif %}"#,
     ext = "html"


### PR DESCRIPTION
It's not calling the `AsRef` trait and I'd prefer to clear any potential confusion and to follow the same nomenclature as `deref`.