### PR TITLE
 Speed-up HTML escaping by using equal sized entities 

### DIFF
--- a/testing/tests/filter_block.rs
+++ b/testing/tests/filter_block.rs
@@ -115,7 +115,7 @@ struct D;
 #[test]
 fn filter_block_html_escape() {
     let template = D;
-    assert_eq!(template.render().unwrap(), r#"&lt;block&gt;"#);
+    assert_eq!(template.render().unwrap(), r#"&#60;block&#62;"#);
 }
 
 // This test ensures that it is not escaped if it is not HTML.

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -19,8 +19,8 @@ fn filter_escape() {
     };
     assert_eq!(
         s.render().unwrap(),
-        "// my &lt;html&gt; is &quot;unsafe&quot; &amp; \
-         should be &#x27;escaped&#x27;"
+        "// my &#60;html&#62; is &#34;unsafe&#34; &#38; \
+         should be &#39;escaped&#39;"
     );
 }
 
@@ -42,7 +42,7 @@ fn filter_opt_escaper_none() {
     assert_eq!(
         t.render().unwrap(),
         r#"<h1 class="title">Foo Bar</h1>
-&lt;h1 class=&quot;title&quot;&gt;Foo Bar&lt;/h1&gt;
+&#60;h1 class=&#34;title&#34;&#62;Foo Bar&#60;/h1&#62;
 <h1 class="title">Foo Bar</h1>
 <h1 class="title">Foo Bar</h1>
 "#
@@ -67,9 +67,9 @@ fn filter_opt_escaper_html() {
     assert_eq!(
         t.render().unwrap(),
         r#"<h1 class="title">Foo Bar</h1>
-&lt;h1 class=&quot;title&quot;&gt;Foo Bar&lt;/h1&gt;
-&lt;h1 class=&quot;title&quot;&gt;Foo Bar&lt;/h1&gt;
-&lt;h1 class=&quot;title&quot;&gt;Foo Bar&lt;/h1&gt;
+&#60;h1 class=&#34;title&#34;&#62;Foo Bar&#60;/h1&#62;
+&#60;h1 class=&#34;title&#34;&#62;Foo Bar&#60;/h1&#62;
+&#60;h1 class=&#34;title&#34;&#62;Foo Bar&#60;/h1&#62;
 "#
     );
 }
@@ -329,7 +329,7 @@ fn test_json_attribute() {
     };
     assert_eq!(
         t.render().unwrap(),
-        r#"<li data-name="&quot;\&quot;\u003e\u003cbutton\u003eHacked!\u003c/button\u003e&quot;"></li>"#
+        r#"<li data-name="&#34;\&#34;\u003e\u003cbutton\u003eHacked!\u003c/button\u003e&#34;"></li>"#
     );
 }
 

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -39,7 +39,7 @@ struct EscapeTemplate<'a> {
 fn test_escape() {
     let s = EscapeTemplate { name: "<>&\"'" };
 
-    assert_eq!(s.render().unwrap(), "Hello, &lt;&gt;&amp;&quot;&#x27;!");
+    assert_eq!(s.render().unwrap(), "Hello, &#60;&#62;&#38;&#34;&#39;!");
 }
 
 #[derive(Template)]
@@ -155,7 +155,7 @@ fn test_literals_escape() {
     let s = LiteralsEscapeTemplate {};
     assert_eq!(
         s.render().unwrap(),
-        "A\n\r\t\\\0♥&#x27;&quot;&quot;\nA\n\r\t\\\0♥&#x27;&quot;&#x27;"
+        "A\n\r\t\\\0♥&#39;&#34;&#34;\nA\n\r\t\\\0♥&#39;&#34;&#39;"
     );
 }
 

--- a/testing/tests/whitespace.rs
+++ b/testing/tests/whitespace.rs
@@ -41,7 +41,7 @@ fn test_extra_whitespace() {
     template.nested_1.nested_2.hash.insert("key", "value");
     assert_eq!(
         template.render().unwrap(),
-        "\n0\n0\n0\n0\n\n\n\n0\n0\n0\n0\n0\n\na0\na1\nvalue\n\n\n\n\n\n[\n  &quot;a0&quot;,\n  &quot;a1&quot;,\n  &quot;a2&quot;,\n  &quot;a3&quot;\n]\n[\n  &quot;a0&quot;,\n  &quot;a1&quot;,\n  &quot;a2&quot;,\n  &quot;a3&quot;\n][\n  &quot;a0&quot;,\n  &quot;a1&quot;,\n  &quot;a2&quot;,\n  &quot;a3&quot;\n]\n[\n  &quot;a1&quot;\n][\n  &quot;a1&quot;\n]\n[\n  &quot;a1&quot;,\n  &quot;a2&quot;\n][\n  &quot;a1&quot;,\n  &quot;a2&quot;\n]\n[\n  &quot;a1&quot;\n][\n  &quot;a1&quot;\n]1-1-1\n3333 3\n2222 2\n0000 0\n3333 3\n\ntruefalse\nfalsefalsefalse\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
+        "\n0\n0\n0\n0\n\n\n\n0\n0\n0\n0\n0\n\na0\na1\nvalue\n\n\n\n\n\n[\n  &#34;a0&#34;,\n  &#34;a1&#34;,\n  &#34;a2&#34;,\n  &#34;a3&#34;\n]\n[\n  &#34;a0&#34;,\n  &#34;a1&#34;,\n  &#34;a2&#34;,\n  &#34;a3&#34;\n][\n  &#34;a0&#34;,\n  &#34;a1&#34;,\n  &#34;a2&#34;,\n  &#34;a3&#34;\n]\n[\n  &#34;a1&#34;\n][\n  &#34;a1&#34;\n]\n[\n  &#34;a1&#34;,\n  &#34;a2&#34;\n][\n  &#34;a1&#34;,\n  &#34;a2&#34;\n]\n[\n  &#34;a1&#34;\n][\n  &#34;a1&#34;\n]1-1-1\n3333 3\n2222 2\n0000 0\n3333 3\n\ntruefalse\nfalsefalsefalse\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
     );
 }
 


### PR DESCRIPTION
By using codepoint entities like `'&'` → `"&#38;"`, we have a much smaller lookup table (58 bytes instead of 29× pointer size ~= 232 bytes). This makes the cache happy, and the benchmark run about ~20% faster.

```text
$ cargo bench --bench escape
Escaping                time:   [3.4087 µs 3.4126 µs 3.4168 µs]
                        change: [-19.790% -19.580% -19.354%] (p = 0.00 < 0.05)
                        Performance has improved.
```

This PR is based on #53.

TODO:

- [x] fix all the expected outputs
