### PR TITLE
phf should be a dev dependency

### DIFF
--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -13,12 +13,12 @@ serde_json = ["dep:serde_json", "rinja/serde_json"]
 
 [dependencies]
 rinja = { path = "../rinja", version = "0.2.0" }
-phf = { version = "0.11", features = ["macros" ]}
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 rinja = { path = "../rinja", version = "0.2.0", features = ["serde_json"] }
 criterion = "0.5"
+phf = { version = "0.11", features = ["macros" ]}
 trybuild = "1.0.76"
 
 [[bench]]


### PR DESCRIPTION
The `phf` crate is used in a benchmark for testing identifier normalization but not in the library itself.  This moves it to be a dev dependency.