### PR TITLE
Copy `404.html` file to readthedocs output dir

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,3 +14,4 @@ build:
     - curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-quickinstall/releases/download/mdbook-0.4.40/mdbook-0.4.40-x86_64-unknown-linux-gnu.tar.gz | tar -xzvvf - -C $HOME/bin
     # Convert the book to HTML.
     - $HOME/bin/mdbook build book --dest-dir $READTHEDOCS_OUTPUT/html
+    - cp book/404.html $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
Seems like  #97 was not enough: I forgot to copy the `404.html` file in the `.readthedocs.yml` file too.