### PR TITLE
derive: allow supplying source in comment

### DIFF
--- a/book/src/creating_templates.md
+++ b/book/src/creating_templates.md
@@ -114,7 +114,10 @@ recognized:
 As an alternative to supplying the code template code in an external file (as `path` argument),
 or as a string (as `source` argument), you can also enable the `"code-in-doc"` feature.
 With this feature, you can specify the template code directly in the documentation
-of the template `struct`. Simply add a ```` ```rinja ```` code block to your documentation:
+of the template `struct`.
+
+Instead of `path = "…"` or `source = "…"`, specify `in_doc = true` in the `#[template]` attribute,
+and in the struct's documentation add a ```` ```rinja ```` code block:
 
 ```rust
 /// Here you can put our usual comments.
@@ -134,7 +137,7 @@ of the template `struct`. Simply add a ```` ```rinja ```` code block to your doc
 ///
 /// All comments are still optional, though.
 #[derive(Template)]
-#[template(ext = "html")]
+#[template(ext = "html", in_doc = true)]
 struct Example<'a> {
     lines: &'a str,
 }
@@ -142,8 +145,6 @@ struct Example<'a> {
 
 If you want to supply the template code in the comments,
 then you have to specify the `ext` argument, too, e.g. `#[template(ext = "html")]`.
-If the `path` or `source` argument is given,
-then this argument takes precedence over the code in the comments.
 
-Instead of ```` ```rinja ````, you can also write ```` ```jinja ```` or ```` ```jinja2 ````,
-e.g. to get it to work better in conjunction with sytax highlighters.
+Instead of `rinja`, you can also write `jinja` or `jinja2`,
+e.g. to get it to work better in conjunction with syntax highlighters.

--- a/book/src/creating_templates.md
+++ b/book/src/creating_templates.md
@@ -124,10 +124,10 @@ recognized:
 As an alternative to supplying the code template code in an external file (as `path` argument),
 or as a string (as `source` argument), you can also enable the `"code-in-doc"` feature.
 With this feature, you can specify the template code directly in the documentation
-of the template `struct`.
+of the template item.
 
 Instead of `path = "…"` or `source = "…"`, specify `in_doc = true` in the `#[template]` attribute,
-and in the struct's documentation add a ```` ```rinja ```` code block:
+and in the item's documentation, add a code block with the `rinja` attribute:
 
 ```rust
 /// Here you can put our usual comments.

--- a/book/src/creating_templates.md
+++ b/book/src/creating_templates.md
@@ -55,6 +55,10 @@ recognized:
       name: &'a str,
   }
   ```
+
+* `in_doc` (as `in_doc = true`):
+  please see the section ["documentation as template code"](#documentation-as-template-code).
+
 * `ext` (as `ext = "txt"`): lets you specify the content type as a file
   extension. This is used to infer an escape mode (see below), and some
   web framework integrations use it to determine the content type.
@@ -66,6 +70,7 @@ recognized:
       name: &'a str,
   }
   ```
+
 * `print` (as `print = "code"`): enable debugging by printing nothing
   (`none`), the parsed syntax tree (`ast`), the generated code (`code`)
   or `all` for both. The requested data will be printed to stdout at
@@ -75,6 +80,7 @@ recognized:
   #[template(path = "hello.html", print = "all")]
   struct HelloTemplate<'a> { ... }
   ```
+
 * `block` (as `block = "block_name"`): renders the block by itself.
   Expressions outside of the block are not required by the struct, and
   inheritance is also supported. This can be useful when you need to
@@ -85,6 +91,7 @@ recognized:
   #[template(path = "hello.html", block = "hello")]
   struct HelloTemplate<'a> { ... }
   ```
+
 * `escape` (as `escape = "none"`): override the template's extension used for
   the purpose of determining the escaper for this template. See the section
   on configuring custom escapers for more information.
@@ -93,6 +100,7 @@ recognized:
   #[template(path = "hello.html", escape = "none")]
   struct HelloTemplate<'a> { ... }
   ```
+
 * `syntax` (as `syntax = "foo"`): set the syntax name for a parser defined
   in the configuration file. The default syntax , "default", is the one
   provided by Rinja.
@@ -101,6 +109,7 @@ recognized:
   #[template(path = "hello.html", syntax = "foo")]
   struct HelloTemplate<'a> { ... }
   ```
+
 * `config` (as `config = "config_file_path"`): set the path for the config file
   to be used. The path is interpreted as relative to your crate root.
   ```rust
@@ -110,6 +119,7 @@ recognized:
   ```
 
 ## Documentation as template code
+[#documentation-as-template-code]: #documentation-as-template-code
 
 As an alternative to supplying the code template code in an external file (as `path` argument),
 or as a string (as `source` argument), you can also enable the `"code-in-doc"` feature.

--- a/book/src/creating_templates.md
+++ b/book/src/creating_templates.md
@@ -108,3 +108,42 @@ recognized:
   #[template(path = "hello.html", config = "config.toml")]
   struct HelloTemplate<'a> { ... }
   ```
+
+## Documentation as template code
+
+As an alternative to supplying the code template code in an external file (as `path` argument),
+or as a string (as `source` argument), you can also enable the `"code-in-doc"` feature.
+With this feature, you can specify the template code directly in the documentation
+of the template `struct`. Simply add a ```` ```rinja ```` code block to your documentation:
+
+```rust
+/// Here you can put our usual comments.
+///
+/// ```rinja
+/// <div>{{ lines|linebreaksbr }}</div>
+/// ```
+///
+/// Any usual docs, including tests can be put in here, too:
+///
+/// ```rust
+/// assert_eq!(
+///     Example { lines: "a\nb\nc" }.to_string(),
+///     "<div>a<br/>b<br/>c</div>"
+/// );
+/// ```
+///
+/// All comments are still optional, though.
+#[derive(Template)]
+#[template(ext = "html")]
+struct Example<'a> {
+    lines: &'a str,
+}
+```
+
+If you want to supply the template code in the comments,
+then you have to specify the `ext` argument, too, e.g. `#[template(ext = "html")]`.
+If the `path` or `source` argument is given,
+then this argument takes precedence over the code in the comments.
+
+Instead of ```` ```rinja ````, you can also write ```` ```jinja ```` or ```` ```jinja2 ````,
+e.g. to get it to work better in conjunction with sytax highlighters.

--- a/rinja/Cargo.toml
+++ b/rinja/Cargo.toml
@@ -22,6 +22,7 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["config", "humansize", "num-traits", "urlencode"]
+code-in-doc = ["rinja_derive/code-in-doc"]
 config = ["rinja_derive/config"]
 humansize = ["rinja_derive/humansize", "dep:humansize"]
 num-traits = ["rinja_derive/num-traits", "dep:num-traits"]

--- a/rinja/Cargo.toml
+++ b/rinja/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja"
-version = "0.3.1"
+version = "0.3.0"
 description = "Type-safe, compiled Jinja-like templates for Rust"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -37,7 +37,7 @@ with-rocket = ["rinja_derive/with-rocket"]
 with-warp = ["rinja_derive/with-warp"]
 
 [dependencies]
-rinja_derive = { version = "=0.3.1", path = "../rinja_derive" }
+rinja_derive = { version = "=0.3.0", path = "../rinja_derive" }
 
 humansize = { version = "2", optional = true }
 num-traits = { version = "0.2.6", optional = true }

--- a/rinja/Cargo.toml
+++ b/rinja/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja"
-version = "0.3.0"
+version = "0.3.1"
 description = "Type-safe, compiled Jinja-like templates for Rust"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -37,7 +37,7 @@ with-rocket = ["rinja_derive/with-rocket"]
 with-warp = ["rinja_derive/with-warp"]
 
 [dependencies]
-rinja_derive = { version = "=0.3.0", path = "../rinja_derive" }
+rinja_derive = { version = "=0.3.1", path = "../rinja_derive" }
 
 humansize = { version = "2", optional = true }
 num-traits = { version = "0.2.6", optional = true }

--- a/rinja/src/filters/builtin.rs
+++ b/rinja/src/filters/builtin.rs
@@ -189,7 +189,7 @@ pub fn linebreaks(s: impl fmt::Display) -> Result<HtmlSafeOutput<String>, fmt::E
 /// /// <div>{{ lines|linebreaksbr }}</div>
 /// /// ```
 /// #[derive(Template)]
