### PR TITLE
Move integration crates in their own workspaces

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['main']
+    branches: ['master']
   pull_request:
   schedule:
     - cron: "32 4 * * 5"
@@ -24,9 +24,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --all-targets
-      - run: cargo test
+      - run: cargo nextest run
 
   Package:
     strategy:
@@ -38,20 +41,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - run: cd ${{ matrix.package }} && cargo test --all-targets
-      - run: cd ${{ matrix.package }} && cargo clippy --all-targets -- -D warnings
-
-  Lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: clippy
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-targets -- -D warnings
+      - run: cd ${{ matrix.package }} && cargo nextest run
+      - run: cd ${{ matrix.package }} && cargo clippy --all-targets -- -D warnings
+
+  Rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      # No need to test `rinja_derive_standalone`. It has same the `src` folder as `rinja_derive`.
+      # No need to run the checks in parallel. They are fast enough.
+      # No need for caching. No code is compiled at all.
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: |
+          set -eu
+          for PKG in \
+            rinja rinja_actix rinja_axum rinja_derive rinja_derive_standalone \
+            rinja_parser rinja_rocket rinja_warp testing examples/actix-web-app
+          do
+            cd "$PKG"
+            echo "Testing: $PKG"
+            cargo fmt -- --check
+            cd -
+          done
 
   MSRV:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,8 @@
 [workspace]
 members = [
     "rinja",
-    "rinja_actix",
-    "rinja_axum",
     "rinja_derive",
     "rinja_parser",
-    "rinja_rocket",
-    "rinja_warp",
     "testing",
 ]
 resolver = "2"
-
-default-members = [
-    "rinja",
-    "rinja_derive",
-    "rinja_parser",
-    "testing",
-]

--- a/rinja_actix/Cargo.toml
+++ b/rinja_actix/Cargo.toml
@@ -8,7 +8,6 @@ categories = ["template-engine"]
 homepage = "https://github.com/rinja-rs/rinja"
 repository = "https://github.com/rinja-rs/rinja"
 license = "MIT OR Apache-2.0"
-workspace = ".."
 readme = "README.md"
 edition = "2021"
 rust-version = "1.71"
@@ -29,3 +28,6 @@ humansize = ["rinja/humansize"]
 num-traits = ["rinja/num-traits"]
 serde_json = ["rinja/serde_json"]
 urlencode = ["rinja/urlencode"]
+
+[workspace]
+members = ["."]

--- a/rinja_axum/Cargo.toml
+++ b/rinja_axum/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/rinja-rs/rinja"
 repository = "https://github.com/rinja-rs/rinja"
 documentation = "https://docs.rs/rinja"
 license = "MIT OR Apache-2.0"
-workspace = ".."
 readme = "README.md"
 
 [dependencies]
@@ -31,3 +30,6 @@ humansize = ["rinja/humansize"]
 num-traits = ["rinja/num-traits"]
 serde_json = ["rinja/serde_json"]
 urlencode = ["rinja/urlencode"]
+
+[workspace]
+members = ["."]

--- a/rinja_rocket/Cargo.toml
+++ b/rinja_rocket/Cargo.toml
@@ -8,7 +8,6 @@ categories = ["template-engine"]
 homepage = "https://github.com/rinja-rs/rinja"
 repository = "https://github.com/rinja-rs/rinja"
 license = "MIT OR Apache-2.0"
-workspace = ".."
 readme = "README.md"
 edition = "2021"
 rust-version = "1.71"
@@ -27,3 +26,6 @@ humansize = ["rinja/humansize"]
 num-traits = ["rinja/num-traits"]
 serde_json = ["rinja/serde_json"]
 urlencode = ["rinja/urlencode"]
+
+[workspace]
+members = ["."]

--- a/rinja_warp/Cargo.toml
+++ b/rinja_warp/Cargo.toml
@@ -8,7 +8,6 @@ categories = ["template-engine"]
 homepage = "https://github.com/rinja-rs/rinja"
 repository = "https://github.com/rinja-rs/rinja"
 license = "MIT OR Apache-2.0"
-workspace = ".."
 readme = "README.md"
 edition = "2021"
 rust-version = "1.71"
@@ -27,3 +26,6 @@ humansize = ["rinja/humansize"]
 num-traits = ["rinja/num-traits"]
 serde_json = ["rinja/serde_json"]
 urlencode = ["rinja/urlencode"]
+
+[workspace]
+members = ["."]


### PR DESCRIPTION
Everytime you hit ctrl+s in VS code, the whole project in checked, which normally is a nice thing, and I would not like to disable that in my configuration.

But in rinja, the diffent integration crates don't work well with one another and every single one will have compile errors in the automatic check, because `rinja_derive` won't know what the relevant `rinja_xyz` crate is. This renders the automatic check useless. Then it takes ages to compile and recompile all transitively used `proc_macros`.

This PR moves all integration crates in there own, individual workspaces. `cargo check` will ignore them unless you traverse manually into their folders. The CI is set up to do just that.