### PR TITLE
Implement operator `as` in template language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rinja
 
-`rinja` is based on [Askama](https://crates.io/crates/askama).
+**Rinja** is based on [Askama](https://crates.io/crates/askama).
 It implements a template rendering engine based on [Jinja](https://jinja.palletsprojects.com/), and
 generates type-safe Rust code from your templates at compile time
 based on a user-defined `struct` to hold the template's context.

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -296,7 +296,7 @@ struct MyTemplate {
 
 ## Calling functions
 
-If you only provide a function name, `rinja` will assume it's a method. If
+If you only provide a function name, rinja will assume it's a method. If
 you want to call a method, you will need to use a path instead:
 
 ```jinja
@@ -658,6 +658,16 @@ E.g. to test if the least significant bit is set in an integer field:
 {% endif %}
 ```
 
+### Type conversion
+
+You can use the [`as`](https://doc.rust-lang.org/std/keyword.as.html) operator in `{{ … }}`
+expressions, and `{% … %}` blocks. It works the same as in Rust, but with some deliberate
+restrictions:
+
+- You can only use [primitive types](https://doc.rust-lang.org/std/primitive/index.html)
+  like `i32` or `f64` both as source variable type and as target type.
+- If the source is a reference to a primitive type, e.g. `&&&bool`, then rinja automatically
+  dereferences the value until it gets the underlying `bool`.
 
 ## Templates in templates
 

--- a/rinja/src/helpers.rs
+++ b/rinja/src/helpers.rs
@@ -89,3 +89,42 @@ where
         Ok(())
     }
 }
+
+pub fn get_primitive_value<T: PrimitiveType>(value: &T) -> T::Value {
+    value.get()
+}
+
+pub trait PrimitiveType: Copy {
+    type Value: Copy;
+
+    fn get(self) -> Self::Value;
+}
+
+impl<T: PrimitiveType> PrimitiveType for &T {
+    type Value = T::Value;
+
+    #[inline]
+    fn get(self) -> Self::Value {
+        T::get(*self)
+    }
+}
+
+macro_rules! primitive_type {
+    ($($ty:ty),* $(,)?) => {$(
+        impl PrimitiveType for $ty {
+            type Value = $ty;
+
+            #[inline]
+            fn get(self) -> Self::Value {
+                self
+            }
+        }
+    )*};
+}
+
+primitive_type! {
+    bool,
+    f32, f64,
+    i8, i16, i32, i64, i128, isize,
+    u8, u16, u32, u64, u128, usize,
+}

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -263,7 +263,7 @@ writer.write_str("bla")?;"#,
         "{% if x == 12 %}bli
          {%- else if x is defined %}12
          {%- else %}nope{% endif %}",
-        r#"if *(&(self.x == 12) as &bool) {
+        r#"if *(&(self.x == 12) as &::core::primitive::bool) {
 writer.write_str("bli")?;
 } else {
 writer.write_str("12")?;
@@ -276,7 +276,7 @@ writer.write_str("12")?;
     // are present.
     compare(
         "{% if y is defined || x == 12 %}{{x}}{% endif %}",
-        r#"if *(&(false || self.x == 12) as &bool) {
+        r#"if *(&(false || self.x == 12) as &::core::primitive::bool) {
     match (
         &((&&::rinja::filters::AutoEscaper::new(&(self.x), ::rinja::filters::Text)).rinja_auto_escape()?),
     ) {
@@ -291,7 +291,7 @@ writer.write_str("12")?;
     );
     compare(
         "{% if y is defined || x == 12 %}{{x}}{% endif %}",
-        r#"if *(&(true || self.x == 12) as &bool) {
+        r#"if *(&(true || self.x == 12) as &::core::primitive::bool) {
     match (
         &((&&::rinja::filters::AutoEscaper::new(&(self.x), ::rinja::filters::Text)).rinja_auto_escape()?),
     ) {
@@ -379,7 +379,7 @@ fn check_bool_conditions() {
 
     compare(
         "{% if true || x == 12 %}{{x}}{% endif %}",
-        r#"if *(&(true || self.x == 12) as &bool) {
+        r#"if *(&(true || self.x == 12) as &::core::primitive::bool) {
     match (
         &((&&::rinja::filters::AutoEscaper::new(&(self.x), ::rinja::filters::Text)).rinja_auto_escape()?),
     ) {
@@ -394,7 +394,7 @@ fn check_bool_conditions() {
     );
     compare(
         "{% if false || x == 12 %}{{x}}{% endif %}",
-        r#"if *(&(false || self.x == 12) as &bool) {
+        r#"if *(&(false || self.x == 12) as &::core::primitive::bool) {
     match (
         &((&&::rinja::filters::AutoEscaper::new(
             &(self.x),

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -202,23 +202,22 @@ impl<'a> Expr<'a> {
             Some("as") => {
                 let (i, target) = opt(identifier)(j)?;
                 let target = target.unwrap_or_default();
-                return match target {
-                    "bool" | "f16" | "f32" | "f64" | "f128" | "i8" | "i16" | "i32" | "i64"
-                    | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {
-                        Ok((i, WithSpan::new(Self::As(Box::new(lhs), target), start)))
-                    }
-                    "" => Err(nom::Err::Failure(ErrorContext::new(
+                if crate::PRIMITIVE_TYPES.contains(&target) {
+                    return Ok((i, WithSpan::new(Self::As(Box::new(lhs), target), start)));
+                } else if target.is_empty() {
+                    return Err(nom::Err::Failure(ErrorContext::new(
                         "`as` operator expects the name of a primitive type on its right-hand side",
                         start,
-                    ))),
-                    _ => Err(nom::Err::Failure(ErrorContext::new(
+                    )));
+                } else {
+                    return Err(nom::Err::Failure(ErrorContext::new(
                         format!(
                             "`as` operator expects the name of a primitive type on its right-hand \
                               side, found `{target}`"
                         ),
                         start,
-                    ))),
-                };
+                    )));
+                }
             }
             _ => return Ok((i, lhs)),
         };

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -533,3 +533,21 @@ fn test_referenced() {
     assert_eq!(template_to_string(&template), "Hello, person!");
     assert_eq!(template_to_string(template), "Hello, person!");
 }
+
+#[derive(rinja::Template)]
+#[template(
+    source = "{{ input as u8 }} {{ &input as u8 }} {{ &&input as u8 }}",
+    ext = "txt"
+)]
+struct TestI16ToU8 {
+    input: i16,
+}
+
+#[test]
+#[allow(clippy::needless_borrows_for_generic_args)]
+fn test_i16_to_u8() {
+    assert_eq!(TestI16ToU8 { input: 0 }.to_string(), "0 0 0");
+    assert_eq!(TestI16ToU8 { input: 0x7f00 }.to_string(), "0 0 0");
+    assert_eq!(TestI16ToU8 { input: 255 }.to_string(), "255 255 255");
+    assert_eq!(TestI16ToU8 { input: -12345 }.to_string(), "199 199 199");
+}

--- a/testing/tests/ui/as-primitive-type.rs
+++ b/testing/tests/ui/as-primitive-type.rs
@@ -1,0 +1,24 @@
+use rinja::Template;
+
+#[derive(Template)]
+#[template(source = r#"{{ 1234 as 4567 }}"#, ext = "html")]
+struct A;
+
+#[derive(Template)]
+#[template(source = r#"{{ 1234 as ? }}"#, ext = "html")]
+struct B;
+
+#[derive(Template)]
+#[template(source = r#"{{ 1234 as u1234 }}"#, ext = "html")]
+struct C;
+
+#[derive(Template)]
+#[template(source = r#"{{ 1234 as core::primitive::u32 }}"#, ext = "html")]
+struct D;
+
+#[derive(Template)]
+#[template(source = r#"{{ 1234 as int32_t }}"#, ext = "html")]
+struct E;
+
+fn main() {
+}

--- a/testing/tests/ui/as-primitive-type.stderr
+++ b/testing/tests/ui/as-primitive-type.stderr
@@ -1,0 +1,49 @@
+error: `as` operator expects the name of a primitive type on its right-hand side
+       failed to parse template source at row 1, column 3 near:
+       "1234 as 4567 }}"
+ --> tests/ui/as-primitive-type.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `as` operator expects the name of a primitive type on its right-hand side
+       failed to parse template source at row 1, column 3 near:
+       "1234 as ? }}"
+ --> tests/ui/as-primitive-type.rs:7:10
+  |
+7 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `as` operator expects the name of a primitive type on its right-hand side, found `u1234`
+       failed to parse template source at row 1, column 3 near:
+       "1234 as u1234 }}"
+  --> tests/ui/as-primitive-type.rs:11:10
+   |
+11 | #[derive(Template)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `as` operator expects the name of a primitive type on its right-hand side, found `core`
+       failed to parse template source at row 1, column 3 near:
+       "1234 as core::primitive::u32 }}"
+  --> tests/ui/as-primitive-type.rs:15:10
+   |
+15 | #[derive(Template)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `as` operator expects the name of a primitive type on its right-hand side, found `int32_t`
+       failed to parse template source at row 1, column 3 near:
+       "1234 as int32_t }}"
+  --> tests/ui/as-primitive-type.rs:19:10
+   |
+19 | #[derive(Template)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Because it is not always super obvious if an identifier refers to `T` or `&T`, any references are automatically followed.

Resolves #61.