### PR TITLE
Add `.rustfmt.toml` configuration

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,12 @@
+edition = "2021"
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+newline_style = "Unix"
+normalize_comments = true
+unstable_features = true
+use_field_init_shorthand = true
+version = "Two"
+
+ignore = [
+    "testing/tests/hello.rs",
+]

--- a/rinja/src/error.rs
+++ b/rinja/src/error.rs
@@ -22,7 +22,6 @@ pub type Result<I, E = Error> = std::result::Result<I, E>;
 /// using a adapter the benefits `failure` would
 /// bring to this crate are small, which is why
 /// `std::error::Error` was used.
-///
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum Error {

--- a/rinja/src/filters/mod.rs
+++ b/rinja/src/filters/mod.rs
@@ -9,9 +9,6 @@ use std::fmt::{self, Write};
 
 #[cfg(feature = "serde_json")]
 mod json;
-#[cfg(feature = "serde_json")]
-pub use self::json::{json, json_pretty, AsIndent};
-
 #[cfg(feature = "humansize")]
 use humansize::{ISizeFormatter, ToF64, DECIMAL};
 #[cfg(feature = "num-traits")]
@@ -20,6 +17,8 @@ use num_traits::{cast::NumCast, Signed};
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use rinja_escape::{Escaper, MarkupDisplay};
 
+#[cfg(feature = "serde_json")]
+pub use self::json::{json, json_pretty, AsIndent};
 use crate::{Error, Result};
 
 #[cfg(feature = "urlencode")]
@@ -427,7 +426,6 @@ where
 /// This struct implements [`fmt::Display`], but only produces a string once.
 /// Any subsequent call to `.to_string()` will result in an empty string, because the iterator is
 /// already consumed.
-//
 // The filter contains a [`Cell`], so we can modify iterator inside a method that takes `self` by
 // reference: [`fmt::Display::fmt()`] normally has the contract that it will produce the same result
 // in multiple invocations for the same object. We break this contract, because have to consume the

--- a/rinja_axum/tests/basic.rs
+++ b/rinja_axum/tests/basic.rs
@@ -1,9 +1,7 @@
-use axum::{
-    body::Body,
-    http::{Request, StatusCode},
-    routing::get,
-    Router,
-};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use axum::Router;
 use http_body_util::BodyExt;
 use rinja_axum::Template;
 use tower::util::ServiceExt;

--- a/rinja_derive/src/config.rs
+++ b/rinja_derive/src/config.rs
@@ -3,12 +3,12 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::{env, fs};
 
+use parser::node::Whitespace;
+use parser::Syntax;
 #[cfg(feature = "config")]
 use serde::Deserialize;
 
 use crate::{CompileError, FileInfo, CRATE};
-use parser::node::Whitespace;
-use parser::Syntax;
 
 #[derive(Debug)]
 pub(crate) struct Config<'a> {
@@ -65,7 +65,7 @@ impl<'a> Config<'a> {
                     return Err(CompileError::new(
                         format!("invalid value for `whitespace`: \"{s}\""),
                         file_info,
-                    ))
+                    ));
                 }
             };
         }

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -6,16 +6,16 @@ use std::path::Path;
 use std::rc::Rc;
 use std::{cmp, hash, mem, str};
 
-use crate::config::WhitespaceHandling;
-use crate::heritage::{Context, Heritage};
-use crate::input::{Source, TemplateInput};
-use crate::{CompileError, CRATE};
-
 use parser::node::{
     Call, Comment, CondTest, FilterBlock, If, Include, Let, Lit, Loop, Match, Whitespace, Ws,
 };
 use parser::{Expr, Filter, Node, Target, WithSpan};
 use quote::quote;
+
+use crate::config::WhitespaceHandling;
+use crate::heritage::{Context, Heritage};
+use crate::input::{Source, TemplateInput};
+use crate::{CompileError, CRATE};
 
 pub(crate) struct Generator<'a> {
     // The template input state: original struct AST and attributes
@@ -240,7 +240,7 @@ impl<'a> Generator<'a> {
         ));
     }
 
