### PR TITLE
Fix filter block

### DIFF
--- a/rinja_derive/src/lib.rs
+++ b/rinja_derive/src/lib.rs
@@ -115,6 +115,7 @@ fn build_skeleton(ast: &syn::DeriveInput) -> Result<String, CompileError> {
         None,
         MapChain::default(),
         input.block.is_some(),
+        0,
     )
     .build(&contexts[&input.path])
 }
@@ -169,6 +170,7 @@ pub(crate) fn build_template(ast: &syn::DeriveInput) -> Result<String, CompileEr
         heritage.as_ref(),
         MapChain::default(),
         input.block.is_some(),
+        0,
     )
     .build(&contexts[&input.path])?;
     if input.print == Print::Code || input.print == Print::All {

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -28,6 +28,7 @@ struct Foo;"##
             r#"impl ::rinja::Template for Foo {{
     fn render_into(&self, writer: &mut (impl ::std::fmt::Write + ?Sized)) -> ::rinja::Result<()> {{
         use ::rinja::filters::AutoEscape as _;
+        use ::core::fmt::Write as _;
         {new_expected}
         ::rinja::Result::Ok(())
     }}

--- a/testing/templates/html-base.html
+++ b/testing/templates/html-base.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+
+        <title>{%- block title -%} Default title {%- endblock title -%}</title>
+    </head>
+
+    <body class="{% block body_classes %}{% endblock body_classes %}">
+        {%- block body -%}{%- endblock body -%}
+    </body>
+</html>

--- a/testing/tests/filter_block.rs
+++ b/testing/tests/filter_block.rs
@@ -197,3 +197,78 @@ hello
   pika"#
     );
 }
+
+#[derive(Template)]
+#[template(
+    source = r#"{% extends "html-base.html" %}
+
+{%- block body -%}
+    <h1>Metadata</h1>
+        {% set y = 12 %}
+
+    {% filter wordcount %}
+        {%- include "../Cargo.toml" +%}
+        y is {{ y }}
+    {% endfilter %}
+{%- endblock body %}
+"#,
+    ext = "html"
+)]
+struct IncludeInFilter;
+
+// This test ensures that `include` are correctly working inside filter blocks and that external
+// variables are used correctly.
+#[test]
+fn filter_block_include() {
+    assert_eq!(
+        IncludeInFilter.render().unwrap(),
+        r#"<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+
+        <title>Default title</title>
+    </head>
+
+    <body class=""><h1>Metadata</h1>
+        
+
+    100</body>
+</html>"#
+    );
+}
+
+#[derive(Template)]
+#[template(
+    source = r#"
+{%- filter title %}
+    {{- x -}}
+    {%- if x == 21 -%}
+        X is big
+    {%- else -%}
+        No clue what X is
+    {%- endif %}
+
+    {% if let Some(v) = v -%}
+        v is {{ v -}}
+    {% endif -%}
+{% endfilter -%}
+"#,
+    ext = "html",
+    print = "code"
+)]
+struct ConditionInFilter {
+    x: usize,
+    v: Option<String>,
+}
+
+// This test ensures that `include` are correctly working inside filter blocks and that external
+// variables are used correctly.
+#[test]
+fn filter_block_conditions() {
+    let s = ConditionInFilter {
+        x: 21,
+        v: Some("hoho".to_string()),
+    };
+    assert_eq!(s.render().unwrap(), "21x Is Big\n\n    V Is Hoho",);
+}

--- a/testing/tests/ui/block_in_filter_block.rs
+++ b/testing/tests/ui/block_in_filter_block.rs
@@ -1,0 +1,21 @@
+use rinja::Template;
+
+#[derive(Template)]
+#[template(
+    source = r#"{% extends "html-base.html" %}
+
+{%- block body -%}
+    <h1>Metadata</h1>
+
+    {% filter wordcount %}
+        {% block title %}New title{% endblock %}
+        a b
+    {% endfilter %}
+{%- endblock body %}
+"#,
+    ext = "html"
+)]
+struct BlockInFilter;
+
+fn main() {
+}

--- a/testing/tests/ui/block_in_filter_block.stderr
+++ b/testing/tests/ui/block_in_filter_block.stderr
@@ -1,0 +1,9 @@
+error: cannot have a block inside a filter block
+ --> BlockInFilter.html:7:10
+       " block title %}New title{% endblock %}\n "...
+ --> tests/ui/block_in_filter_block.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
It's the last issue I encountered blocking the docs.rs migration.

So in short: we were writing all "sub instructions" (like `include`) in `writer` as usual. Except that the filter block is supposed to be applied to anything that was output inside it. To go around this problem, I simpler shadow the `writer` variable in a sub-block (the filter block) and then call the filters on it.