### PR TITLE
derive: allow split up template attributes

### DIFF
--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -544,10 +544,19 @@ struct TestI16ToU8 {
 }
 
 #[test]
-#[allow(clippy::needless_borrows_for_generic_args)]
 fn test_i16_to_u8() {
     assert_eq!(TestI16ToU8 { input: 0 }.to_string(), "0 0 0");
     assert_eq!(TestI16ToU8 { input: 0x7f00 }.to_string(), "0 0 0");
     assert_eq!(TestI16ToU8 { input: 255 }.to_string(), "255 255 255");
     assert_eq!(TestI16ToU8 { input: -12345 }.to_string(), "199 199 199");
+}
+
+#[derive(Template)]
+#[template(source = "🙂")]
+#[template(ext = "txt")]
+struct SplitTemplateDeclaration;
+
+#[test]
+fn test_split_template_declaration() {
+    assert_eq!(SplitTemplateDeclaration.to_string(), "🙂")
 }

--- a/testing/tests/ui/duplicated_template_attribute.stderr
+++ b/testing/tests/ui/duplicated_template_attribute.stderr
@@ -1,5 +1,5 @@
-error: duplicated 'template' attribute
- --> tests/ui/duplicated_template_attribute.rs:8:3
+error: must specify `source` OR `path` exactly once
+ --> tests/ui/duplicated_template_attribute.rs:9:5
   |
-8 | #[template(
-  |   ^^^^^^^^
+9 |     source = "🙃",
+  |     ^^^^^^

--- a/testing/tests/ui/no_template_attribute.stderr
+++ b/testing/tests/ui/no_template_attribute.stderr
@@ -1,4 +1,4 @@
-error: no attribute 'template' found
+error: no attribute `template` found
  --> tests/ui/no_template_attribute.rs:4:8
   |
 4 | struct NoTemplate;


### PR DESCRIPTION
In generated code or macros, it might be useful to emit multiple `#[template]` attributes. E.g.

```rust
 #[template(source = "Hello!")]
 #[template(ext = "txt")]
 struct Hello;
```