### PR TITLE
derive: use fewer unwraps

### DIFF
--- a/rinja_derive/src/config.rs
+++ b/rinja_derive/src/config.rs
@@ -105,7 +105,7 @@ impl Config {
         let config_path = key.0.config_path.as_deref();
         let template_whitespace = key.0.template_whitespace.as_deref();
 
-        let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+        let root = manifest_root();
         let default_dirs = vec![root.join("templates")];
 
         let mut syntaxes = BTreeMap::new();
@@ -445,7 +445,7 @@ pub(crate) fn read_config_file(
     config_path: Option<&str>,
     span: Option<Span>,
 ) -> Result<String, CompileError> {
-    let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let root = manifest_root();
     let filename = match config_path {
         Some(config_path) => root.join(config_path),
         None => root.join(CONFIG_FILE_NAME),
@@ -466,6 +466,10 @@ pub(crate) fn read_config_file(
     } else {
         Ok("".to_string())
     }
+}
+
+fn manifest_root() -> PathBuf {
+    env::var_os("CARGO_MANIFEST_DIR").map_or_else(|| PathBuf::from("."), PathBuf::from)
 }
 
 fn str_set(vals: &[&'static str]) -> Vec<Cow<'static, str>> {

--- a/rinja_derive/src/lib.rs
+++ b/rinja_derive/src/lib.rs
@@ -90,7 +90,10 @@ use syn::parse_quote_spanned;
     proc_macro_derive(Template, attributes(template))
 )]
 pub fn derive_template(input: TokenStream12) -> TokenStream12 {
-    let ast = syn::parse2(input.into()).unwrap();
+    let ast = match syn::parse2(input.into()) {
+        Ok(ast) => ast,
+        Err(err) => return err.to_compile_error().into(),
+    };
     match build_template(&ast) {
         Ok(source) => source.parse().unwrap(),
         Err(CompileError {


### PR DESCRIPTION
`rinja_derive(_standalone)` expects that the environment variable `CARGO_MANIFEST_DIR` is set and panics otherwise. It also expects that the input can be parsed as a struct/enum/union and panics otherwise.

This PR uses `"."` as fallback path if `CARGO_MANIFEST_DIR` is unset, and generates a compiler error if the input TokenStream could not be parsed.

Both error conditions should only occur in `rinja_derive_standalone`, esp. if you have an unexpected runtime like WASM that does not have a filesystem or environment variables.