### PR TITLE
Prevent jinja `let` to move variables

### DIFF
--- a/testing/tests/ref_deref.rs
+++ b/testing/tests/ref_deref.rs
@@ -39,7 +39,7 @@ fn test_ref_deref() {
 #[derive(Template)]
 #[template(
     source = r#"
-{%- let x = *title -%}
+{%- let x = **title -%}
 {%- if x == "another" -%}
 another2
 {%- else -%}

--- a/testing/tests/vars.rs
+++ b/testing/tests/vars.rs
@@ -131,3 +131,23 @@ fn test_decl_assign_range() {
     let t = DeclAssignRange;
     assert_eq!(t.render().unwrap(), "1");
 }
+
+#[derive(Template)]
+#[template(
+    source = "
+{%- set t = title -%}
+{{t}}/{{title -}}
+",
+    ext = "txt"
+)]
+struct DoNotMoveFields {
+    title: String,
+}
+
+#[test]
+fn test_not_moving_fields_in_var() {
+    let x = DoNotMoveFields {
+        title: "a".to_string(),
+    };
+    assert_eq!(x.render().unwrap(), "a/a");
+}


### PR DESCRIPTION
Bug I had today and kind of a follow-up to #38.