### PR TITLE
Add handling of boolean literals to condition evaluation

### DIFF
--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -372,8 +372,7 @@ impl<'a> Generator<'a> {
         only_contains_is_defined: &mut bool,
     ) -> EvaluatedResult {
         match **expr {
-            Expr::BoolLit(_)
-            | Expr::NumLit(_)
+            Expr::NumLit(_)
             | Expr::StrLit(_)
             | Expr::CharLit(_)
             | Expr::Var(_)
@@ -392,6 +391,8 @@ impl<'a> Generator<'a> {
                 *only_contains_is_defined = false;
                 EvaluatedResult::Unknown
             }
+            Expr::BoolLit(true) => EvaluatedResult::AlwaysTrue,
+            Expr::BoolLit(false) => EvaluatedResult::AlwaysFalse,
             Expr::Unary("!", ref inner) => {
                 match self.evaluate_condition(inner, only_contains_is_defined) {
                     EvaluatedResult::AlwaysTrue => EvaluatedResult::AlwaysFalse,

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -1888,8 +1888,12 @@ impl<'a> Generator<'a> {
         DisplayWrap::Wrapped
     }
 
-    fn visit_bool_lit(&mut self, buf: &mut Buffer, s: &str) -> DisplayWrap {
-        buf.write(s);
+    fn visit_bool_lit(&mut self, buf: &mut Buffer, s: bool) -> DisplayWrap {
+        if s {
+            buf.write("true");
+        } else {
+            buf.write("false");
+        }
         DisplayWrap::Unwrapped
     }
 

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -35,7 +35,7 @@ macro_rules! expr_prec_layer {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Expr<'a> {
-    BoolLit(&'a str),
+    BoolLit(bool),
     NumLit(&'a str),
     StrLit(&'a str),
     CharLit(&'a str),
@@ -334,8 +334,8 @@ impl<'a> Expr<'a> {
         let start = i;
         map(path_or_identifier, |v| match v {
             PathOrIdentifier::Path(v) => Self::Path(v),
-            PathOrIdentifier::Identifier(v @ "true") => Self::BoolLit(v),
-            PathOrIdentifier::Identifier(v @ "false") => Self::BoolLit(v),
+            PathOrIdentifier::Identifier("true") => Self::BoolLit(true),
+            PathOrIdentifier::Identifier("false") => Self::BoolLit(false),
             PathOrIdentifier::Identifier(v) => Self::Var(v),
         })(i)
         .map(|(i, expr)| (i, WithSpan::new(expr, start)))


### PR DESCRIPTION
This PR always checks for booleans in `condition_evaluation` function. One thing I thought about: we could skip this function entirely if we don't have `is (not) defined` inside a condition. However, it'd require to either go through all items of the conditions to see if one of them is `is (not) defined` or to pass a `&mut bool` to check if the expression encounters one of them.

Another thing I thought: instead of handling the evaluation in the generator, we could potentially handle it in the parser directly (and therefore, not having the branches in the AST if the previous `if` excluded it). Not sure if it's a good idea or not though.

Anyway, this PR is much simpler than that since it only adds checks for boolean literals. :)