### PR TITLE
Implement `FastWritable` for `|json`

### DIFF
--- a/rinja/benches/to-json.rs
+++ b/rinja/benches/to-json.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use rinja::filters::{escape, json, json_pretty, Html};
+use rinja::Template;
 
 criterion_main!(benches);
 criterion_group!(benches, functions);
@@ -12,34 +12,58 @@ fn functions(c: &mut Criterion) {
 }
 
 fn escape_json(b: &mut criterion::Bencher<'_>) {
+    #[derive(Template)]
+    #[template(ext = "html", source = "{{self.0|json|safe}}")]
+    struct Tmpl(&'static str);
+
     b.iter(|| {
+        let mut len = 0;
         for &s in STRINGS {
-            format!("{}", json(s).unwrap());
+            len += Tmpl(s).to_string().len();
         }
+        len
     });
 }
 
 fn escape_json_pretty(b: &mut criterion::Bencher<'_>) {
+    #[derive(Template)]
+    #[template(ext = "html", source = "{{self.0|json(2)|safe}}")]
+    struct Tmpl(&'static str);
+
     b.iter(|| {
+        let mut len = 0;
         for &s in STRINGS {
-            format!("{}", json_pretty(s, 2).unwrap());
+            len += Tmpl(s).to_string().len();
         }
+        len
     });
 }
 
 fn escape_json_for_html(b: &mut criterion::Bencher<'_>) {
+    #[derive(Template)]
+    #[template(ext = "html", source = "{{self.0|json}}")]
+    struct Tmpl(&'static str);
+
     b.iter(|| {
+        let mut len = 0;
         for &s in STRINGS {
-            format!("{}", escape(json(s).unwrap(), Html).unwrap());
+            len += Tmpl(s).to_string().len();
         }
+        len
     });
 }
 
 fn escape_json_for_html_pretty(b: &mut criterion::Bencher<'_>) {
+    #[derive(Template)]
+    #[template(ext = "html", source = "{{self.0|json(2)}}")]
+    struct Tmpl(&'static str);
+
     b.iter(|| {
+        let mut len = 0;
         for &s in STRINGS {
-            format!("{}", escape(json_pretty(s, 2).unwrap(), Html).unwrap(),);
+            len += Tmpl(s).to_string().len();
         }
+        len
     });
 }
 


### PR DESCRIPTION
```text
escape JSON             time:   [7.5003 µs 7.5130 µs 7.5271 µs]
                        change: [-14.410% -14.012% -13.643%] (p = 0.00 < 0.05)

escape JSON (pretty)    time:   [7.4790 µs 7.4907 µs 7.5052 µs]
                        change: [-15.374% -14.949% -14.591%] (p = 0.00 < 0.05)

escape JSON for HTML    time:   [11.428 µs 11.446 µs 11.466 µs]
                        change: [-9.6135% -8.5244% -7.8519%] (p = 0.00 < 0.05)

escape JSON for HTML (pretty)
                        time:   [11.394 µs 11.413 µs 11.435 µs]
                        change: [-10.979% -10.701% -10.449%] (p = 0.00 < 0.05)