-/// #[template(ext = "html")]
+/// #[template(ext = "html", in_doc = true)]
 /// struct Example<'a> {
 ///     lines: &'a str,
 /// }

--- a/rinja/src/filters/builtin.rs
+++ b/rinja/src/filters/builtin.rs
@@ -147,7 +147,7 @@ impl<W: fmt::Write> fmt::Write for UrlencodeWriter<W> {
 /// composition.
 ///
 /// ```ignore
-/// {{ value | fmt("{:?}") }}
+/// {{ value|fmt("{:?}") }}
 /// ```
 ///
 /// Compare with [format](./fn.format.html).
@@ -161,7 +161,7 @@ pub fn fmt() {}
 /// the Rinja code generator.
 ///
 /// ```ignore
-/// {{ "{:?}{:?}" | format(value, other_value) }}
+/// {{ "{:?}{:?}"|format(value, other_value) }}
 /// ```
 ///
 /// Compare with [fmt](./fn.fmt.html).
@@ -181,6 +181,25 @@ pub fn linebreaks(s: impl fmt::Display) -> Result<HtmlSafeOutput<String>, fmt::E
 }
 
 /// Converts all newlines in a piece of plain text to HTML line breaks
+///
+/// ```rust
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ lines|linebreaksbr }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html")]
+/// struct Example<'a> {
+///     lines: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { lines: "a\nb\nc" }.to_string(),
+///     "<div>a<br/>b<br/>c</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn linebreaksbr(s: impl fmt::Display) -> Result<HtmlSafeOutput<String>, fmt::Error> {
     fn linebreaksbr(s: String) -> String {

--- a/rinja_actix/Cargo.toml
+++ b/rinja_actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_actix"
-version = "0.3.0"
+version = "0.3.1"
 description = "Actix-Web integration for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
 [dependencies]
-rinja = { version = "0.3.0", path = "../rinja", default-features = false, features = ["with-actix-web"] }
+rinja = { version = "0.3.1", path = "../rinja", default-features = false, features = ["with-actix-web"] }
 
 actix-web = { version = "4", default-features = false }
 

--- a/rinja_actix/Cargo.toml
+++ b/rinja_actix/Cargo.toml
@@ -28,6 +28,7 @@ bytes = { version = "1" }
 
 [features]
 default = ["rinja/default"]
+code-in-doc = ["rinja/code-in-doc"]
 config = ["rinja/config"]
 humansize = ["rinja/humansize"]
 num-traits = ["rinja/num-traits"]

--- a/rinja_actix/Cargo.toml
+++ b/rinja_actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_actix"
-version = "0.3.1"
+version = "0.3.0"
 description = "Actix-Web integration for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
 [dependencies]
-rinja = { version = "0.3.1", path = "../rinja", default-features = false, features = ["with-actix-web"] }
+rinja = { version = "0.3.0", path = "../rinja", default-features = false, features = ["with-actix-web"] }
 
 actix-web = { version = "4", default-features = false }
 

--- a/rinja_axum/Cargo.toml
+++ b/rinja_axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_axum"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.71"
 description = "Axum integration for Rinja templates"
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
 [dependencies]
-rinja = { version = "0.3.0", path = "../rinja", default-features = false, features = ["with-axum"] }
+rinja = { version = "0.3.1", path = "../rinja", default-features = false, features = ["with-axum"] }
 
 axum-core = "0.4"
 http = "1.0"

--- a/rinja_axum/Cargo.toml
+++ b/rinja_axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_axum"
-version = "0.3.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.71"
 description = "Axum integration for Rinja templates"
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
 [dependencies]
-rinja = { version = "0.3.1", path = "../rinja", default-features = false, features = ["with-axum"] }
+rinja = { version = "0.3.0", path = "../rinja", default-features = false, features = ["with-axum"] }
 
 axum-core = "0.4"
 http = "1.0"

--- a/rinja_axum/Cargo.toml
+++ b/rinja_axum/Cargo.toml
@@ -30,6 +30,7 @@ tower = { version = "0.5", features = ["util"] }
 
 [features]
 default = ["rinja/default"]
+code-in-doc = ["rinja/code-in-doc"]
 config = ["rinja/config"]
 humansize = ["rinja/humansize"]
 num-traits = ["rinja/num-traits"]

--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_derive"
-version = "0.3.1"
+version = "0.3.0"
 description = "Procedural macro package for Rinja"
 homepage = "https://github.com/rinja-rs/rinja"
 repository = "https://github.com/rinja-rs/rinja"
@@ -30,7 +30,7 @@ with-rocket = []
 with-warp = []
 
 [dependencies]
-parser = { package = "rinja_parser", version = "=0.3.1", path = "../rinja_parser" }
+parser = { package = "rinja_parser", version = "=0.3.0", path = "../rinja_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
 pulldown-cmark = { version = "0.12.0", optional = true, default-features = false }

--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -33,7 +33,7 @@ with-warp = []
 parser = { package = "rinja_parser", version = "=0.3.0", path = "../rinja_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
-pulldown-cmark = { version = "0.11.1", optional = true, default-features = false }
+pulldown-cmark = { version = "0.12.0", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 memchr = "2"

--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_derive"
-version = "0.3.0"
+version = "0.3.1"
 description = "Procedural macro package for Rinja"
 homepage = "https://github.com/rinja-rs/rinja"
 repository = "https://github.com/rinja-rs/rinja"
@@ -30,7 +30,7 @@ with-rocket = []
 with-warp = []
 
 [dependencies]
-parser = { package = "rinja_parser", version = "=0.3.0", path = "../rinja_parser" }
+parser = { package = "rinja_parser", version = "=0.3.1", path = "../rinja_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
 pulldown-cmark = { version = "0.12.0", optional = true, default-features = false }

--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -39,6 +39,7 @@ mime = "0.3"
 mime_guess = "2"
 once_map = { version = "0.4.18", default-features = false, features = ["std"] }
 proc-macro2 = "1"
+pulldown-cmark = { version = "0.11.0", default-features = false }
 quote = "1"
 rustc-hash = "2.0.0"
 syn = "2.0.3"

--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -18,6 +18,7 @@ rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 proc-macro = true
 
 [features]
+code-in-doc = ["dep:pulldown-cmark"]
 config = ["dep:serde", "dep:basic-toml", "parser/config"]
 humansize = []
 urlencode = []
@@ -32,6 +33,7 @@ with-warp = []
 parser = { package = "rinja_parser", version = "=0.3.0", path = "../rinja_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
+pulldown-cmark = { version = "0.11.0", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 memchr = "2"
@@ -39,7 +41,6 @@ mime = "0.3"
 mime_guess = "2"
 once_map = { version = "0.4.18", default-features = false, features = ["std"] }
 proc-macro2 = "1"
-pulldown-cmark = { version = "0.11.0", default-features = false }
 quote = "1"
 rustc-hash = "2.0.0"
 syn = "2.0.3"

--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -33,7 +33,7 @@ with-warp = []
 parser = { package = "rinja_parser", version = "=0.3.0", path = "../rinja_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
-pulldown-cmark = { version = "0.11.0", optional = true, default-features = false }
+pulldown-cmark = { version = "0.11.1", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 memchr = "2"

--- a/rinja_derive/src/input.rs
+++ b/rinja_derive/src/input.rs
@@ -406,6 +406,10 @@ impl TemplateArgs {
             }
         }
 
+        if args.source.is_none() {
+            args.source = source_from_docs(ast)?;
+        }
+
         Ok(args)
     }
 
@@ -420,6 +424,142 @@ impl TemplateArgs {
     pub(crate) fn config_path(&self) -> Option<&str> {
         self.config.as_deref()
     }
+}
+
+/// Try to find the souce in the comment, in a "```rinja```" block
+///
+/// This is only done if no path or source was given in the `#[template]` attribute.
+fn source_from_docs(
+    ast: &syn::DeriveInput,
+) -> Result<Option<(Source, Option<Span>)>, CompileError> {
+    #[derive(PartialEq, Eq)]
+    enum State {
+        Any,
+        /// number of backticks
+        OtherCode(usize),
+        /// number of backticks, previous whitespace prefix
+        RinjaCode(usize, String),
+    }
+
+    let mut span: Option<Span> = None;
+    let mut assign_span = |kv: &syn::MetaNameValue| {
+        // FIXME: uncomment once <https://github.com/rust-lang/rust/issues/54725> is stable
+        // let new_span = kv.path.span();
+        // span = Some(match span {
+        //     Some(cur_span) => cur_span.join(new_span).unwrap_or(cur_span),
+        //     None => new_span,
+        // });
+
+        if span.is_none() {
+            span = Some(kv.path.span());
+        }
+    };
+
+    let mut source = String::new();
+    let mut state = State::Any;
+    for a in &ast.attrs {
+        // is a comment?
+        let syn::Meta::NameValue(kv) = &a.meta else {
+            continue;
+        };
+        if !kv.path.is_ident("doc") {
+            continue;
+        }
+
+        // is an understood comment, e.g. not `#[doc = inline_str(…)]`
+        let mut value = &kv.value;
+        let value = loop {
+            match value {
+                syn::Expr::Lit(lit) => break lit,
+                syn::Expr::Group(group) => value = &group.expr,
+                _ => continue,
+            }
+        };
+        let syn::Lit::Str(value) = &value.lit else {
+            continue;
+        };
+
+        // an empty string has no lines, but we must print a newline
+        let value = value.value();
+        if value.is_empty() {
+            if matches!(state, State::RinjaCode { .. }) {
+                source.push('\n');
+            }
+            continue;
+        }
+
+        // iterate over the lines of the input
+        for line in value.lines() {
+            // doc lines start with an extra space
+            let strip_pos = line
+                .find(|c: char| !c.is_ascii_whitespace())
+                .unwrap_or_default();
+            let (prefix, stripped_line) = line.split_at(strip_pos);
+
+            // count number of leading backticks, if there are at least 3
+            let (backtick_count, backtick_syntax) = match stripped_line
+                .find(|c: char| c != '`')
+                .unwrap_or(stripped_line.len())
+            {
+                0..=2 => (0, ""),
+                i => (i, &stripped_line[i..]),
+            };
+
+            match state {
+                State::Any => {
+                    if backtick_count > 0 {
+                        // at the start of a ```block```
+                        if !backtick_syntax
+                            .split(",")
+                            .any(|s| JINJA_EXTENSIONS.contains(&s.trim()))
+                        {
+                            state = State::OtherCode(backtick_count);
+                        } else {
+                            assign_span(kv);
+                            state = State::RinjaCode(backtick_count, prefix.to_owned());
+                            // combined rinja blocks are separated by a newline
+                            if !source.is_empty() {
+                                source.push('\n');
+                            }
+                        }
+                    }
+                }
+                State::OtherCode(expected_count) => {
+                    if backtick_count == expected_count && backtick_syntax.is_empty() {
+                        // end the block
+                        state = State::Any;
+                    }
+                }
+                State::RinjaCode(expected_count, ref prefix) => {
+                    if backtick_count == expected_count && backtick_syntax.is_empty() {
+                        // end the block
+                        state = State::Any;
+                        // the "```" is on a new line
+                        if source.ends_with('\n') {
+                            source.pop();
+                        }
+                    } else {
+                        assign_span(kv);
+                        source.push_str(line.strip_prefix(prefix).unwrap_or(line));
+                        source.push('\n');
+                    }
+                }
+            }
+        }
+    }
+    if source.is_empty() {
+        return Ok(None);
+    }
+    if matches!(state, State::RinjaCode(..)) {
+        // we don't care about other unclosed blocks
+        return Err(CompileError::new_with_span(
+            r#"unterminated "```rinja" block"#,
+            None,
+            span,
+        ));
+    }
+
+    Ok(Some((Source::Source(source.into()), span)))
 }
 
 struct ResultIter<I, E>(Result<I, Option<E>>);
@@ -495,8 +635,6 @@ fn ext_default_to_path<'a>(ext: Option<&'a str>, path: &'a Path) -> Option<&'a s
 }
 
 fn extension(path: &Path) -> Option<&str> {
-    const JINJA_EXTENSIONS: &[&str] = &["j2", "jinja", "jinja2", "rinja"];
-
     let ext = path.extension()?.to_str()?;
     if JINJA_EXTENSIONS.contains(&ext) {
         // an extension was found: file stem cannot be absent
@@ -599,6 +737,8 @@ pub(crate) fn get_template_source(
         |_, _, cached| Arc::clone(cached),
     )
 }
+
+const JINJA_EXTENSIONS: &[&str] = &["j2", "jinja", "jinja2", "rinja"];
 
 #[cfg(test)]
 mod tests {

--- a/rinja_derive/src/input.rs
+++ b/rinja_derive/src/input.rs
@@ -57,9 +57,9 @@ impl TemplateInput<'_> {
         let &(ref source, source_span) = source.as_ref().ok_or_else(|| {
             CompileError::new(
                 #[cfg(not(feature = "code-in-doc"))]
-                "specify one template argument `path` OR `source`",
+                "specify one template argument `path` or `source`",
                 #[cfg(feature = "code-in-doc")]
-                "specify one template argument `path` OR `source` OR `in_doc`",
+                "specify one template argument `path`, `source` or `in_doc`",
                 None,
             )
         })?;
@@ -433,7 +433,7 @@ impl TemplateArgs {
     }
 }
 
-/// Try to find the souce in the comment, in a "```rinja```" block
+/// Try to find the souce in the comment, in a `rinja` code block.
 ///
 /// This is only done if no path or source was given in the `#[template]` attribute.
 fn source_from_docs(
@@ -655,9 +655,9 @@ fn ensure_source_once(
     } else {
         Err(CompileError::no_file_info(
             #[cfg(feature = "code-in-doc")]
-            "must specify `source` OR `path` OR `is_doc` exactly once",
+            "must specify `source`, `path` or `is_doc` exactly once",
             #[cfg(not(feature = "code-in-doc"))]
-            "must specify `source` OR `path` exactly once",
+            "must specify `source` or `path` exactly once",
             Some(name.span()),
         ))
     }

--- a/rinja_derive/src/input.rs
+++ b/rinja_derive/src/input.rs
@@ -9,7 +9,6 @@ use mime::Mime;
 use once_map::OnceMap;
 use parser::{Node, Parsed};
 use proc_macro2::Span;
-use pulldown_cmark::{CodeBlockKind, Event, Parser, Tag, TagEnd};
 use rustc_hash::FxBuildHasher;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
@@ -407,6 +406,7 @@ impl TemplateArgs {
             }
         }
 
+        #[cfg(feature = "code-in-doc")]
         if args.source.is_none() {
             args.source = source_from_docs(ast);
         }
@@ -427,6 +427,7 @@ impl TemplateArgs {
     }
 }
 
+#[cfg(feature = "code-in-doc")]
 /// Try to find the souce in the comment, in a "```rinja```" block
 ///
 /// This is only done if no path or source was given in the `#[template]` attribute.
@@ -437,6 +438,7 @@ fn source_from_docs(ast: &syn::DeriveInput) -> Option<(Source, Option<Span>)> {
     Some((source, span))
 }
 
+#[cfg(feature = "code-in-doc")]
 fn collect_comment_blocks(ast: &syn::DeriveInput) -> Option<(Option<Span>, String)> {
     let mut span: Option<Span> = None;
     let mut assign_span = |kv: &syn::MetaNameValue| {
@@ -486,6 +488,7 @@ fn collect_comment_blocks(ast: &syn::DeriveInput) -> Option<(Option<Span>, Strin
     Some((span, source))
 }
 
+#[cfg(feature = "code-in-doc")]
 fn strip_common_ws_prefix(source: String) -> Option<String> {
     let mut common_prefix_iter = source
         .lines()
@@ -515,7 +518,10 @@ fn strip_common_ws_prefix(source: String) -> Option<String> {
     )
 }
 
+#[cfg(feature = "code-in-doc")]
 fn collect_rinja_code_blocks(source: String) -> Option<Source> {
+    use pulldown_cmark::{CodeBlockKind, Event, Parser, Tag, TagEnd};
+
     let mut tmpl_source = String::new();
     let mut in_rinja_code = false;
     let mut had_rinja_code = false;

--- a/rinja_derive/src/lib.rs
+++ b/rinja_derive/src/lib.rs
@@ -64,6 +64,29 @@ use syn::parse_quote_spanned;
 /// web framework integrations use it to determine the content type.
 /// Cannot be used together with `path`.
 ///
+/// ### in_doc
+///
+/// E.g. `in_doc = true`
+///
+/// As an alternative to supplying the code template code in an external file (as `path` argument),
+/// or as a string (as `source` argument), you can also enable the `"code-in-doc"` feature.
+/// With this feature, you can specify the template code directly in the documentation
+/// of the template `struct`.
+///
+/// Instead of `path = "…"` or `source = "…"`, specify `in_doc = true` in the `#[template]`
+/// attribute, and in the struct's documentation add a ```` ```rinja ```` code block:
+///
+/// ```rust,ignore
+/// /// ```rinja
+/// /// <div>{{ lines|linebreaksbr }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     lines: &'a str,
+/// }
+/// ```
+///
 /// ### print
 ///
 /// E.g. `print = "code"`

--- a/rinja_derive/src/lib.rs
+++ b/rinja_derive/src/lib.rs
@@ -74,7 +74,7 @@ use syn::parse_quote_spanned;
 /// of the template `struct`.
 ///
 /// Instead of `path = "…"` or `source = "…"`, specify `in_doc = true` in the `#[template]`
-/// attribute, and in the struct's documentation add a ```` ```rinja ```` code block:
+/// attribute, and in the struct's documentation add a `rinja` code block:
 ///
 /// ```rust,ignore
 /// /// ```rinja

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -613,7 +613,6 @@ fn test_code_in_comment() {
     "#;
     let ast = syn::parse_str(ts).unwrap();
     let generated = build_template(&ast).unwrap();
-    eprintln!("{}", &generated);
     assert!(generated.contains("Hello\nworld!"));
     assert!(!generated.contains("compile_error"));
 
@@ -655,5 +654,34 @@ fn test_code_in_comment() {
     let ast = syn::parse_str(ts).unwrap();
     let generated = build_template(&ast).unwrap();
     assert!(generated.contains("Hello\nworld!"));
+    assert!(!generated.contains("compile_error"));
+
+    let ts = "
+        #[template(ext = \"txt\")]
+        /// `````
+        /// ```rinja
+        /// {{bla}}
+        /// ```
+        /// `````
+        struct BlockOnBlock;
+    ";
+    let ast = syn::parse_str(ts).unwrap();
+    let err = build_template(&ast).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "template `path` or `source` not found in attributes"
+    );
+
+    let ts = "
+        #[template(ext = \"txt\")]
+        /// ```rinja
+        /// `````
+        /// {{bla}}
+        /// `````
+        /// ```
+        struct BlockOnBlock;
+    ";
+    let ast = syn::parse_str(ts).unwrap();
+    let generated = build_template(&ast).unwrap();
     assert!(!generated.contains("compile_error"));
 }

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -593,7 +593,7 @@ A
 #[test]
 fn test_code_in_comment() {
     let ts = r#"
-        #[template(ext = "txt")]
+        #[template(ext = "txt", in_doc = true)]
         /// ```rinja
         /// Hello world!
         /// ```
@@ -605,7 +605,7 @@ fn test_code_in_comment() {
     assert!(!generated.contains("compile_error"));
 
     let ts = r#"
-        #[template(ext = "txt")]
+        #[template(ext = "txt", in_doc = true)]
         /// ```rinja
         /// Hello
         /// world!
@@ -620,7 +620,7 @@ fn test_code_in_comment() {
     let ts = r#"
         /// ```rinja
         /// Hello
-        #[template(ext = "txt")]
+        #[template(ext = "txt", in_doc = true)]
         /// world!
         /// ```
         struct Tmpl;
@@ -635,7 +635,7 @@ fn test_code_in_comment() {
         ///
         /// ```rinja
         /// Hello
-        #[template(ext = "txt")]
+        #[template(ext = "txt", in_doc = true)]
         /// world!
         /// ```
         ///
@@ -648,7 +648,7 @@ fn test_code_in_comment() {
     assert!(!generated.contains("compile_error"));
 
     let ts = "
-        #[template(ext = \"txt\")]
+        #[template(ext = \"txt\", in_doc = true)]
         #[doc = \"```rinja\nHello\nworld!\n```\"]
         struct Tmpl;
     ";
@@ -658,7 +658,7 @@ fn test_code_in_comment() {
     assert!(!generated.contains("compile_error"));
 
     let ts = "
-        #[template(ext = \"txt\")]
+        #[template(ext = \"txt\", in_doc = true)]
         /// `````
         /// ```rinja
         /// {{bla}}
@@ -670,11 +670,11 @@ fn test_code_in_comment() {
     let err = build_template(&ast).unwrap_err();
     assert_eq!(
         err.to_string(),
-        "template `path` or `source` not found in attributes"
+        "when using `in_doc = true`, the struct's documentation needs a `rinja` code block"
     );
 
     let ts = "
-        #[template(ext = \"txt\")]
+        #[template(ext = \"txt\", in_doc = true)]
         /// ```rinja
         /// `````
         /// {{bla}}

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -589,6 +589,7 @@ A
     );
 }
 
+#[cfg(feature = "code-in-doc")]
 #[test]
 fn test_code_in_comment() {
     let ts = r#"

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -588,3 +588,72 @@ A
         15,
     );
 }
+
+#[test]
+fn test_code_in_comment() {
+    let ts = r#"
+        #[template(ext = "txt")]
+        /// ```rinja
+        /// Hello world!
+        /// ```
+        struct Tmpl;
+    "#;
+    let ast = syn::parse_str(ts).unwrap();
+    let generated = build_template(&ast).unwrap();
+    assert!(generated.contains("Hello world!"));
+    assert!(!generated.contains("compile_error"));
+
+    let ts = r#"
+        #[template(ext = "txt")]
+        /// ```rinja
+        /// Hello
+        /// world!
+        /// ```
+        struct Tmpl;
+    "#;
+    let ast = syn::parse_str(ts).unwrap();
+    let generated = build_template(&ast).unwrap();
+    eprintln!("{}", &generated);
+    assert!(generated.contains("Hello\nworld!"));
+    assert!(!generated.contains("compile_error"));
+
+    let ts = r#"
+        /// ```rinja
+        /// Hello
+        #[template(ext = "txt")]
+        /// world!
+        /// ```
+        struct Tmpl;
+    "#;
+    let ast = syn::parse_str(ts).unwrap();
+    let generated = build_template(&ast).unwrap();
+    assert!(generated.contains("Hello\nworld!"));
+    assert!(!generated.contains("compile_error"));
+
+    let ts = r#"
+        /// This template greets the whole world
+        ///
+        /// ```rinja
+        /// Hello
+        #[template(ext = "txt")]
+        /// world!
+        /// ```
+        ///
+        /// Some more text.
+        struct Tmpl;
+    "#;
+    let ast = syn::parse_str(ts).unwrap();
+    let generated = build_template(&ast).unwrap();
+    assert!(generated.contains("Hello\nworld!"));
+    assert!(!generated.contains("compile_error"));
+
+    let ts = "
+        #[template(ext = \"txt\")]
+        #[doc = \"```rinja\nHello\nworld!\n```\"]
+        struct Tmpl;
+    ";
+    let ast = syn::parse_str(ts).unwrap();
+    let generated = build_template(&ast).unwrap();
+    assert!(generated.contains("Hello\nworld!"));
+    assert!(!generated.contains("compile_error"));
+}

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_derive_standalone"
-version = "0.3.1"
+version = "0.3.0"
 description = "Procedural macro package for Rinja"
 homepage = "https://github.com/rinja-rs/rinja"
 repository = "https://github.com/rinja-rs/rinja"
@@ -30,7 +30,7 @@ with-rocket = []
 with-warp = []
 
 [dependencies]
-parser = { package = "rinja_parser", version = "=0.3.1", path = "../rinja_parser" }
+parser = { package = "rinja_parser", version = "=0.3.0", path = "../rinja_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
 pulldown-cmark = { version = "0.12.0", optional = true, default-features = false }

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_derive_standalone"
-version = "0.3.0"
+version = "0.3.1"
 description = "Procedural macro package for Rinja"
 homepage = "https://github.com/rinja-rs/rinja"
 repository = "https://github.com/rinja-rs/rinja"
@@ -30,7 +30,7 @@ with-rocket = []
 with-warp = []
 
 [dependencies]
-parser = { package = "rinja_parser", version = "=0.3.0", path = "../rinja_parser" }
+parser = { package = "rinja_parser", version = "=0.3.1", path = "../rinja_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
 pulldown-cmark = { version = "0.12.0", optional = true, default-features = false }

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -17,6 +17,8 @@ rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 [features]
 default = ["__standalone"]
 __standalone = []
+
+code-in-doc = ["dep:pulldown-cmark"]
 config = ["dep:serde", "dep:basic-toml", "parser/config"]
 humansize = []
 urlencode = []
@@ -31,6 +33,7 @@ with-warp = []
 parser = { package = "rinja_parser", version = "=0.3.0", path = "../rinja_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
+pulldown-cmark = { version = "0.11.0", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 memchr = "2"
@@ -38,7 +41,6 @@ mime = "0.3"
 mime_guess = "2"
 once_map = { version = "0.4.18", default-features = false, features = ["std"] }
 proc-macro2 = "1"
-pulldown-cmark = { version = "0.11.0", default-features = false }
 quote = "1"
 rustc-hash = "2.0.0"
 syn = "2.0.3"

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -38,6 +38,7 @@ mime = "0.3"
 mime_guess = "2"
 once_map = { version = "0.4.18", default-features = false, features = ["std"] }
 proc-macro2 = "1"
+pulldown-cmark = { version = "0.11.0", default-features = false }
 quote = "1"
 rustc-hash = "2.0.0"
 syn = "2.0.3"

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -33,7 +33,7 @@ with-warp = []
 parser = { package = "rinja_parser", version = "=0.3.0", path = "../rinja_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
-pulldown-cmark = { version = "0.11.1", optional = true, default-features = false }
+pulldown-cmark = { version = "0.12.0", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 memchr = "2"

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -33,7 +33,7 @@ with-warp = []
 parser = { package = "rinja_parser", version = "=0.3.0", path = "../rinja_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
-pulldown-cmark = { version = "0.11.0", optional = true, default-features = false }
+pulldown-cmark = { version = "0.11.1", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 memchr = "2"

--- a/rinja_parser/Cargo.toml
+++ b/rinja_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_parser"
-version = "0.3.0"
+version = "0.3.1"
 description = "Parser for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]

--- a/rinja_parser/Cargo.toml
+++ b/rinja_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_parser"
-version = "0.3.1"
+version = "0.3.0"
 description = "Parser for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]

--- a/rinja_rocket/Cargo.toml
+++ b/rinja_rocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_rocket"
-version = "0.3.1"
+version = "0.3.0"
 description = "Rocket integration for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
 [dependencies]
-rinja = { version = "0.3.1", path = "../rinja", default-features = false, features = ["with-rocket"] }
+rinja = { version = "0.3.0", path = "../rinja", default-features = false, features = ["with-rocket"] }
 
 rocket = { version = "0.5", default-features = false }
 

--- a/rinja_rocket/Cargo.toml
+++ b/rinja_rocket/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1.0", features = ["macros", "rt"] }
 
 [features]
 default = ["rinja/default"]
+code-in-doc = ["rinja/code-in-doc"]
 config = ["rinja/config"]
 humansize = ["rinja/humansize"]
 num-traits = ["rinja/num-traits"]

--- a/rinja_rocket/Cargo.toml
+++ b/rinja_rocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_rocket"
-version = "0.3.0"
+version = "0.3.1"
 description = "Rocket integration for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
 [dependencies]
-rinja = { version = "0.3.0", path = "../rinja", default-features = false, features = ["with-rocket"] }
+rinja = { version = "0.3.1", path = "../rinja", default-features = false, features = ["with-rocket"] }
 
 rocket = { version = "0.5", default-features = false }
 

--- a/rinja_warp/Cargo.toml
+++ b/rinja_warp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_warp"
-version = "0.3.1"
+version = "0.3.0"
 description = "Warp integration for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
 [dependencies]
-rinja = { version = "0.3.1", path = "../rinja", default-features = false, features = ["with-warp"] }
+rinja = { version = "0.3.0", path = "../rinja", default-features = false, features = ["with-warp"] }
 
 warp = { version = "0.3", default-features = false }
 

--- a/rinja_warp/Cargo.toml
+++ b/rinja_warp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_warp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Warp integration for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
 [dependencies]
-rinja = { version = "0.3.0", path = "../rinja", default-features = false, features = ["with-warp"] }
+rinja = { version = "0.3.1", path = "../rinja", default-features = false, features = ["with-warp"] }
 
 warp = { version = "0.3", default-features = false }
 

--- a/rinja_warp/Cargo.toml
+++ b/rinja_warp/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1.0", features = ["macros", "rt"] }
 
 [features]
 default = ["rinja/default"]
+code-in-doc = ["rinja/code-in-doc"]
 config = ["rinja/config"]
 humansize = ["rinja/humansize"]
 num-traits = ["rinja/num-traits"]

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_testing"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["rinja-rs developers"]
 workspace = ".."
 edition = "2021"
@@ -13,12 +13,12 @@ code-in-doc = ["rinja/code-in-doc"]
 serde_json = ["dep:serde_json", "rinja/serde_json"]
 
 [dependencies]
-rinja = { path = "../rinja", version = "0.3.0" }
+rinja = { path = "../rinja", version = "0.3.1" }
 
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-rinja = { path = "../rinja", version = "0.3.0", features = ["code-in-doc", "serde_json"] }
+rinja = { path = "../rinja", version = "0.3.1", features = ["code-in-doc", "serde_json"] }
 
 criterion = "0.5"
 phf = { version = "0.11", features = ["macros" ] }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -8,7 +8,8 @@ rust-version = "1.71"
 publish = false
 
 [features]
-default = ["serde_json"]
+default = ["code-in-doc", "serde_json"]
+code-in-doc = ["rinja/code-in-doc"]
 serde_json = ["dep:serde_json", "rinja/serde_json"]
 
 [dependencies]
@@ -17,7 +18,7 @@ rinja = { path = "../rinja", version = "0.3.0" }
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-rinja = { path = "../rinja", version = "0.3.0", features = ["serde_json"] }
+rinja = { path = "../rinja", version = "0.3.0", features = ["code-in-doc", "serde_json"] }
 
 criterion = "0.5"
 phf = { version = "0.11", features = ["macros" ] }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_testing"
-version = "0.3.1"
+version = "0.3.0"
 authors = ["rinja-rs developers"]
 workspace = ".."
 edition = "2021"
@@ -13,12 +13,12 @@ code-in-doc = ["rinja/code-in-doc"]
 serde_json = ["dep:serde_json", "rinja/serde_json"]
 
 [dependencies]
-rinja = { path = "../rinja", version = "0.3.1" }
+rinja = { path = "../rinja", version = "0.3.0" }
 
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-rinja = { path = "../rinja", version = "0.3.1", features = ["code-in-doc", "serde_json"] }
+rinja = { path = "../rinja", version = "0.3.0", features = ["code-in-doc", "serde_json"] }
 
 criterion = "0.5"
 phf = { version = "0.11", features = ["macros" ] }

--- a/testing/tests/filter_block.rs
+++ b/testing/tests/filter_block.rs
@@ -233,7 +233,7 @@ fn filter_block_include() {
     <body class=""><h1>Metadata</h1>
         
 
-    100</body>
+    105</body>
 </html>"#
     );
 }

--- a/testing/tests/source-in-code.rs
+++ b/testing/tests/source-in-code.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "code-in-doc")]
+
 // Regarding `#[rustfmt::skip]`: `cargo fmt` strips extraneous newlines in code block,
 // but we want to test if `rinja_derive` works with extraneous newlines.
 

--- a/testing/tests/source-in-code.rs
+++ b/testing/tests/source-in-code.rs
@@ -1,0 +1,282 @@
+// Regarding `#[rustfmt::skip]`: `cargo fmt` strips extraneous newlines in code block,
+// but we want to test if `rinja_derive` works with extraneous newlines.
+
+use rinja::Template;
+
+#[rustfmt::skip]
+#[test]
+fn test_code_in_comment_only() {
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// ```rinja
+    /// Hello world!
+    /// ```
+    struct Tmpl;
+
+    assert_eq!(Tmpl.to_string(), "Hello world!");
+}
+
+#[rustfmt::skip]
+#[test]
+fn test_code_in_comment_with_line_break() {
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// ```rinja
+    /// Hello
+    /// world!
+    /// ```
+    struct Tmpl1;
+    assert_eq!(Tmpl1.to_string(), "Hello\nworld!");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// ```rinja
+    /// Hello
+    ///
+    /// world!
+    /// ```
+    struct Tmpl2;
+    assert_eq!(Tmpl2.to_string(), "Hello\n\nworld!");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// ```rinja
+    /// 
+    /// Hello
+    ///
+    /// world!
+    /// ```
+    struct Tmpl3;
+    assert_eq!(Tmpl3.to_string(), "\nHello\n\nworld!");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// ```rinja
+    /// Hello
+    ///
+    /// world!
+    ///
+    /// ```
+    struct Tmpl4;
+    assert_eq!(Tmpl4.to_string(), "Hello\n\nworld!\n");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// ```rinja
+    /// 
+    ///
+    /// Hello
+    ///
+    ///
+    /// world!
+    ///
+    ///
+    /// ```
+    struct Tmpl5;
+    assert_eq!(Tmpl5.to_string(), "\n\nHello\n\n\nworld!\n\n");
+}
+
+#[rustfmt::skip]
+#[test]
+fn test_code_in_comment_with_derive_in_between() {
+    /// ```rinja
+    /// Hello
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// world!
+    /// ```
+    struct Tmpl1;
+    assert_eq!(Tmpl1.to_string(), "Hello\nworld!");
+
+    /// This template greets the whole world
+    ///
+    /// ```rinja
+    /// Hello
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// world!
+    /// ```
+    /// 
+    /// Some more text.
+    struct Tmpl2;
+    assert_eq!(Tmpl2.to_string(), "Hello\nworld!");
+}
+
+#[rustfmt::skip]
+#[test]
+fn test_code_in_comment_split_up() {
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// Text1
+    /// ```rinja
+    /// Hello
+    /// ```
+    /// Text2
+    /// ```rinja
+    /// world!
+    /// ```
+    /// Text3
+    struct Tmpl1;
+    assert_eq!(Tmpl1.to_string(), "Hello\nworld!");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// Text1
+    ///
+    /// ```rinja
+    /// Hello
+    /// ```
+    ///
+    /// Text2
+    ///
+    /// ```rinja
+    /// world!
+    /// ```
+    ///
+    /// Text3
+    struct Tmpl2;
+    assert_eq!(Tmpl2.to_string(), "Hello\nworld!");
+}
+
+#[rustfmt::skip]
+#[test]
+fn test_code_in_comment_doc() {
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    #[doc = "```rinja\nHello world!\n```"]
+    struct Tmpl1;
+    assert_eq!(Tmpl1.to_string(), "Hello world!");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    #[doc = "```rinja"]
+    #[doc = "Hello world!"]
+    #[doc = "```"]
+    struct Tmpl2;
+    assert_eq!(Tmpl2.to_string(), "Hello world!");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    #[doc = "```rinja\nHello world!"]
+    #[doc = "```"]
+    struct Tmpl3;
+    assert_eq!(Tmpl3.to_string(), "Hello world!");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    #[doc = "```rinja"]
+    #[doc = "Hello world!\n```"]
+    struct Tmpl4;
+    assert_eq!(Tmpl4.to_string(), "Hello world!");
+}
+
+#[rustfmt::skip]
+#[test]
+fn test_code_in_comment_multiline() {
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /**
+    ```rinja
+    Hello world!
+    ```
+    */
+    struct Tmpl1;
+    assert_eq!(Tmpl1.to_string(), "Hello world!");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /**
+    ```rinja
+    Hello
+    world!
+    ```
+    */
+    struct Tmpl2;
+    assert_eq!(Tmpl2.to_string(), "Hello\nworld!");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /**
+    ```rinja
+
+    Hello
+    world!
+    ```
+    */
+    struct Tmpl3;
+    assert_eq!(Tmpl3.to_string(), "\nHello\nworld!");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /**
+    ```rinja
+    Hello
+    world!
+
+    ```
+    */
+    struct Tmpl4;
+    assert_eq!(Tmpl4.to_string(), "Hello\nworld!\n");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /**
+    ```rinja
+
+    Hello
+
+    world!
+
+    ```
+    */
+    struct Tmpl5;
+    assert_eq!(Tmpl5.to_string(), "\nHello\n\nworld!\n");
+}
+
+#[rustfmt::skip]
+#[test]
+fn test_code_in_comment_backticks() {
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// ````rinja
+    /// Hello
+    /// ````
+    struct Tmpl1;
+    assert_eq!(Tmpl1.to_string(), "Hello");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// `````rinja
+    /// Hello
+    /// `````
+    struct Tmpl2;
+    assert_eq!(Tmpl2.to_string(), "Hello");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// ``````````````````````````````````````````````````````````````````````````````````````rinja
+    /// Hello
+    /// ``````````````````````````````````````````````````````````````````````````````````````
+    struct Tmpl3;
+    assert_eq!(Tmpl3.to_string(), "Hello");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// ```rinja
+    /// `````
+    /// Hello
+    /// `````
+    /// ```
+    struct Tmpl4;
+    assert_eq!(Tmpl4.to_string(), "`````\nHello\n`````");
+
+    #[derive(Template)]
+    #[template(ext = "txt")]
+    /// `````rinja
+    /// ```
+    /// Hello
+    /// ```
+    /// `````
+    struct Tmpl5;
+    assert_eq!(Tmpl5.to_string(), "```\nHello\n```");
+}

--- a/testing/tests/source-in-code.rs
+++ b/testing/tests/source-in-code.rs
@@ -9,7 +9,7 @@ use rinja::Template;
 #[test]
 fn test_code_in_comment_only() {
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// ```rinja
     /// Hello world!
     /// ```
@@ -22,7 +22,7 @@ fn test_code_in_comment_only() {
 #[test]
 fn test_code_in_comment_with_line_break() {
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// ```rinja
     /// Hello
     /// world!
@@ -31,7 +31,7 @@ fn test_code_in_comment_with_line_break() {
     assert_eq!(Tmpl1.to_string(), "Hello\nworld!");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// ```rinja
     /// Hello
     ///
@@ -41,7 +41,7 @@ fn test_code_in_comment_with_line_break() {
     assert_eq!(Tmpl2.to_string(), "Hello\n\nworld!");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// ```rinja
     /// 
     /// Hello
@@ -52,7 +52,7 @@ fn test_code_in_comment_with_line_break() {
     assert_eq!(Tmpl3.to_string(), "\nHello\n\nworld!");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// ```rinja
     /// Hello
     ///
@@ -63,7 +63,7 @@ fn test_code_in_comment_with_line_break() {
     assert_eq!(Tmpl4.to_string(), "Hello\n\nworld!\n");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// ```rinja
     /// 
     ///
@@ -84,7 +84,7 @@ fn test_code_in_comment_with_derive_in_between() {
     /// ```rinja
     /// Hello
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// world!
     /// ```
     struct Tmpl1;
@@ -95,7 +95,7 @@ fn test_code_in_comment_with_derive_in_between() {
     /// ```rinja
     /// Hello
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// world!
     /// ```
     /// 
@@ -108,7 +108,7 @@ fn test_code_in_comment_with_derive_in_between() {
 #[test]
 fn test_code_in_comment_split_up() {
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// Text1
     /// ```rinja
     /// Hello
@@ -122,7 +122,7 @@ fn test_code_in_comment_split_up() {
     assert_eq!(Tmpl1.to_string(), "Hello\nworld!");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// Text1
     ///
     /// ```rinja
@@ -144,13 +144,13 @@ fn test_code_in_comment_split_up() {
 #[test]
 fn test_code_in_comment_doc() {
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     #[doc = "```rinja\nHello world!\n```"]
     struct Tmpl1;
     assert_eq!(Tmpl1.to_string(), "Hello world!");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     #[doc = "```rinja"]
     #[doc = "Hello world!"]
     #[doc = "```"]
@@ -158,14 +158,14 @@ fn test_code_in_comment_doc() {
     assert_eq!(Tmpl2.to_string(), "Hello world!");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     #[doc = "```rinja\nHello world!"]
     #[doc = "```"]
     struct Tmpl3;
     assert_eq!(Tmpl3.to_string(), "Hello world!");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     #[doc = "```rinja"]
     #[doc = "Hello world!\n```"]
     struct Tmpl4;
@@ -176,7 +176,7 @@ fn test_code_in_comment_doc() {
 #[test]
 fn test_code_in_comment_multiline() {
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /**
     ```rinja
     Hello world!
@@ -186,7 +186,7 @@ fn test_code_in_comment_multiline() {
     assert_eq!(Tmpl1.to_string(), "Hello world!");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /**
     ```rinja
     Hello
@@ -197,7 +197,7 @@ fn test_code_in_comment_multiline() {
     assert_eq!(Tmpl2.to_string(), "Hello\nworld!");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /**
     ```rinja
 
@@ -209,7 +209,7 @@ fn test_code_in_comment_multiline() {
     assert_eq!(Tmpl3.to_string(), "\nHello\nworld!");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /**
     ```rinja
     Hello
@@ -221,7 +221,7 @@ fn test_code_in_comment_multiline() {
     assert_eq!(Tmpl4.to_string(), "Hello\nworld!\n");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /**
     ```rinja
 
@@ -239,7 +239,7 @@ fn test_code_in_comment_multiline() {
 #[test]
 fn test_code_in_comment_backticks() {
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// ````rinja
     /// Hello
     /// ````
@@ -247,7 +247,7 @@ fn test_code_in_comment_backticks() {
     assert_eq!(Tmpl1.to_string(), "Hello");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// `````rinja
     /// Hello
     /// `````
@@ -255,7 +255,7 @@ fn test_code_in_comment_backticks() {
     assert_eq!(Tmpl2.to_string(), "Hello");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// ``````````````````````````````````````````````````````````````````````````````````````rinja
     /// Hello
     /// ``````````````````````````````````````````````````````````````````````````````````````
@@ -263,7 +263,7 @@ fn test_code_in_comment_backticks() {
     assert_eq!(Tmpl3.to_string(), "Hello");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// ```rinja
     /// `````
     /// Hello
@@ -273,7 +273,7 @@ fn test_code_in_comment_backticks() {
     assert_eq!(Tmpl4.to_string(), "");
 
     #[derive(Template)]
-    #[template(ext = "txt")]
+    #[template(ext = "txt", in_doc = true)]
     /// `````rinja
     /// ```
     /// Hello

--- a/testing/tests/source-in-code.rs
+++ b/testing/tests/source-in-code.rs
@@ -268,7 +268,7 @@ fn test_code_in_comment_backticks() {
     /// `````
     /// ```
     struct Tmpl4;
-    assert_eq!(Tmpl4.to_string(), "`````\nHello\n`````");
+    assert_eq!(Tmpl4.to_string(), "");
 
     #[derive(Template)]
     #[template(ext = "txt")]

--- a/testing/tests/ui/duplicated_template_attribute.stderr
+++ b/testing/tests/ui/duplicated_template_attribute.stderr
@@ -1,4 +1,4 @@
-error: must specify `source` OR `path` OR `is_doc` exactly once
+error: must specify `source`, `path` or `is_doc` exactly once
  --> tests/ui/duplicated_template_attribute.rs:9:5
   |
 9 |     source = "🙃",

--- a/testing/tests/ui/duplicated_template_attribute.stderr
+++ b/testing/tests/ui/duplicated_template_attribute.stderr
@@ -1,4 +1,4 @@
-error: must specify `source` OR `path` exactly once
+error: must specify `source` OR `path` OR `is_doc` exactly once
  --> tests/ui/duplicated_template_attribute.rs:9:5
   |
 9 |     source = "🙃",

--- a/testing/tests/ui/rinja-block.rs
+++ b/testing/tests/ui/rinja-block.rs
@@ -1,7 +1,7 @@
 use rinja::Template;
 
 #[derive(Template)]
-#[template(ext = "txt")]
+#[template(ext = "txt", in_doc = true)]
 /// Some documentation
 ///
 /// ```html,rinja
@@ -12,12 +12,62 @@ use rinja::Template;
 struct SyntaxError;
 
 #[derive(Template)]
-#[template(ext = "txt")]
+#[template(ext = "txt", in_doc = true)]
 /// `````
 /// ```rinja
 /// {{bla}}
 /// ```
 /// `````
 struct BlockInBlock;
+
+#[derive(Template)]
+#[template(ext = "txt")]
+/// Some documentation
+///
+/// ```html,rinja
+/// Hello.
+/// ```
+struct InDocMissing;
+
+#[derive(Template)]
+#[template(ext = "txt", in_doc)]
+/// Some documentation
+///
+/// ```html,rinja
+/// Hello.
+/// ```
+struct InDocEmpty;
+
+#[derive(Template)]
+#[template(ext = "txt", in_doc = false)]
+/// Some documentation
+///
+/// ```html,rinja
+/// Hello.
+/// ```
+struct InDocWrong;
+
+#[derive(Template)]
+#[template(ext = "txt", in_doc = "yes")]
+/// Some documentation
+///
+/// ```html,rinja
+/// Hello.
+/// ```
+struct InDocWrongType;
+
+#[derive(Template)]
+#[template(ext = "txt", in_doc = true)]
+enum NoDocForEnum {
+    Yes,
+    No,
+}
+
+#[derive(Template)]
+#[template(ext = "txt", in_doc = true)]
+union NoDocForUnion {
+    u: u8,
+    i: i8,
+}
 
 fn main() {}

--- a/testing/tests/ui/rinja-block.rs
+++ b/testing/tests/ui/rinja-block.rs
@@ -5,18 +5,19 @@ use rinja::Template;
 /// Some documentation
 ///
 /// ```html,rinja
-/// <h1>No terminator</h1>
-struct Unterminated;
-
-#[derive(Template)]
-#[template(ext = "txt")]
-/// Some documentation
-///
-/// ```html,rinja
 /// {% if true %}
 ///     {% fail %}
 /// {% endif %}
 /// ```
 struct SyntaxError;
+
+#[derive(Template)]
+#[template(ext = "txt")]
+/// `````
+/// ```rinja
+/// {{bla}}
+/// ```
+/// `````
+struct BlockInBlock;
 
 fn main() {}

--- a/testing/tests/ui/rinja-block.rs
+++ b/testing/tests/ui/rinja-block.rs
@@ -1,0 +1,22 @@
+use rinja::Template;
+
+#[derive(Template)]
+#[template(ext = "txt")]
+/// Some documentation
+///
+/// ```html,rinja
+/// <h1>No terminator</h1>
+struct Unterminated;
+
+#[derive(Template)]
+#[template(ext = "txt")]
+/// Some documentation
+///
+/// ```html,rinja
+/// {% if true %}
+///     {% fail %}
+/// {% endif %}
+/// ```
+struct SyntaxError;
+
+fn main() {}

--- a/testing/tests/ui/rinja-block.stderr
+++ b/testing/tests/ui/rinja-block.stderr
@@ -6,8 +6,44 @@ error: failed to parse template source
 5 | /// Some documentation
   | ^^^^^^^^^^^^^^^^^^^^^^
 
-error: template `path` or `source` not found in attributes
-  --> tests/ui/rinja-block.rs:15:3
+error: when using `in_doc = true`, the struct's documentation needs a `rinja` code block
+  --> tests/ui/rinja-block.rs:15:25
    |
-15 | #[template(ext = "txt")]
+15 | #[template(ext = "txt", in_doc = true)]
+   |                         ^^^^^^
+
+error: specify one template argument `path` OR `source` OR `in_doc`
+  --> tests/ui/rinja-block.rs:24:3
+   |
+24 | #[template(ext = "txt")]
    |   ^^^^^^^^
+
+error: unsupported attribute argument
+  --> tests/ui/rinja-block.rs:33:25
+   |
+33 | #[template(ext = "txt", in_doc)]
+   |                         ^^^^^^
+
+error: argument `in_doc` expects boolean literal `true`
+  --> tests/ui/rinja-block.rs:42:25
+   |
+42 | #[template(ext = "txt", in_doc = false)]
+   |                         ^^^^^^
+
+error: argument `in_doc` expects boolean literal `true`
+  --> tests/ui/rinja-block.rs:51:25
+   |
+51 | #[template(ext = "txt", in_doc = "yes")]
+   |                         ^^^^^^
+
+error: when using `in_doc = true`, the enum's documentation needs a `rinja` code block
+  --> tests/ui/rinja-block.rs:60:25
+   |
+60 | #[template(ext = "txt", in_doc = true)]
+   |                         ^^^^^^
+
+error: when using `in_doc = true`, the union's documentation needs a `rinja` code block
+  --> tests/ui/rinja-block.rs:67:25
+   |
+67 | #[template(ext = "txt", in_doc = true)]
+   |                         ^^^^^^

--- a/testing/tests/ui/rinja-block.stderr
+++ b/testing/tests/ui/rinja-block.stderr
@@ -1,0 +1,13 @@
+error: unterminated "```rinja" block
+ --> tests/ui/rinja-block.rs:7:1
+  |
+7 | /// ```html,rinja
+  | ^^^^^^^^^^^^^^^^^
+
+error: failed to parse template source
+ --> <source attribute>:2:6
+       " fail %}\n{% endif %}"
+  --> tests/ui/rinja-block.rs:15:1
+   |
+15 | /// ```html,rinja
+   | ^^^^^^^^^^^^^^^^^

--- a/testing/tests/ui/rinja-block.stderr
+++ b/testing/tests/ui/rinja-block.stderr
@@ -24,17 +24,17 @@ error: unsupported attribute argument
 33 | #[template(ext = "txt", in_doc)]
    |                         ^^^^^^
 
-error: argument `in_doc` expects boolean literal `true`
-  --> tests/ui/rinja-block.rs:42:25
+error: specify one template argument `path` OR `source` OR `in_doc`
+  --> tests/ui/rinja-block.rs:42:3
    |
 42 | #[template(ext = "txt", in_doc = false)]
-   |                         ^^^^^^
+   |   ^^^^^^^^
 
-error: argument `in_doc` expects boolean literal `true`
-  --> tests/ui/rinja-block.rs:51:25
+error: argument `in_doc` expects as boolean value
+  --> tests/ui/rinja-block.rs:51:34
    |
 51 | #[template(ext = "txt", in_doc = "yes")]
-   |                         ^^^^^^
+   |                                  ^^^^^
 
 error: when using `in_doc = true`, the enum's documentation needs a `rinja` code block
   --> tests/ui/rinja-block.rs:60:25

--- a/testing/tests/ui/rinja-block.stderr
+++ b/testing/tests/ui/rinja-block.stderr
@@ -1,13 +1,13 @@
-error: unterminated "```rinja" block
- --> tests/ui/rinja-block.rs:7:1
-  |
-7 | /// ```html,rinja
-  | ^^^^^^^^^^^^^^^^^
-
 error: failed to parse template source
  --> <source attribute>:2:6
        " fail %}\n{% endif %}"
-  --> tests/ui/rinja-block.rs:15:1
+ --> tests/ui/rinja-block.rs:5:1
+  |
+5 | /// Some documentation
+  | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: template `path` or `source` not found in attributes
+  --> tests/ui/rinja-block.rs:15:3
    |
-15 | /// ```html,rinja
-   | ^^^^^^^^^^^^^^^^^
+15 | #[template(ext = "txt")]
+   |   ^^^^^^^^

--- a/testing/tests/ui/rinja-block.stderr
+++ b/testing/tests/ui/rinja-block.stderr
@@ -12,7 +12,7 @@ error: when using `in_doc = true`, the struct's documentation needs a `rinja` co
 15 | #[template(ext = "txt", in_doc = true)]
    |                         ^^^^^^
 
-error: specify one template argument `path` OR `source` OR `in_doc`
+error: specify one template argument `path`, `source` or `in_doc`
   --> tests/ui/rinja-block.rs:24:3
    |
 24 | #[template(ext = "txt")]
@@ -24,7 +24,7 @@ error: unsupported attribute argument
 33 | #[template(ext = "txt", in_doc)]
    |                         ^^^^^^
 
-error: specify one template argument `path` OR `source` OR `in_doc`
+error: specify one template argument `path`, `source` or `in_doc`
   --> tests/ui/rinja-block.rs:42:3
    |
 42 | #[template(ext = "txt", in_doc = false)]


### PR DESCRIPTION
Using `#[template(source = "…")]` is tiresome, because you have to escape the input. That makes it difficult to read, too. Using `#[template(path = "…")` can be tiresome, too, if the code is small and/or if you just want to prototype something.

This PR adds a third option to supply the source of a template: You can supply the source in the comments of a template. This works similar to doctest. Any <code>```rinja```</code> block gets extracted, and the combined blocks are the source code of the template.