### PR TITLE
Add HTML safe types

### DIFF
--- a/book/src/filters.md
+++ b/book/src/filters.md
@@ -607,9 +607,9 @@ if you know that *some* inputs for our filter will always result in a safe outpu
 ```rust
 fn as_sign(i: i32) -> Result<MaybeSafe<&'static str>, rinja::Error> {
     match i.into() {
-        i if i < 0 => Ok(MaybeSafe { text: "<0", safe: false }),
-        i if i > 0 => Ok(MaybeSafe { text: ">0", safe: false }),
-        _          => Ok(MaybeSafe { text: "=0", safe: true }),
+        i if i < 0 => Ok(MaybeSafe { text: "<0", needs_escaping: true }),
+        i if i > 0 => Ok(MaybeSafe { text: ">0", needs_escaping: true }),
+        _          => Ok(MaybeSafe { text: "=0", needs_escaping: false }),
     }
 }
 ```

--- a/book/src/filters.md
+++ b/book/src/filters.md
@@ -607,9 +607,9 @@ if you know that *some* inputs for our filter will always result in a safe outpu
 ```rust
 fn as_sign(i: i32) -> Result<MaybeSafe<&'static str>, rinja::Error> {
     match i.into() {
-        i if i < 0 => Ok(MaybeSafe { text: "<0", needs_escaping: true }),
-        i if i > 0 => Ok(MaybeSafe { text: ">0", needs_escaping: true }),
-        _          => Ok(MaybeSafe { text: "=0", needs_escaping: false }),
+        i if i < 0 => Ok(MaybeSafe::Safe("<0")),
+        i if i > 0 => Ok(MaybeSafe::Safe(">0")),
+        _          => Ok(MaybeSafe::NeedsEscaping("=0")),
     }
 }
 ```

--- a/examples/actix-web-app/templates/_layout.html
+++ b/examples/actix-web-app/templates/_layout.html
@@ -17,7 +17,7 @@
             E.g. maybe you would like to have "Rinja example application" as default title for
             your pages, then simply add this text (without quotation marks) in the block!
 
-            The default content can be as complex as you need to to be.
+            The default content can be as complex as you need it to be.
             E.g. it may contain any nodes like `{% if … %}`, and even other blocks.
         ~#}
         <title>{% block title %}{% endblock %}</title>
@@ -55,13 +55,13 @@
 {%- macro lang_select(handler, query) -%}
     <ul id="lang-select">
         {%- if lang != Lang::en -%}
-            <li><a href="{{ req.url_for(handler, [Lang::en])? }}{{ query|safe }}">This page in English</a></li>
+            <li><a href="{{ req.url_for(handler, [Lang::en])? }}{{ query }}">This page in English</a></li>
         {%- endif -%}
         {%- if lang != Lang::de -%}
-            <li><a href="{{ req.url_for(handler, [Lang::de])? }}{{ query|safe }}">Diese Seite auf deutsch.</a></li>
+            <li><a href="{{ req.url_for(handler, [Lang::de])? }}{{ query }}">Diese Seite auf deutsch.</a></li>
         {%- endif -%}
         {%- if lang != Lang::fr -%}
-            <li><a href="{{ req.url_for(handler, [Lang::fr])? }}{{ query|safe }}">Cette page est en français.</a></li>
+            <li><a href="{{ req.url_for(handler, [Lang::fr])? }}{{ query }}">Cette page est en français.</a></li>
         {%- endif -%}
     </ul>
 {%- endmacro lang_select -%}

--- a/rinja/src/filters/escape.rs
+++ b/rinja/src/filters/escape.rs
@@ -386,6 +386,16 @@ const _: () = {
     }
 };
 
