### PR TITLE
Add example app

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         package: [
           rinja, rinja_actix, rinja_axum, rinja_derive, rinja_derive_standalone, rinja_escape,
-          rinja_parser, rinja_rocket, rinja_warp, testing,
+          rinja_parser, rinja_rocket, rinja_warp, testing, examples/actix-web-app,
         ]
     runs-on: ubuntu-latest
     steps:

--- a/examples/actix-web-app/Cargo.toml
+++ b/examples/actix-web-app/Cargo.toml
@@ -2,19 +2,31 @@
 name = "actix-web-app"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
+# This is an example application that uses both rinja as template engine,
+# and actix-web as your web-framework.
+# rinja_actix makes it easy to use rinja templates as `Responder` of an actix-web request.
+# The rendered template is simply the response of your handler!
 rinja_actix = { version = "0.15.0", path = "../../rinja_actix" }
-
 actix-web = { version = "4.8.0", default-features = false, features = ["macros"] }
+tokio = { version = "1.38.0", features = ["sync", "rt-multi-thread"] }
+
+# serde and strum are used to parse (deserialize) and generate (serialize) information
+# between web requests, e.g. to share the selected display language.
+serde = { version = "1.0.203", features = ["derive"] }
+strum = { version = "0.26.3", features = ["derive"] }
+
+# These depenendies are simply used for a better user experience, having access logs in the
+# console, and error messages if anything goes wrong, e.g. if the port is already in use.
 env_logger = "0.11.3"
 log = "0.4.22"
 pretty-error-debug = "0.3.0"
-serde = { version = "1.0.203", features = ["derive"] }
-strum = { version = "0.26.3", features = ["derive"] }
 thiserror = "1.0.61"
-tokio = { version = "1.38.0", features = ["sync", "rt-multi-thread"] }
 
+# In a real application you would not need this section. It is only used in here, so that this
+# example can have a more lenient MSRV (minimum supported rust version) than rinja as a whole.
 [workspace]
 members = ["."]

--- a/examples/actix-web-app/Cargo.toml
+++ b/examples/actix-web-app/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "actix-web-app"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+rinja_actix = { version = "0.15.0", path = "../../rinja_actix" }
+
+actix-web = { version = "4.8.0", default-features = false, features = ["macros"] }
+env_logger = "0.11.3"
+log = "0.4.22"
+pretty-error-debug = "0.3.0"
+serde = { version = "1.0.203", features = ["derive"] }
+strum = { version = "0.26.3", features = ["derive"] }
+thiserror = "1.0.61"
+tokio = { version = "1.38.0", features = ["sync", "rt-multi-thread"] }
+
+[workspace]
+members = ["."]

