### PR TITLE
Improve compile-time if conditions handling

### DIFF
--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -367,6 +367,34 @@ impl<'a> Expr<'a> {
         let start = i;
         map(char_lit, |i| WithSpan::new(Self::CharLit(i), start))(i)
     }
+
+    pub fn contains_bool_lit_or_is_defined(&self) -> bool {
+        match self {
+            Self::BoolLit(_) | Self::IsDefined(_) | Self::IsNotDefined(_) => true,
+            Self::Unary(_, expr) | Self::Group(expr) => expr.contains_bool_lit_or_is_defined(),
+            Self::BinOp("&&" | "||", left, right) => {
+                left.contains_bool_lit_or_is_defined() || right.contains_bool_lit_or_is_defined()
+            }
+            Self::NumLit(_)
+            | Self::StrLit(_)
+            | Self::CharLit(_)
+            | Self::Var(_)
+            | Self::FilterSource
+            | Self::RustMacro(_, _)
+            | Self::As(_, _)
+            | Self::Call(_, _)
+            | Self::Range(_, _, _)
+            | Self::Try(_)
+            | Self::NamedArgument(_, _)
+            | Self::Filter(_)
+            | Self::Attr(_, _)
+            | Self::Index(_, _)
+            | Self::Tuple(_)
+            | Self::Array(_)
+            | Self::BinOp(_, _, _)
+            | Self::Path(_) => false,
+        }
+    }
 }
 
 fn token_xor(i: &str) -> ParseResult<'_> {

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -146,6 +146,11 @@ impl<'a, T> WithSpan<'a, T> {
     pub fn span(&self) -> &'a str {
         self.span
     }
+
+    pub fn deconstruct(self) -> (T, &'a str) {
+        let Self { inner, span } = self;
+        (inner, span)
+    }
 }
 
 impl<'a, T> Deref for WithSpan<'a, T> {

--- a/rinja_parser/src/memchr_splitter.rs
+++ b/rinja_parser/src/memchr_splitter.rs
@@ -7,7 +7,7 @@ pub(crate) trait Splitter: Copy {
     fn split<'a>(&self, haystack: &'a str) -> Option<(&'a str, &'a str)>;
 }
 
-impl<T: Splitter + ?Sized> Splitter for &T {
+impl<T: Splitter> Splitter for &T {
     #[inline]
     fn split<'a>(&self, haystack: &'a str) -> Option<(&'a str, &'a str)> {
         T::split(self, haystack)

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -272,6 +272,7 @@ impl<'a> Cond<'a> {
 pub struct CondTest<'a> {
     pub target: Option<Target<'a>>,
     pub expr: WithSpan<'a, Expr<'a>>,
+    pub contains_bool_lit_or_is_defined: bool,
 }
 
 impl<'a> CondTest<'a> {
@@ -288,7 +289,15 @@ impl<'a> CondTest<'a> {
             )),
             ws(|i| Expr::parse(i, s.level.get())),
         )(i)?;
-        Ok((i, Self { target, expr }))
+        let contains_bool_lit_or_is_defined = expr.contains_bool_lit_or_is_defined();
+        Ok((
+            i,
+            Self {
+                target,
+                expr,
+                contains_bool_lit_or_is_defined,
+            },
+        ))
     }
 }
 

--- a/testing/tests/is_defined.rs
+++ b/testing/tests/is_defined.rs
@@ -31,3 +31,16 @@ const v = 0;
 </script>"#
     );
 }
+
+#[derive(Template)]
+#[template(
+    source = r#"{% if x is defined && x == 12 %}bli{% else %}bla{% endif %}"#,
+    ext = "html"
+)]
+struct IsDefinedChaining;
+
+// This test ensures that if the variable is not defined, it will not generate following code.
+#[test]
+fn is_defined_chaining() {
+    assert_eq!(IsDefinedChaining.render().unwrap(), r#"bla"#);
+}


### PR DESCRIPTION
Fixes https://github.com/rinja-rs/rinja/issues/115.

It finally allows to write:

```jinja
{% if x is defined && x == 12 %}
```

without having compile-time errors because of the `x == 12` part. :)