+/// Like [`Safe`], but only for HTML output
+pub struct HtmlSafeOutput<T: fmt::Display>(pub T);
+
+impl<T: fmt::Display> fmt::Display for HtmlSafeOutput<T> {
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 macro_rules! mark_html_safe {
     ($($ty:ty),* $(,)?) => {$(
         impl HtmlSafe for $ty {}
@@ -411,6 +421,7 @@ impl<T: HtmlSafe + ?Sized> HtmlSafe for std::sync::Arc<T> {}
 impl<T: HtmlSafe + ?Sized> HtmlSafe for std::sync::MutexGuard<'_, T> {}
 impl<T: HtmlSafe + ?Sized> HtmlSafe for std::sync::RwLockReadGuard<'_, T> {}
 impl<T: HtmlSafe + ?Sized> HtmlSafe for std::sync::RwLockWriteGuard<'_, T> {}
+impl<T: HtmlSafe> HtmlSafe for HtmlSafeOutput<T> {}
 impl<T: HtmlSafe> HtmlSafe for std::num::Wrapping<T> {}
 
 impl<T> HtmlSafe for std::borrow::Cow<'_, T>

--- a/rinja/src/filters/escape.rs
+++ b/rinja/src/filters/escape.rs
@@ -202,12 +202,12 @@ impl<'a, T: fmt::Display + ?Sized, E: Escaper> AutoEscape for &&AutoEscaper<'a, 
 ///
 /// If you are unsure if your type generates HTML safe output in all cases, then DON'T mark it.
 /// Better safe than sorry!
-pub trait HtmlSafeMarker: fmt::Display {}
+pub trait HtmlSafe: fmt::Display {}
 
-impl<T: HtmlSafeMarker + ?Sized> HtmlSafeMarker for &T {}
+impl<T: HtmlSafe + ?Sized> HtmlSafe for &T {}
 
 /// Don't escape HTML safe types
-impl<'a, T: HtmlSafeMarker + ?Sized> AutoEscape for &AutoEscaper<'a, T, Html> {
+impl<'a, T: HtmlSafe + ?Sized> AutoEscape for &AutoEscaper<'a, T, Html> {
     type Escaped = &'a T;
     type Error = Infallible;
 
@@ -321,7 +321,7 @@ const _: () = {
 
 macro_rules! mark_html_safe {
     ($($ty:ty),* $(,)?) => {$(
-        impl HtmlSafeMarker for $ty {}
+        impl HtmlSafe for $ty {}
     )*};
 }
 
@@ -336,20 +336,20 @@ mark_html_safe! {
     std::num::NonZeroU64, std::num::NonZeroU128, std::num::NonZeroUsize,
 }
 
-impl<T: HtmlSafeMarker + ?Sized> HtmlSafeMarker for Box<T> {}
-impl<T: HtmlSafeMarker + ?Sized> HtmlSafeMarker for std::cell::Ref<'_, T> {}
-impl<T: HtmlSafeMarker + ?Sized> HtmlSafeMarker for std::cell::RefMut<'_, T> {}
-impl<T: HtmlSafeMarker + ?Sized> HtmlSafeMarker for std::rc::Rc<T> {}
-impl<T: HtmlSafeMarker + ?Sized> HtmlSafeMarker for std::sync::Arc<T> {}
-impl<T: HtmlSafeMarker + ?Sized> HtmlSafeMarker for std::sync::MutexGuard<'_, T> {}
-impl<T: HtmlSafeMarker + ?Sized> HtmlSafeMarker for std::sync::RwLockReadGuard<'_, T> {}
-impl<T: HtmlSafeMarker + ?Sized> HtmlSafeMarker for std::sync::RwLockWriteGuard<'_, T> {}
-impl<T: HtmlSafeMarker> HtmlSafeMarker for std::num::Wrapping<T> {}
+impl<T: HtmlSafe + ?Sized> HtmlSafe for Box<T> {}
+impl<T: HtmlSafe + ?Sized> HtmlSafe for std::cell::Ref<'_, T> {}
+impl<T: HtmlSafe + ?Sized> HtmlSafe for std::cell::RefMut<'_, T> {}
+impl<T: HtmlSafe + ?Sized> HtmlSafe for std::rc::Rc<T> {}
+impl<T: HtmlSafe + ?Sized> HtmlSafe for std::sync::Arc<T> {}
+impl<T: HtmlSafe + ?Sized> HtmlSafe for std::sync::MutexGuard<'_, T> {}
+impl<T: HtmlSafe + ?Sized> HtmlSafe for std::sync::RwLockReadGuard<'_, T> {}
+impl<T: HtmlSafe + ?Sized> HtmlSafe for std::sync::RwLockWriteGuard<'_, T> {}
+impl<T: HtmlSafe> HtmlSafe for std::num::Wrapping<T> {}
 
-impl<T> HtmlSafeMarker for std::borrow::Cow<'_, T>
+impl<T> HtmlSafe for std::borrow::Cow<'_, T>
 where
-    T: HtmlSafeMarker + std::borrow::ToOwned + ?Sized,
-    T::Owned: HtmlSafeMarker,
+    T: HtmlSafe + std::borrow::ToOwned + ?Sized,
+    T::Owned: HtmlSafe,
 {
 }
 
@@ -385,14 +385,14 @@ fn test_html_safe_marker() {
         }
     }
 
-    impl HtmlSafeMarker for Script2 {}
+    impl HtmlSafe for Script2 {}
 
     assert_eq!(
         (&&AutoEscaper::new(&Script1, Html))
             .rinja_auto_escape()
             .unwrap()
             .to_string(),
-        "&lt;script&gt;",
+        "&#60;script&#62;",
     );
     assert_eq!(
         (&&AutoEscaper::new(&Script2, Html))
@@ -437,14 +437,14 @@ fn test_html_safe_marker() {
             .rinja_auto_escape()
             .unwrap()
             .to_string(),
-        "&lt;script&gt;",
+        "&#60;script&#62;",
     );
     assert_eq!(
         (&&AutoEscaper::new(&Unsafe(Script2), Html))
             .rinja_auto_escape()
             .unwrap()
             .to_string(),
-        "&lt;script&gt;",
+        "&#60;script&#62;",
     );
 
     assert_eq!(
@@ -484,7 +484,7 @@ fn test_html_safe_marker() {
             .rinja_auto_escape()
             .unwrap()
             .to_string(),
-        "&lt;script&gt;",
+        "&#60;script&#62;",
     );
     assert_eq!(
         (&&AutoEscaper::new(
@@ -497,6 +497,6 @@ fn test_html_safe_marker() {
             .rinja_auto_escape()
             .unwrap()
             .to_string(),
-        "&lt;script&gt;",
+        "&#60;script&#62;",
     );
 }

--- a/rinja/src/filters/mod.rs
+++ b/rinja/src/filters/mod.rs
@@ -12,7 +12,7 @@ use std::convert::Infallible;
 use std::fmt::{self, Write};
 
 pub use escape::{
-    e, escape, safe, AutoEscape, AutoEscaper, Escaper, Html, HtmlSafeMarker, MaybeSafe, Safe, Text,
+    e, escape, safe, AutoEscape, AutoEscaper, Escaper, Html, HtmlSafe, MaybeSafe, Safe, Text,
     Unsafe,
 };
 #[cfg(feature = "humansize")]

--- a/rinja/src/filters/mod.rs
+++ b/rinja/src/filters/mod.rs
@@ -11,7 +11,7 @@ use std::cell::Cell;
 use std::convert::Infallible;
 use std::fmt::{self, Write};
 
-pub use escape::{e, escape, safe, Escaper, Html, Text};
+pub use escape::{e, escape, safe, AutoEscape, AutoEscaper, Escaper, Html, HtmlSafeMarker, Text};
 #[cfg(feature = "humansize")]
 use humansize::{ISizeFormatter, ToF64, DECIMAL};
 #[cfg(feature = "serde_json")]

--- a/rinja/src/filters/mod.rs
+++ b/rinja/src/filters/mod.rs
@@ -11,7 +11,10 @@ use std::cell::Cell;
 use std::convert::Infallible;
 use std::fmt::{self, Write};
 
-pub use escape::{e, escape, safe, AutoEscape, AutoEscaper, Escaper, Html, HtmlSafeMarker, Text};
+pub use escape::{
+    e, escape, safe, AutoEscape, AutoEscaper, Escaper, Html, HtmlSafeMarker, MaybeSafe, Safe, Text,
+    Unsafe,
+};
 #[cfg(feature = "humansize")]
 use humansize::{ISizeFormatter, ToF64, DECIMAL};
 #[cfg(feature = "serde_json")]

--- a/rinja/src/filters/mod.rs
+++ b/rinja/src/filters/mod.rs
@@ -12,8 +12,8 @@ use std::convert::Infallible;
 use std::fmt::{self, Write};
 
 pub use escape::{
-    e, escape, safe, AutoEscape, AutoEscaper, Escaper, Html, HtmlSafe, MaybeSafe, Safe, Text,
-    Unsafe,
+    e, escape, safe, AutoEscape, AutoEscaper, Escaper, Html, HtmlSafe, HtmlSafeOutput, MaybeSafe,
+    Safe, Text, Unsafe,
 };
 #[cfg(feature = "humansize")]
 use humansize::{ISizeFormatter, ToF64, DECIMAL};
@@ -98,8 +98,8 @@ impl fmt::Display for FilesizeFormatFilter {
 ///
 /// [`urlencode_strict`]: ./fn.urlencode_strict.html
 #[inline]
-pub fn urlencode<T: fmt::Display>(s: T) -> Result<impl fmt::Display, Infallible> {
-    Ok(UrlencodeFilter(s, URLENCODE_SET))
+pub fn urlencode(s: impl fmt::Display) -> Result<HtmlSafeOutput<impl fmt::Display>, Infallible> {
+    Ok(HtmlSafeOutput(UrlencodeFilter(s, URLENCODE_SET)))
 }
 
 #[cfg(feature = "urlencode")]
@@ -118,8 +118,10 @@ pub fn urlencode<T: fmt::Display>(s: T) -> Result<impl fmt::Display, Infallible>
 ///
 /// If you want to preserve `/`, see [`urlencode`](./fn.urlencode.html).
 #[inline]
-pub fn urlencode_strict<T: fmt::Display>(s: T) -> Result<impl fmt::Display, Infallible> {
-    Ok(UrlencodeFilter(s, URLENCODE_STRICT_SET))
+pub fn urlencode_strict(
+    s: impl fmt::Display,
+) -> Result<HtmlSafeOutput<impl fmt::Display>, Infallible> {
+    Ok(HtmlSafeOutput(UrlencodeFilter(s, URLENCODE_STRICT_SET)))
 }
 
 #[cfg(feature = "urlencode")]

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -27,6 +27,7 @@ struct Foo;"##
         let expected = format!(
             r#"impl ::rinja::Template for Foo {{
     fn render_into(&self, writer: &mut (impl ::std::fmt::Write + ?Sized)) -> ::rinja::Result<()> {{
+        use ::rinja::filters::AutoEscape as _;
         {new_expected}
         ::rinja::Result::Ok(())
     }}
@@ -58,7 +59,7 @@ impl ::std::fmt::Display for Foo {{
     ::std::write!(
         writer,
         "{expr0}",
-        expr0 = &::rinja::filters::escape(&(query), ::rinja::filters::Text)?,
+        expr0 = &(&&::rinja::filters::AutoEscaper::new(&(query), ::rinja::filters::Text)).rinja_auto_escape()?,
     )?;
 }"#,
     );
@@ -71,7 +72,7 @@ impl ::std::fmt::Display for Foo {{
     ::std::write!(
         writer,
         "{expr0}",
-        expr0 = &::rinja::filters::escape(&(s), ::rinja::filters::Text)?,
+        expr0 = &(&&::rinja::filters::AutoEscaper::new(&(s), ::rinja::filters::Text)).rinja_auto_escape()?,
     )?;
 }"#,
     );
@@ -84,7 +85,7 @@ impl ::std::fmt::Display for Foo {{
     ::std::write!(
         writer,
         "{expr0}",
-        expr0 = &::rinja::filters::escape(&(s), ::rinja::filters::Text)?,
+        expr0 = &(&&::rinja::filters::AutoEscaper::new(&(s), ::rinja::filters::Text)).rinja_auto_escape()?,
     )?;
 }"#,
     );


### PR DESCRIPTION
This PR adds an `HtmlSafeMarker` trait. Types that implement this marker are know to never generate strings containing the characters `< > & " '`, so they don't have to be escaped.

All glory goes to \@dtolnay's ["Autoref-based stable specialization"][1] case study / blog entry.

[1]: <https://github.com/dtolnay/case-studies/blob/0a9f083f334e53bc854a80022b1984b1bae36ef6/autoref-specialization/README.md>

This PR is built on #53.

Resolves #51.