--- a/examples/actix-web-app/LICENSE-APACHE
+++ b/examples/actix-web-app/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/examples/actix-web-app/LICENSE-MIT
+++ b/examples/actix-web-app/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/examples/actix-web-app/README.md
+++ b/examples/actix-web-app/README.md
@@ -1,0 +1,17 @@
+# rinja + actix-web example web app
+
+This is a simple web application that uses rinja as template engine, and
+[actix-web](https://crates.io/crates/actix-web) as web framework.
+It lets the user of the web page select a display language, and asks for their name.
+The example shows the interaction between both projects, and serves as an example to use
+basic rinja features such as base templates to a unified layout skeletton for your page,
+and less boilerplate in your template code.
+
+To run the example execute `cargo run` in this folder.
+Once the project is running, open <http://127.0.0.1:8080/> in your browser.
+To gracefully shut does the server, type ctrl+C in your terminal.
+
+The files of the project contain comments for you to read.
+The recommended reading order is "templates/_layout.html", "templates/index.html",
+"Cargo.toml", "src/main.rs". Also please have a look at our [book](https://rinja.readthedocs.io/),
+which explains rinja's features in greater detail.

--- a/examples/actix-web-app/src/main.rs
+++ b/examples/actix-web-app/src/main.rs
@@ -1,11 +1,12 @@
 use actix_web::http::{header, Method};
 use actix_web::{
-    get, middleware, web, App, Either, HttpRequest, HttpResponse, HttpServer, Responder, Result,
+    get, middleware, web, App, HttpRequest, HttpResponse, HttpServer, Responder, Result,
 };
 use rinja_actix::Template;
 use serde::Deserialize;
 use tokio::runtime;
 
+// This function and the next mostly contains boiler plate to get an actix-web application running.
 fn main() -> Result<(), Error> {
     let env = env_logger::Env::new().default_filter_or("info");
     env_logger::try_init_from_env(env).map_err(Error::Log)?;
@@ -19,6 +20,7 @@ fn main() -> Result<(), Error> {
 
 async fn amain() -> Result<(), Error> {
     let server = HttpServer::new(|| {
+        // This closure contains the setup of the routing rules of your app.
         App::new()
             .wrap(middleware::Logger::default())
             .wrap(middleware::NormalizePath::new(
@@ -29,6 +31,7 @@ async fn amain() -> Result<(), Error> {
             .service(greeting_handler)
             .default_service(web::to(not_found_handler))
     });
+    // In a real application you would most likely read the configuration from a config file.
     let server = server.bind(("127.0.0.1", 8080)).map_err(Error::Bind)?;
     for addr in server.addrs() {
         println!("Listening on: http://{addr}/");
@@ -48,7 +51,20 @@ enum Error {
     Run(#[source] std::io::Error),
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Deserialize, strum::Display, strum::AsRefStr)]
+/// Using this type your user can select the display language of your page.
+///
+/// The same type is used by actix-web as part of the URL, and in rinja to select what content to
+/// show, and also as an HTML attribute in `<html lang=`. To make it possible to use the same type
+/// for three diffent use cases, we use a few derive macros:
+///
+///  * `Default` to have a default/fallback language.
+///  * `Debug` is not strictly needed, but it might aid debugging.
+///  * `Clone` + `Copy` so that we can pass the language by value.
+///  * `PartialEq` so that we can use the type in comparisons with `==` or `!=`.
+///  * `serde::Deserialize` so that actix-web can parse the type in incoming URLs.
+///  * `strum::AsRefStr` so that actix-web the use the type to construct URL for printing.
+///  * `strum::Display` so that rinja can write the value in templates.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Deserialize, strum::AsRefStr, strum::Display)]
 #[allow(non_camel_case_types)]
 enum Lang {
     #[default]
@@ -57,7 +73,13 @@ enum Lang {
     fr,
 }
 
+/// This is your "Error: 404 - not found" handler
 async fn not_found_handler(req: HttpRequest) -> Result<impl Responder> {
+    // It uses a rinja template to display its content.
+    // The member `req` contains the request, and is used e.g. to generate URLs in our template.
+    // The member `lang` is used by "_layout.html" which "404.html" extends. Even though it
+    // is always the fallback language English in here, "_layout.html" expects to be able to access
+    // this field, so you have to provide it.
     #[derive(Debug, Template)]
     #[template(path = "404.html")]
     struct Tmpl {
@@ -65,35 +87,62 @@ async fn not_found_handler(req: HttpRequest) -> Result<impl Responder> {
         lang: Lang,
     }
 
-    match req.method() {
-        &Method::GET => Ok(Either::Left(Tmpl {
+    if req.method() == Method::GET {
+        // In here we have to render the result to a string manually, because we don't want to
+        // generate a "status 200" result, but "status 404". In other cases you can simply return
+        // the template, wrapped in `Ok()`, and the request gets generated with "status 200",
+        // and the right MIME type.
+        let tmpl = Tmpl {
             req,
             lang: Lang::default(),
-        })),
-        _ => Ok(Either::Right(HttpResponse::MethodNotAllowed().finish())),
+        };
+        // The MIME type was derived by rinja by the extension of the template file.
+        Ok(HttpResponse::NotFound()
+            .append_header((header::CONTENT_TYPE, Tmpl::MIME_TYPE))
+            .body(tmpl.to_string()))
+    } else {
+        Ok(HttpResponse::MethodNotAllowed().finish())
     }
 }
 
+/// The is first page your user hits does not contain language infomation, so we redirect them
+/// to a URL that does contain the default language.
 #[get("/")]
 async fn start_handler(req: HttpRequest) -> Result<impl Responder> {
+    // This example show how the type `Lang` can be used to construct a URL in actix-web.
     let url = req.url_for("index_handler", [Lang::default()])?;
     Ok(HttpResponse::Found()
         .insert_header((header::LOCATION, url.as_str()))
         .finish())
 }
 
+/// This type collects the query parameter `?name=` (if present)
 #[derive(Debug, Deserialize)]
 struct IndexHandlerQuery {
     #[serde(default)]
     name: String,
 }
 
+/// This is the first localized page your user sees.
+///
+/// It has arguments in the path that need to be parsable using `serde::Deserialize`;
+/// see `Lang` for an explanation.
+/// And also query parameters (anything after `?` in the incoming URL).
 #[get("/{lang}/index.html")]
 async fn index_handler(
     req: HttpRequest,
     path: web::Path<(Lang,)>,
     web::Query(query): web::Query<IndexHandlerQuery>,
 ) -> Result<impl Responder> {
+    // Same as in `not_found_handler`, we have `req` to build URLs in the template, and
+    // `lang` to select the display language. In the template we both use `{% match lang %}` and
+    // `{% if lang !=`, the former to select the text of a specific language, e.g. in the `<title>`;
+    // and the latter to display references to all other available languages except the currently
+    // selected one.
+    // The field `name` will contain the value of the query paramater of the same name.
+    // In `IndexHandlerQuery` we annotated the field with `#[serde(default)]`, so if the value is
+    // absent, an empty string is selected by default, which is visible to the user an empty
+    // `<input type="text" />` element.
     #[derive(Debug, Template)]
     #[template(path = "index.html")]
     struct Tmpl {
@@ -115,6 +164,11 @@ struct GreetingHandlerQuery {
     name: String,
 }
 
+/// This is the final page of this example application.
+///
+/// Like `index_handler` it contains a language in the URL, and a query parameter to read the user's
+/// provided name. In here, the query argument `name` has no default value, so actix-web will show
+/// an error message if absent.
 #[get("/{lang}/greet-me.html")]
 async fn greeting_handler(
     req: HttpRequest,

--- a/examples/actix-web-app/src/main.rs
+++ b/examples/actix-web-app/src/main.rs
@@ -1,0 +1,137 @@
+use actix_web::http::{header, Method};
+use actix_web::{
+    get, middleware, web, App, Either, HttpRequest, HttpResponse, HttpServer, Responder, Result,
+};
+use rinja_actix::Template;
+use serde::Deserialize;
+use tokio::runtime;
+
+fn main() -> Result<(), Error> {
+    let env = env_logger::Env::new().default_filter_or("info");
+    env_logger::try_init_from_env(env).map_err(Error::Log)?;
+
+    runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(Error::Rt)?
+        .block_on(amain())
+}
+
+async fn amain() -> Result<(), Error> {
+    let server = HttpServer::new(|| {
+        App::new()
+            .wrap(middleware::Logger::default())
+            .wrap(middleware::NormalizePath::new(
+                middleware::TrailingSlash::MergeOnly,
+            ))
+            .service(start_handler)
+            .service(index_handler)
+            .service(greeting_handler)
+            .default_service(web::to(not_found_handler))
+    });
+    let server = server.bind(("127.0.0.1", 8080)).map_err(Error::Bind)?;
+    for addr in server.addrs() {
+        println!("Listening on: http://{addr}/");
+    }
+    server.run().await.map_err(Error::Run)
+}
+
+#[derive(thiserror::Error, pretty_error_debug::Debug)]
+enum Error {
+    #[error("could not setup logger")]
+    Log(#[source] log::SetLoggerError),
+    #[error("could not setup async runtime")]
+    Rt(#[source] std::io::Error),
+    #[error("could not bind socket")]
+    Bind(#[source] std::io::Error),
+    #[error("could not run server")]
+    Run(#[source] std::io::Error),
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Deserialize, strum::Display, strum::AsRefStr)]
+#[allow(non_camel_case_types)]
+enum Lang {
+    #[default]
+    en,
+    de,
+}
+
+async fn not_found_handler(req: HttpRequest) -> Result<impl Responder> {
+    #[derive(Debug, Template)]
+    #[template(path = "404.html")]
+    struct Tmpl {
+        req: HttpRequest,
+        lang: Lang,
+    }
+
+    match req.method() {
+        &Method::GET => Ok(Either::Left(Tmpl {
+            req,
+            lang: Lang::default(),
+        })),
+        _ => Ok(Either::Right(HttpResponse::MethodNotAllowed().finish())),
+    }
+}
+
+#[get("/")]
+async fn start_handler(req: HttpRequest) -> Result<impl Responder> {
+    let url = req.url_for("index_handler", [Lang::default()])?;
+    Ok(HttpResponse::Found()
+        .insert_header((header::LOCATION, url.as_str()))
+        .finish())
+}
+
+#[derive(Debug, Deserialize)]
+struct IndexHandlerQuery {
+    #[serde(default)]
+    name: String,
+}
+
+#[get("/{lang}/index.html")]
+async fn index_handler(
+    req: HttpRequest,
+    path: web::Path<(Lang,)>,
+    web::Query(query): web::Query<IndexHandlerQuery>,
+) -> Result<impl Responder> {
+    #[derive(Debug, Template)]
+    #[template(path = "index.html")]
+    struct Tmpl {
+        req: HttpRequest,
+        lang: Lang,
+        name: String,
+    }
+
+    let (lang,) = path.into_inner();
+    Ok(Tmpl {
+        req,
+        lang,
+        name: query.name,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct GreetingHandlerQuery {
+    name: String,
+}
+
+#[get("/{lang}/greet-me.html")]
+async fn greeting_handler(
+    req: HttpRequest,
+    path: web::Path<(Lang,)>,
+    web::Query(query): web::Query<GreetingHandlerQuery>,
+) -> Result<impl Responder> {
+    #[derive(Debug, Template)]
+    #[template(path = "greet.html")]
+    struct Tmpl {
+        req: HttpRequest,
+        lang: Lang,
+        name: String,
+    }
+
+    let (lang,) = path.into_inner();
+    Ok(Tmpl {
+        req,
+        lang,
+        name: query.name,
+    })
+}

--- a/examples/actix-web-app/src/main.rs
+++ b/examples/actix-web-app/src/main.rs
@@ -54,6 +54,7 @@ enum Lang {
     #[default]
     en,
     de,
+    fr,
 }
 
 async fn not_found_handler(req: HttpRequest) -> Result<impl Responder> {

--- a/examples/actix-web-app/templates/404.html
+++ b/examples/actix-web-app/templates/404.html
@@ -1,10 +1,10 @@
 {% extends "_layout.html" %}
 
-{% block title -%}
+{%- block title -%}
     404: Not Found
-{%- endblock %}
+{%- endblock -%}
 
-{% block content -%}
+{%- block content -%}
     <h1>404: Not Found</h1>
     <h2><a href="{{ req.url_for_static("start_handler")? }}">Back to the first page.</a></h2>
-{%- endblock %}
+{%- endblock -%}

--- a/examples/actix-web-app/templates/404.html
+++ b/examples/actix-web-app/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "_layout.html" %}
+
+{% block title -%}
+    404: Not Found
+{%- endblock %}
+
+{% block content -%}
+    <h1>404: Not Found</h1>
+    <h2><a href="{{ req.url_for_static("start_handler")? }}">Back to the first page.</a></h2>
+{%- endblock %}

--- a/examples/actix-web-app/templates/_layout.css
+++ b/examples/actix-web-app/templates/_layout.css
@@ -1,0 +1,56 @@
+{#-
+    This file is included by "_layout.html".
+    You can still use template syntax (such as this comment) in here.
+-#}
+
+html {
+    background-color: #eee;
+    color: #111;
+    font-size: 62.5%;
+    min-height: 100vh;
+    color-scheme: light;
+}
+* {
+    line-height: 1.2em;
+}
+body {
+    background-color: #fff;
+    font-size: 1.8rem;
+    max-width: 40em;
+    margin: 1em auto;
+    padding: 2em;
+}
+h1 { font-size: 2.4rem; }
+h2 { font-size: 2.2rem; }
+h3 { font-size: 2.0rem; }
+a:link, a:visited {
+    color: #36c;
+    text-decoration: none;
+}
+a:active, a:hover, a:focus {
+    text-decoration: underline;
+    text-underline-offset: 0.3em;
+}
+#lang-select {
+    font-size: 80%;
+    width: max-content;
+    margin: 2em 0 0 auto;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+}
+#lang-select li {
+    flex-grow: 1;
+    flex-basis: auto;
+    margin: .25em 0 0 0;
+    padding: 0 1em;
+    text-align: center;
+    list-style-type: none;
+    border-left: 0.1rem solid currentColor;
+}
+#lang-select li:first-of-type {
+    border-left: 0 none transparent;
+}
+#lang-select li:last-of-type {
+    padding-right: 0;
+}

--- a/examples/actix-web-app/templates/_layout.html
+++ b/examples/actix-web-app/templates/_layout.html
@@ -51,3 +51,17 @@
         {%~ block content %}{% endblock ~%}
     </body>
 </html>
+
+{%- macro lang_select(handler, query) -%}
+    <ul id="lang-select">
+        {%- if lang != Lang::en -%}
+            <li><a href="{{ req.url_for(handler, [Lang::en])? }}{{ query|safe }}">This page in English</a></li>
+        {%- endif -%}
+        {%- if lang != Lang::de -%}
+            <li><a href="{{ req.url_for(handler, [Lang::de])? }}{{ query|safe }}">Diese Seite auf deutsch.</a></li>
+        {%- endif -%}
+        {%- if lang != Lang::fr -%}
+            <li><a href="{{ req.url_for(handler, [Lang::fr])? }}{{ query|safe }}">Cette page est en français.</a></li>
+        {%- endif -%}
+    </ul>
+{%- endmacro lang_select -%}

--- a/examples/actix-web-app/templates/_layout.html
+++ b/examples/actix-web-app/templates/_layout.html
@@ -43,6 +43,24 @@
                 font-size: 80%;
                 width: max-content;
                 margin: 2em 0 0 auto;
+                display: flex;
+                flex-direction: row;
+                flex-wrap: wrap;
+            }
+            #lang-select li {
+                flex-grow: 1;
+                flex-basis: auto;
+                margin: .25em 0 0 0;
+                padding: 0 1em;
+                text-align: center;
+                list-style-type: none;
+                border-left: 0.1rem solid currentColor;
+            }
+            #lang-select li:first-of-type {
+                border-left: 0 none transparent;
+            }
+            #lang-select li:last-of-type {
+                padding-right: 0;
             }
         /*]]>*/
         </style>

--- a/examples/actix-web-app/templates/_layout.html
+++ b/examples/actix-web-app/templates/_layout.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="{{lang}}">
+    <head>
+        <meta charset="UTF-8" />
+        <title>{% block title %}{% endblock %}</title>
+        <meta http-equiv="expires" content="Sat, 01 Dec 2001 00:00:00 GMT" />
+        <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate" />
+        <meta http-equiv="pragma" content="no-cache" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="noindex, nofollow" />
+
+        <style>
+        /*<![CDATA[*/
+            html {
+                background-color: #eee;
+                color: #111;
+                font-size: 62.5%;
+                min-height: 100vh;
+                color-scheme: light;
+            }
+            * {
+                line-height: 1.2em;
+            }
+            body {
+                background-color: #fff;
+                font-size: 1.8rem;
+                max-width: 40em;
+                margin: 1em auto;
+                padding: 2em;
+            }
+            h1 { font-size: 2.4rem; }
+            h2 { font-size: 2.2rem; }
+            h3 { font-size: 2.0rem; }
+            a:link, a:visited {
+                color: #36c;
+                text-decoration: none;
+            }
+            a:active, a:hover, a:focus {
+                text-decoration: underline;
+                text-underline-offset: 0.3em;
+            }
+            #lang-select {
+                font-size: 80%;
+                width: max-content;
+                margin: 2em 0 0 auto;
+            }
+        /*]]>*/
+        </style>
+    </head>
+    <body>
+        {%~ block content %}{% endblock ~%}
+    </body>
+</html>

--- a/examples/actix-web-app/templates/_layout.html
+++ b/examples/actix-web-app/templates/_layout.html
@@ -1,67 +1,49 @@
+{#-
+    This is the basic layout of our example application.
+    It is the core skeletton shared between all pages.
+    It expects the struct of any template that `{% extends %}` this layout to contain
+    (at least) a field `lang: Lang`, so it can be used in the `<html lang=` attribute.
+-#}
+
 <!DOCTYPE html>
 <html lang="{{lang}}">
     <head>
         <meta charset="UTF-8" />
+        {#-
+            A base template can contain `blocks`, which my be overridden templates that use
+            this base template. A block may contain a default content, if the extending
+            template does want to / need to override the content of a block.
+
+            E.g. maybe you would like to have "Rinja example application" as default title for
+            your pages, then simply add this text (without quotation marks) in the block!
+
+            The default content can be as complex as you need to to be.
+            E.g. it may contain any nodes like `{% if … %}`, and even other blocks.
+        ~#}
         <title>{% block title %}{% endblock %}</title>
+
         <meta http-equiv="expires" content="Sat, 01 Dec 2001 00:00:00 GMT" />
         <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate" />
         <meta http-equiv="pragma" content="no-cache" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="robots" content="noindex, nofollow" />
 
+        {#-
+            In a real application you most likely would want to link style sheets,
+            any JavaScripts etc. using e.g. `actix-files`, instead of embedding the content
+            in your generated HTML.
+
+            As you can see, this comment starts with `-`, which will tells the comment
+            to strip all white spaces before it, until it finds the first non-white space
+            character, a `>`.
+
+            The comment is also terminated with `~`. This also strips white spaces, but
+            will leave one space, or a newline character, if the stripped content contained
+            a newline.
+        ~#}
         <style>
         /*<![CDATA[*/
-            html {
-                background-color: #eee;
-                color: #111;
-                font-size: 62.5%;
-                min-height: 100vh;
-                color-scheme: light;
-            }
-            * {
-                line-height: 1.2em;
-            }
-            body {
-                background-color: #fff;
-                font-size: 1.8rem;
-                max-width: 40em;
-                margin: 1em auto;
-                padding: 2em;
-            }
-            h1 { font-size: 2.4rem; }
-            h2 { font-size: 2.2rem; }
-            h3 { font-size: 2.0rem; }
-            a:link, a:visited {
-                color: #36c;
-                text-decoration: none;
-            }
-            a:active, a:hover, a:focus {
-                text-decoration: underline;
-                text-underline-offset: 0.3em;
-            }
-            #lang-select {
-                font-size: 80%;
-                width: max-content;
-                margin: 2em 0 0 auto;
-                display: flex;
-                flex-direction: row;
-                flex-wrap: wrap;
-            }
-            #lang-select li {
-                flex-grow: 1;
-                flex-basis: auto;
-                margin: .25em 0 0 0;
-                padding: 0 1em;
-                text-align: center;
-                list-style-type: none;
-                border-left: 0.1rem solid currentColor;
-            }
-            #lang-select li:first-of-type {
-                border-left: 0 none transparent;
-            }
-            #lang-select li:last-of-type {
-                padding-right: 0;
-            }
+            {%~ include "_layout.css" ~%}
         /*]]>*/
         </style>
     </head>

--- a/examples/actix-web-app/templates/greet.html
+++ b/examples/actix-web-app/templates/greet.html
@@ -39,15 +39,5 @@
         </a>
     </h2>
 
-    <ul id="lang-select">
-        {%- if lang != Lang::en -%}
-            <li><a href="{{ req.url_for("greeting_handler", [Lang::en])? }}?name={{ name|urlencode }}">This page in English</a></li>
-        {%- endif -%}
-        {%- if lang != Lang::de -%}
-            <li><a href="{{ req.url_for("greeting_handler", [Lang::de])? }}?name={{ name|urlencode }}">Diese Seite auf deutsch.</a></li>
-        {%- endif -%}
-        {%- if lang != Lang::fr -%}
-            <li><a href="{{ req.url_for("greeting_handler", [Lang::fr])? }}?name={{ name|urlencode }}">Cette page est en français.</a></li>
-        {%- endif -%}
-    </ul>
+    {%- call lang_select("greeting_handler", name|urlencode|fmt("?name={}")) -%}
 {%- endblock -%}

--- a/examples/actix-web-app/templates/greet.html
+++ b/examples/actix-web-app/templates/greet.html
@@ -1,0 +1,44 @@
+{% extends "_layout.html" %}
+
+{% block title -%}
+    {%- match lang -%}
+        {%- when Lang::en -%} Hello, {{name}}!
+        {%- when Lang::de -%} Hallo, {{name}}!
+    {%- endmatch -%}
+{%- endblock %}
+
+{%- block content -%}
+    <h1>
+        {%- match lang -%}
+            {%- when Lang::en -%} Hello
+            {%- when Lang::de -%} Hallo
+        {%- endmatch -%}
+    </h1>
+    <p>
+        {%- match lang -%}
+            {%- when Lang::en -%}
+                Hello, <strong>{{name}}</strong>, nice to meet you! {#-~#}
+                I'm a <a href="https://rinja.readthedocs.io/en/latest/">Rinja</a> example application.
+            {%- when Lang::de -%}
+                Hallo, <strong>{{name}}</strong>, schön dich kennenzulernen! {#-~#}
+                Ich bin eine <a href="https://rinja.readthedocs.io/en/latest/">Rinja</a>-Beispielanwendung.
+        {%- endmatch -%}
+    </p>
+    <h2>
+        <a href="{{ req.url_for("index_handler", [lang])? }}?name={{ name|urlencode }}">
+            {%- match lang -%}
+                {%- when Lang::en -%} Back to the first page.
+                {%- when Lang::de -%} Zurück zur ersten Seite.
+            {%- endmatch -%}
+        </a>
+    </h2>
+
+    <ul id="lang-select">
+        {%- if lang != Lang::en -%}
+            <li><a href="{{ req.url_for("greeting_handler", [Lang::en])? }}?name={{ name|urlencode }}">This page in English</a></li>
+        {%- endif -%}
+        {%- if lang != Lang::de -%}
+            <li><a href="{{ req.url_for("greeting_handler", [Lang::de])? }}?name={{ name|urlencode }}">Diese Seite auf deutsch.</a></li>
+        {%- endif -%}
+    </ul>
+{%- endblock %}

--- a/examples/actix-web-app/templates/greet.html
+++ b/examples/actix-web-app/templates/greet.html
@@ -1,17 +1,19 @@
 {% extends "_layout.html" %}
 
-{% block title -%}
+{%- block title -%}
     {%- match lang -%}
         {%- when Lang::en -%} Hello, {{name}}!
         {%- when Lang::de -%} Hallo, {{name}}!
+        {%- when Lang::fr -%} Bonjour, {{name}}!
     {%- endmatch -%}
-{%- endblock %}
+{%- endblock -%}
 
 {%- block content -%}
     <h1>
         {%- match lang -%}
-            {%- when Lang::en -%} Hello
-            {%- when Lang::de -%} Hallo
+            {%- when Lang::en -%} Hello!
+            {%- when Lang::de -%} Hallo!
+            {%- when Lang::fr -%} Bonjour!
         {%- endmatch -%}
     </h1>
     <p>
@@ -22,6 +24,9 @@
             {%- when Lang::de -%}
                 Hallo, <strong>{{name}}</strong>, schön dich kennenzulernen! {#-~#}
                 Ich bin eine <a href="https://rinja.readthedocs.io/en/latest/">Rinja</a>-Beispielanwendung.
+            {%- when Lang::fr -%}
+                Bonjour, <strong>{{name}}</strong>, ravi de vous rencontrer ! {#-~#}
+                Je suis une application d'exemple de <a href="https://rinja.readthedocs.io/en/latest/">Rinja</a>.
         {%- endmatch -%}
     </p>
     <h2>
@@ -29,6 +34,7 @@
             {%- match lang -%}
                 {%- when Lang::en -%} Back to the first page.
                 {%- when Lang::de -%} Zurück zur ersten Seite.
+                {%- when Lang::fr -%} Retour à la première page.
             {%- endmatch -%}
         </a>
     </h2>
@@ -40,5 +46,8 @@
         {%- if lang != Lang::de -%}
             <li><a href="{{ req.url_for("greeting_handler", [Lang::de])? }}?name={{ name|urlencode }}">Diese Seite auf deutsch.</a></li>
         {%- endif -%}
+        {%- if lang != Lang::fr -%}
+            <li><a href="{{ req.url_for("greeting_handler", [Lang::fr])? }}?name={{ name|urlencode }}">Cette page est en français.</a></li>
+        {%- endif -%}
     </ul>
-{%- endblock %}
+{%- endblock -%}

--- a/examples/actix-web-app/templates/index.html
+++ b/examples/actix-web-app/templates/index.html
@@ -81,15 +81,9 @@
         </p>
     </form>
 
-    <ul id="lang-select">
-        {%- if lang != Lang::en -%}
-            <li><a href="{{ req.url_for("index_handler", [Lang::en])? }}">This page in English</a></li>
-        {%- endif -%}
-        {%- if lang != Lang::de -%}
-            <li><a href="{{ req.url_for("index_handler", [Lang::de])? }}">Diese Seite auf deutsch.</a></li>
-        {%- endif -%}
-        {%- if lang != Lang::fr -%}
-            <li><a href="{{ req.url_for("index_handler", [Lang::fr])? }}">Cette page est en français.</a></li>
-        {%- endif -%}
-    </ul>
+    {#-
+        The called macro is defined in base template "_layout.html",
+        and used to display the language selection footer.
+    ~#}
+    {%- call lang_select("index_handler", "") -%}
 {%- endblock -%}

--- a/examples/actix-web-app/templates/index.html
+++ b/examples/actix-web-app/templates/index.html
@@ -1,17 +1,19 @@
 {% extends "_layout.html" %}
 
-{% block title -%}
+{%- block title -%}
     {%- match lang -%}
-        {%- when Lang::en -%} Hello
-        {%- when Lang::de -%} Hallo
+        {%- when Lang::en -%} Hello!
+        {%- when Lang::de -%} Hallo!
+        {%- when Lang::fr -%} Bonjour!
     {%- endmatch -%}
-{%- endblock %}
+{%- endblock -%}
 
 {%- block content -%}
     <h1>
         {%- match lang -%}
-            {%- when Lang::en -%} Hello
-            {%- when Lang::de -%} Hallo
+            {%- when Lang::en -%} Hello!
+            {%- when Lang::de -%} Hallo!
+            {%- when Lang::fr -%} Bonjour!
         {%- endmatch -%}
     </h1>
     <form
@@ -27,6 +29,9 @@
                 {%- when Lang::de -%}
                     Ich möchte dir gerne <em>hallo</em> sagen. {#-~#}
                     Bitte nenne mir doch deinen Namen!
+                {%- when Lang::fr -%}
+                    Je voudrais vous dire <em>bonjour</em>. {#-~#}
+                    Pourriez-vous me donner votre nom ?
             {%- endmatch -%}
         </p>
         <p>
@@ -34,6 +39,7 @@
                 {%- match lang -%}
                     {%- when Lang::en -%} My name is
                     {%- when Lang::de -%} Ich heiße
+                    {%- when Lang::fr -%} Je m'appelle
                 {%- endmatch -%}:
                 <input
                     type="text"
@@ -50,6 +56,7 @@
                     {%- match lang -%}
                         {%- when Lang::en -%} Greet me, then!
                         {%- when Lang::de -%} Dann begrüße mich!
+                        {%- when Lang::fr -%} Saluons-nous !
                     {%- endmatch -%}
                 </button>
             </label>
@@ -63,5 +70,8 @@
         {%- if lang != Lang::de -%}
             <li><a href="{{ req.url_for("index_handler", [Lang::de])? }}">Diese Seite auf deutsch.</a></li>
         {%- endif -%}
+        {%- if lang != Lang::fr -%}
+            <li><a href="{{ req.url_for("index_handler", [Lang::fr])? }}">Cette page est en français.</a></li>
+        {%- endif -%}
     </ul>
-{%- endblock %}
+{%- endblock -%}

--- a/examples/actix-web-app/templates/index.html
+++ b/examples/actix-web-app/templates/index.html
@@ -1,0 +1,67 @@
+{% extends "_layout.html" %}
+
+{% block title -%}
+    {%- match lang -%}
+        {%- when Lang::en -%} Hello
+        {%- when Lang::de -%} Hallo
+    {%- endmatch -%}
+{%- endblock %}
+
+{%- block content -%}
+    <h1>
+        {%- match lang -%}
+            {%- when Lang::en -%} Hello
+            {%- when Lang::de -%} Hallo
+        {%- endmatch -%}
+    </h1>
+    <form
+        method="GET"
+        action="{{ req.url_for("greeting_handler", [lang])? }}"
+        autocomplete="off"
+    >
+        <p>
+            {%- match lang -%}
+                {%- when Lang::en -%}
+                    I would like to say <em>hello</em>. {#-~#}
+                    Would you please tell me your name?
+                {%- when Lang::de -%}
+                    Ich möchte dir gerne <em>hallo</em> sagen. {#-~#}
+                    Bitte nenne mir doch deinen Namen!
+            {%- endmatch -%}
+        </p>
+        <p>
+            <label>
+                {%- match lang -%}
+                    {%- when Lang::en -%} My name is
+                    {%- when Lang::de -%} Ich heiße
+                {%- endmatch -%}:
+                <input
+                    type="text"
+                    value="{{name}}"
+                    name="name"
+                    required
+                    style="width: 10em"
+                />
+            </label>
+        </p>
+        <p>
+            <label>
+                <button type="submit">
+                    {%- match lang -%}
+                        {%- when Lang::en -%} Greet me, then!
+                        {%- when Lang::de -%} Dann begrüße mich!
+                    {%- endmatch -%}
+                </button>
+            </label>
+        </p>
+    </form>
+
+    <ul id="lang-select">
+        {%- if lang != Lang::en -%}
+            <li><a href="{{ req.url_for("index_handler", [Lang::en])? }}">This page in English</a></li>
+        {%- endif -%}
+        {%- if lang != Lang::de -%}
+            <li><a href="{{ req.url_for("index_handler", [Lang::de])? }}">Diese Seite auf deutsch.</a></li>
+        {%- endif -%}
+    </ul>
+{%- endblock %}

--- a/examples/actix-web-app/templates/index.html
+++ b/examples/actix-web-app/templates/index.html
@@ -1,6 +1,9 @@
 {% extends "_layout.html" %}
 
 {%- block title -%}
+    {#-
+        In here you can see how to use the language URL compment to select the text to display.
+    -#}
     {%- match lang -%}
         {%- when Lang::en -%} Hello!
         {%- when Lang::de -%} Hallo!
@@ -16,12 +19,27 @@
             {%- when Lang::fr -%} Bonjour!
         {%- endmatch -%}
     </h1>
+    {#-
+        The `action` URL is built by actix-web, by using the user request `req` and
+        the language component of the URL. Both are fields in the struct that uses
+        this template file.
+    ~#}
     <form
         method="GET"
         action="{{ req.url_for("greeting_handler", [lang])? }}"
         autocomplete="off"
     >
         <p>
+            {#-
+                If your text contains long lines, you may want to split them,
+                so you as a developer have an easier time reading them.
+
+                If you don't want to end up with a multitude of spaces in the
+                generated content, you can use empty comments as seen below: `#-~#`.
+                This would strip the space before the comment, and leave a newline
+                character after the comment. Another option would be `#~-#`,
+                so that single space remains.
+            -#}
             {%- match lang -%}
                 {%- when Lang::en -%}
                     I would like to say <em>hello</em>. {#-~#}


### PR DESCRIPTION
I thought: We explain a lot in the book, use all functions in the tests, but we have no real example application so you can see rinja in action in a half-way realistic setting.

Todo:
- [x] write a README
- [x] add some comments in the source
- [x] adding a french translation in the templates

If that is a good example, I don't know. I was too lazy to write the ubiquitous TODO-app example.