### PR TITLE
Remove quick_cache dependency

### DIFF
--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -30,7 +30,6 @@ mime = "0.3"
 mime_guess = "2"
 once_map = "0.4.18"
 proc-macro2 = "1"
-quick_cache = "0.6.0"
 quote = "1"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 syn = "2"


### PR DESCRIPTION
The commit 2f5a637 removed quick_cache for once_map.