### PR TITLE
derive: Refactor a few types (less cloning, more re-usability)

### DIFF
--- a/rinja_derive/src/config.rs
+++ b/rinja_derive/src/config.rs
@@ -292,13 +292,13 @@ fn str_set<'a>(vals: &[&'a str]) -> Vec<Cow<'a, str>> {
 pub(crate) fn get_template_source(
     tpl_path: &Path,
     import_from: Option<(&Rc<Path>, &str, &str)>,
-) -> Result<String, CompileError> {
+) -> Result<Rc<str>, CompileError> {
     match fs::read_to_string(tpl_path) {
         Ok(mut source) => {
             if source.ends_with('\n') {
                 let _ = source.pop();
             }
-            Ok(source)
+            Ok(source.into())
         }
         Err(err) => {
             let msg = format!(
@@ -333,7 +333,7 @@ mod tests {
         let path = Config::new("", None, None)
             .and_then(|config| config.find_template("b.html", None))
             .unwrap();
-        assert_eq!(get_template_source(&path, None).unwrap(), "bar");
+        assert_eq!(get_template_source(&path, None).unwrap(), "bar".into());
     }
 
     #[test]

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -1425,7 +1425,11 @@ impl<'a> Generator<'a> {
                 .config
                 .escapers
                 .iter()
-                .find_map(|(escapers, escaper)| escapers.contains(name).then_some(escaper))
+                .find_map(|(extensions, path)| {
+                    extensions
+                        .contains(&Cow::Borrowed(name))
+                        .then_some(path.as_ref())
+                })
                 .ok_or_else(|| ctx.generate_error("invalid escaper for escape filter", node))?,
             None => self.input.escaper,
         };

--- a/rinja_derive/src/input.rs
+++ b/rinja_derive/src/input.rs
@@ -113,7 +113,7 @@ impl TemplateInput<'_> {
         map: &mut HashMap<Rc<Path>, Parsed>,
     ) -> Result<(), CompileError> {
         let (source, source_path) = match &self.source {
-            Source::Source(s) => (s.into(), None),
+            Source::Source(s) => (s.clone(), None),
             Source::Path(_) => (
                 get_template_source(&self.path, None)?,
                 Some(Rc::clone(&self.path)),
@@ -312,7 +312,7 @@ impl TemplateArgs {
                             "must specify 'source' or 'path', not both",
                         ));
                     }
-                    args.source = Some(Source::Source(s.value()));
+                    args.source = Some(Source::Source(s.value().into()));
                 } else {
                     return Err(CompileError::no_file_info(
                         "template source must be string literal",
@@ -386,7 +386,7 @@ impl TemplateArgs {
 
     pub(crate) fn fallback() -> Self {
         Self {
-            source: Some(Source::Source("".to_string())),
+            source: Some(Source::Source("".into())),
             ext: Some("txt".to_string()),
             ..Self::default()
         }
@@ -419,7 +419,7 @@ fn extension(path: &Path) -> Option<&str> {
 #[derive(Debug, Hash, PartialEq)]
 pub(crate) enum Source {
     Path(String),
-    Source(String),
+    Source(Rc<str>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Hash)]

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -688,7 +688,7 @@ impl<'a> State<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq)]
 pub struct Syntax<'a> {
     pub block_start: &'a str,
     pub block_end: &'a str,


### PR DESCRIPTION
Minor optimizations and pre-requisites needed if we want to implement #49:

* Implement `Hash + PartialEq` for more types
* Use `Cow<str>` instead of `String` if possible
* Don't calculate HashMap entry hashes twice

The derive benchmark runs 3 to 5% faster across the board.