-    /* Helper methods for handling node types */
+    // Helper methods for handling node types
 
     fn handle(
         &mut self,
@@ -960,7 +960,7 @@ impl<'a> Generator<'a> {
             (None, Some((prev_name, gen))) => (prev_name, gen + 1),
             // `super()` is called from outside a block
             (None, None) => {
-                return Err(ctx.generate_error("cannot call 'super()' outside block", node))
+                return Err(ctx.generate_error("cannot call 'super()' outside block", node));
             }
         };
 
@@ -1225,7 +1225,7 @@ impl<'a> Generator<'a> {
         self.handle_ws(comment.ws);
     }
 
-    /* Visitor methods for expression types */
+    // Visitor methods for expression types
 
     fn visit_expr_root(
         &mut self,
@@ -1415,7 +1415,7 @@ impl<'a> Generator<'a> {
         let opt_escaper = match args.get(1).map(|expr| &**expr) {
             Some(Expr::StrLit(name)) => Some(*name),
             Some(_) => {
-                return Err(ctx.generate_error("invalid escaper type for escape filter", node))
+                return Err(ctx.generate_error("invalid escaper type for escape filter", node));
             }
             None => None,
         };
@@ -1618,7 +1618,7 @@ impl<'a> Generator<'a> {
                     _ => {
                         return Err(
                             ctx.generate_error("loop.cycle(…) cannot use an empty array", left)
-                        )
+                        );
                     }
                 },
                 s => return Err(ctx.generate_error(&format!("unknown loop method: {s:?}"), left)),
@@ -1873,7 +1873,7 @@ impl<'a> Generator<'a> {
         }
     }
 
-    /* Helper methods for dealing with whitespace nodes */
+    // Helper methods for dealing with whitespace nodes
 
     // Combines `flush_ws()` and `prepare_ws()` to handle both trailing whitespace from the
     // preceding literal and leading whitespace from the succeeding literal.

--- a/rinja_derive/src/input.rs
+++ b/rinja_derive/src/input.rs
@@ -57,7 +57,7 @@ impl TemplateInput<'_> {
             (&Source::Source(_), None) => {
                 return Err(CompileError::no_file_info(
                     "must include 'ext' attribute when using 'source' attribute",
-                ))
+                ));
             }
         };
 
@@ -240,12 +240,12 @@ impl TemplateArgs {
                 Ok(_) => {
                     return Err(CompileError::no_file_info(
                         "duplicated 'template' attribute",
-                    ))
+                    ));
                 }
                 Err(e) => {
                     return Err(CompileError::no_file_info(format!(
                         "unable to parse template arguments: {e}"
-                    )))
+                    )));
                 }
             };
         }
@@ -264,7 +264,7 @@ impl TemplateArgs {
                     return Err(CompileError::no_file_info(format!(
                         "unsupported attribute argument {:?}",
                         item.to_token_stream()
-                    )))
+                    )));
                 }
             };
 
@@ -280,13 +280,13 @@ impl TemplateArgs {
                     _ => {
                         return Err(CompileError::no_file_info(format!(
                             "unsupported argument value type for {ident:?}"
-                        )))
+                        )));
                     }
                 },
                 _ => {
                     return Err(CompileError::no_file_info(format!(
                         "unsupported argument value type for {ident:?}"
-                    )))
+                    )));
                 }
             };
 
@@ -440,7 +440,7 @@ impl FromStr for Print {
             v => {
                 return Err(CompileError::no_file_info(format!(
                     "invalid value for print option: {v}"
-                )))
+                )));
             }
         })
     }

