### PR TITLE
 Bump version numbers to v0.3.0 

### DIFF
--- a/examples/actix-web-app/Cargo.toml
+++ b/examples/actix-web-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-app"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -10,7 +10,7 @@ publish = false
 # and actix-web as your web-framework.
 # rinja_actix makes it easy to use rinja templates as `Responder` of an actix-web request.
 # The rendered template is simply the response of your handler!
-rinja_actix = { version = "0.2.0", path = "../../rinja_actix" }
+rinja_actix = { version = "0.3.0", path = "../../rinja_actix" }
 actix-web = { version = "4.8.0", default-features = false, features = ["macros"] }
 tokio = { version = "1.38.0", features = ["sync", "rt-multi-thread"] }
 

--- a/rinja/Cargo.toml
+++ b/rinja/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja"
-version = "0.2.0"
+version = "0.3.0"
 description = "Type-safe, compiled Jinja-like templates for Rust"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -32,7 +32,7 @@ with-rocket = ["rinja_derive/with-rocket"]
 with-warp = ["rinja_derive/with-warp"]
 
 [dependencies]
-rinja_derive = { version = "0.2.0", path = "../rinja_derive" }
+rinja_derive = { version = "=0.3.0", path = "../rinja_derive" }
 
 itoa = "1.0.11"
 

--- a/rinja_actix/Cargo.toml
+++ b/rinja_actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_actix"
-version = "0.2.0"
+version = "0.3.0"
 description = "Actix-Web integration for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.71"
 
 [dependencies]
-rinja = { version = "0.2.0", path = "../rinja", default-features = false, features = ["with-actix-web"] }
+rinja = { version = "0.3.0", path = "../rinja", default-features = false, features = ["with-actix-web"] }
 actix-web = { version = "4", default-features = false }
 
 [dev-dependencies]

--- a/rinja_axum/Cargo.toml
+++ b/rinja_axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_axum"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.71"
 description = "Axum integration for Rinja templates"
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-rinja = { version = "0.2.0", path = "../rinja", default-features = false, features = ["with-axum"] }
+rinja = { version = "0.3.0", path = "../rinja", default-features = false, features = ["with-axum"] }
 axum-core = "0.4"
 http = "1.0"
 

--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_derive"
-version = "0.2.0"
+version = "0.3.0"
 description = "Procedural macro package for Rinja"
 homepage = "https://github.com/rinja-rs/rinja"
 repository = "https://github.com/rinja-rs/rinja"
@@ -25,7 +25,8 @@ with-rocket = []
 with-warp = []
 
 [dependencies]
-parser = { package = "rinja_parser", version = "0.2.0", path = "../rinja_parser" }
+parser = { package = "rinja_parser", version = "=0.3.0", path = "../rinja_parser" }
+
 basic-toml = { version = "0.1.1", optional = true }
 memchr = "2"
 mime = "0.3"

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_derive_standalone"
-version = "0.2.0"
+version = "0.3.0"
 description = "Procedural macro package for Rinja"
 homepage = "https://github.com/rinja-rs/rinja"
 repository = "https://github.com/rinja-rs/rinja"
@@ -24,7 +24,8 @@ with-rocket = []
 with-warp = []
 
 [dependencies]
-parser = { package = "rinja_parser", version = "0.2.0", path = "../rinja_parser" }
+parser = { package = "rinja_parser", version = "=0.3.0", path = "../rinja_parser" }
+
 basic-toml = { version = "0.1.1", optional = true }
 memchr = "2"
 mime = "0.3"

--- a/rinja_parser/Cargo.toml
+++ b/rinja_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_parser"
-version = "0.2.0"
+version = "0.3.0"
 description = "Parser for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]

--- a/rinja_rocket/Cargo.toml
+++ b/rinja_rocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_rocket"
-version = "0.2.0"
+version = "0.3.0"
 description = "Rocket integration for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.71"
 
 [dependencies]
-rinja = { version = "0.2.0", path = "../rinja", default-features = false, features = ["with-rocket"] }
+rinja = { version = "0.3.0", path = "../rinja", default-features = false, features = ["with-rocket"] }
 rocket = { version = "0.5", default-features = false }
 
 [dev-dependencies]

--- a/rinja_warp/Cargo.toml
+++ b/rinja_warp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_warp"
-version = "0.2.0"
+version = "0.3.0"
 description = "Warp integration for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.71"
 
 [dependencies]
-rinja = { version = "0.2.0", path = "../rinja", default-features = false, features = ["with-warp"] }
+rinja = { version = "0.3.0", path = "../rinja", default-features = false, features = ["with-warp"] }
 warp = { version = "0.3", default-features = false }
 
 [dev-dependencies]

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_testing"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["rinja-rs developers"]
 workspace = ".."
 edition = "2021"
@@ -12,11 +12,11 @@ default = ["serde_json"]
 serde_json = ["dep:serde_json", "rinja/serde_json"]
 
 [dependencies]
-rinja = { path = "../rinja", version = "0.2.0" }
+rinja = { path = "../rinja", version = "0.3.0" }
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-rinja = { path = "../rinja", version = "0.2.0", features = ["serde_json"] }
+rinja = { path = "../rinja", version = "0.3.0", features = ["serde_json"] }
 criterion = "0.5"
 phf = { version = "0.11", features = ["macros" ]}
 trybuild = "1.0.76"


### PR DESCRIPTION
* rinja 0.2.1 is backward compatible to v0.2.0, only adding new functions traits, not changing existing ones
* rinja_derive 0.3.0 emits code that uses e.g. `rinja::helpers::get_primitive_value()` which were not present in rinja 0.2.0, so it is not backward compatible
* rinja_parser introduces new enum members, so it is not backward compatible

Resolves #101.