### PR TITLE
Change the error message to make it start at the `as` keyword

### DIFF
--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -195,8 +195,8 @@ impl<'a> Expr<'a> {
 
     fn is_as(i: &'a str, level: Level) -> ParseResult<'a, WithSpan<'a, Self>> {
         let start = i;
-        let (i, lhs) = Self::filtered(i, level)?;
-        let (j, rhs) = opt(ws(identifier))(i)?;
+        let (before_keyword, lhs) = Self::filtered(i, level)?;
+        let (j, rhs) = opt(ws(identifier))(before_keyword)?;
         let i = match rhs {
             Some("is") => j,
             Some("as") => {
@@ -207,7 +207,7 @@ impl<'a> Expr<'a> {
                 } else if target.is_empty() {
                     return Err(nom::Err::Failure(ErrorContext::new(
                         "`as` operator expects the name of a primitive type on its right-hand side",
-                        start,
+                        before_keyword.trim_start(),
                     )));
                 } else {
                     return Err(nom::Err::Failure(ErrorContext::new(
@@ -215,11 +215,11 @@ impl<'a> Expr<'a> {
                             "`as` operator expects the name of a primitive type on its right-hand \
                               side, found `{target}`"
                         ),
-                        start,
+                        before_keyword.trim_start(),
                     )));
                 }
             }
-            _ => return Ok((i, lhs)),
+            _ => return Ok((before_keyword, lhs)),
         };
 
         let (i, rhs) = opt(terminated(opt(keyword("not")), ws(keyword("defined"))))(i)?;

--- a/testing/tests/ui/as-primitive-type.rs
+++ b/testing/tests/ui/as-primitive-type.rs
@@ -20,5 +20,9 @@ struct D;
 #[template(source = r#"{{ 1234 as int32_t }}"#, ext = "html")]
 struct E;
 
+#[derive(Template)]
+#[template(source = r#"{{ (1234 + 4 * 12 / 45675445 - 13) as int32_t }}"#, ext = "html")]
+struct F;
+
 fn main() {
 }

--- a/testing/tests/ui/as-primitive-type.stderr
+++ b/testing/tests/ui/as-primitive-type.stderr
@@ -1,6 +1,6 @@
 error: `as` operator expects the name of a primitive type on its right-hand side
-       failed to parse template source at row 1, column 3 near:
-       "1234 as 4567 }}"
+       failed to parse template source at row 1, column 8 near:
+       "as 4567 }}"
  --> tests/ui/as-primitive-type.rs:3:10
   |
 3 | #[derive(Template)]
@@ -9,8 +9,8 @@ error: `as` operator expects the name of a primitive type on its right-hand side
   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `as` operator expects the name of a primitive type on its right-hand side
-       failed to parse template source at row 1, column 3 near:
-       "1234 as ? }}"
+       failed to parse template source at row 1, column 8 near:
+       "as ? }}"
  --> tests/ui/as-primitive-type.rs:7:10
   |
 7 | #[derive(Template)]
@@ -19,8 +19,8 @@ error: `as` operator expects the name of a primitive type on its right-hand side
   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `as` operator expects the name of a primitive type on its right-hand side, found `u1234`
-       failed to parse template source at row 1, column 3 near:
-       "1234 as u1234 }}"
+       failed to parse template source at row 1, column 8 near:
+       "as u1234 }}"
   --> tests/ui/as-primitive-type.rs:11:10
    |
 11 | #[derive(Template)]
@@ -29,8 +29,8 @@ error: `as` operator expects the name of a primitive type on its right-hand side
    = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `as` operator expects the name of a primitive type on its right-hand side, found `core`
-       failed to parse template source at row 1, column 3 near:
-       "1234 as core::primitive::u32 }}"
+       failed to parse template source at row 1, column 8 near:
+       "as core::primitive::u32 }}"
   --> tests/ui/as-primitive-type.rs:15:10
    |
 15 | #[derive(Template)]
@@ -39,11 +39,21 @@ error: `as` operator expects the name of a primitive type on its right-hand side
    = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `as` operator expects the name of a primitive type on its right-hand side, found `int32_t`
-       failed to parse template source at row 1, column 3 near:
-       "1234 as int32_t }}"
+       failed to parse template source at row 1, column 8 near:
+       "as int32_t }}"
   --> tests/ui/as-primitive-type.rs:19:10
    |
 19 | #[derive(Template)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `as` operator expects the name of a primitive type on its right-hand side, found `int32_t`
+       failed to parse template source at row 1, column 35 near:
+       "as int32_t }}"
+  --> tests/ui/as-primitive-type.rs:23:10
+   |
+23 | #[derive(Template)]
    |          ^^^^^^^^
    |
    = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Follow-up of https://github.com/rinja-rs/rinja/pull/63.

I thought about the case where there is a big expression before the `as` keyword. In this case, it's really not clear when we show everything what's actually wrong. It renders better when we make it start at the `as` keyword so we still keep the keyword to give context but remove the "noise" coming from the expression so the user can see better what's going on.

If it makes sense?

I added a test case to illustrate it if you want to compare. ;)