--- a/rinja_escape/src/lib.rs
+++ b/rinja_escape/src/lib.rs
@@ -169,8 +169,9 @@ pub trait Escaper {
 mod tests {
     extern crate std;
 
-    use super::*;
     use std::string::ToString;
+
+    use super::*;
 
     #[test]
     fn test_escape() {

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -792,8 +792,9 @@ pub fn strip_common(base: &Path, path: &Path) -> String {
 #[cfg(not(windows))]
 #[cfg(test)]
 mod test {
-    use super::{char_lit, num_lit, strip_common};
     use std::path::Path;
+
+    use super::{char_lit, num_lit, strip_common};
 
     #[test]
     fn test_strip_common() {

--- a/testing/tests/inheritance.rs
+++ b/testing/tests/inheritance.rs
@@ -62,8 +62,9 @@ pub mod parent {
 }
 
 pub mod child {
-    use super::parent::*;
     use rinja::Template;
+
+    use super::parent::*;
 
     #[derive(Template)]
     #[template(path = "child.html")]

--- a/testing/tests/render_in_place.rs
+++ b/testing/tests/render_in_place.rs
@@ -34,6 +34,6 @@ fn test_render_in_place() {
     };
     assert_eq!(
         t.render().unwrap(),
-       "Section 1: A=A\nB=B\nSection 2: C=C\nD=D\nSection 3 for:\n* A=1\nB=2\n* A=A\nB=B\n* A=a\nB=b\n"
+        "Section 1: A=A\nB=B\nSection 2: C=C\nD=D\nSection 3 for:\n* A=1\nB=2\n* A=A\nB=B\n* A=a\nB=b\n"
     );
 }

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::disallowed_names)] // For the use of `foo` in test cases
 
-use rinja::Template;
-
 use std::collections::HashMap;
+
+use rinja::Template;
 
 #[derive(Template)]
 #[template(path = "simple.html")]

--- a/testing/tests/ui.rs
+++ b/testing/tests/ui.rs
@@ -2,6 +2,7 @@
 
 use std::os::unix::fs::symlink;
 use std::path::Path;
+
 use trybuild::TestCases;
 
 #[test]

--- a/testing/tests/whitespace.rs
+++ b/testing/tests/whitespace.rs
@@ -39,7 +39,10 @@ fn test_extra_whitespace() {
     let mut template = AllowWhitespaces::default();
     template.nested_1.nested_2.array = &["a0", "a1", "a2", "a3"];
     template.nested_1.nested_2.hash.insert("key", "value");
-    assert_eq!(template.render().unwrap(), "\n0\n0\n0\n0\n\n\n\n0\n0\n0\n0\n0\n\na0\na1\nvalue\n\n\n\n\n\n[\n  &quot;a0&quot;,\n  &quot;a1&quot;,\n  &quot;a2&quot;,\n  &quot;a3&quot;\n]\n[\n  &quot;a0&quot;,\n  &quot;a1&quot;,\n  &quot;a2&quot;,\n  &quot;a3&quot;\n][\n  &quot;a0&quot;,\n  &quot;a1&quot;,\n  &quot;a2&quot;,\n  &quot;a3&quot;\n]\n[\n  &quot;a1&quot;\n][\n  &quot;a1&quot;\n]\n[\n  &quot;a1&quot;,\n  &quot;a2&quot;\n][\n  &quot;a1&quot;,\n  &quot;a2&quot;\n]\n[\n  &quot;a1&quot;\n][\n  &quot;a1&quot;\n]1-1-1\n3333 3\n2222 2\n0000 0\n3333 3\n\ntruefalse\nfalsefalsefalse\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+    assert_eq!(
+        template.render().unwrap(),
+        "\n0\n0\n0\n0\n\n\n\n0\n0\n0\n0\n0\n\na0\na1\nvalue\n\n\n\n\n\n[\n  &quot;a0&quot;,\n  &quot;a1&quot;,\n  &quot;a2&quot;,\n  &quot;a3&quot;\n]\n[\n  &quot;a0&quot;,\n  &quot;a1&quot;,\n  &quot;a2&quot;,\n  &quot;a3&quot;\n][\n  &quot;a0&quot;,\n  &quot;a1&quot;,\n  &quot;a2&quot;,\n  &quot;a3&quot;\n]\n[\n  &quot;a1&quot;\n][\n  &quot;a1&quot;\n]\n[\n  &quot;a1&quot;,\n  &quot;a2&quot;\n][\n  &quot;a1&quot;,\n  &quot;a2&quot;\n]\n[\n  &quot;a1&quot;\n][\n  &quot;a1&quot;\n]1-1-1\n3333 3\n2222 2\n0000 0\n3333 3\n\ntruefalse\nfalsefalsefalse\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
+    );
 }
 
 macro_rules! test_template_minimize {


### PR DESCRIPTION
This PR configures the formatting with a few defaults that aid readability, in my opinion. One drawback of adding this file is that rustfmt uses unstable features, now, and you have to use nightly to run it:

```sh
cargo +nightly fmt --all
```