### PR TITLE
parser: reject closing delimiters that look like an operator

### DIFF
--- a/rinja_derive/src/config.rs
+++ b/rinja_derive/src/config.rs
@@ -360,6 +360,26 @@ impl<'a> RawSyntax<'a> {
             }
         }
 
+        for end in [syntax.block_end, syntax.expr_end, syntax.comment_end] {
+            for prefix in ["<<", ">>", "&&", "..", "||"] {
+                if end.starts_with(prefix) {
+                    let msg = if end == prefix {
+                        format!("a closing delimiter must not start with an operator: {end:?}")
+                    } else {
+                        format!(
+                            "a closing delimiter must not start an with operator: \
+                             {end:?} starts with {prefix:?}",
+                        )
+                    };
+                    return Err(CompileError::new_with_span(
+                        msg,
+                        file_info.copied(),
+                        config_span,
+                    ));
+                }
+            }
+        }
+
         Ok(syntax)
     }
 }

--- a/testing/issue-128-2.toml
+++ b/testing/issue-128-2.toml
@@ -1,0 +1,4 @@
+[[syntax]]
+name = "mwe"
+expr_start = "<<<"
+expr_end = ">>>"

--- a/testing/issue-128.toml
+++ b/testing/issue-128.toml
@@ -1,0 +1,4 @@
+[[syntax]]
+name = "mwe"
+expr_start = "<<"
+expr_end = ">>"

--- a/testing/tests/ui/broken-config.stderr
+++ b/testing/tests/ui/broken-config.stderr
@@ -10,14 +10,14 @@ error: unable to read $WORKSPACE/target/tests/trybuild/rinja_testing/folder-conf
 8 | #[template(source = "", ext = "txt", config = "folder-config.toml")]
   |                                               ^^^^^^^^^^^^^^^^^^^^
 
-error: a delimiter may not be the prefix of another delimiter: "<<<" vs "<<<<"
+error: an opening delimiter may not be the prefix of another delimiter. The block delimiter ("<<<") clashes with the expression delimiter ("<<<<")
         --> testing/delim-clash.toml
   --> tests/ui/broken-config.rs:12:47
    |
 12 | #[template(source = "", ext = "txt", config = "delim-clash.toml")]
    |                                               ^^^^^^^^^^^^^^^^^^
 
-error: delimiters must be at least two characters long: "<"
+error: delimiters must be at least two characters long. The opening block delimiter ("<") is too short
         --> testing/delim-too-short.toml
   --> tests/ui/broken-config.rs:16:47
    |

--- a/testing/tests/ui/terminator-operator.rs
+++ b/testing/tests/ui/terminator-operator.rs
@@ -1,0 +1,17 @@
+use rinja::Template;
+
+#[derive(Template)]
+#[template(source = "<<a>> and <<b>>", config = "issue-128.toml", syntax = "mwe", ext="")]
+struct HelloTemplate {
+    a: u32,
+    b: u32,
+}
+
+#[derive(Template)]
+#[template(source = "<<a>> and <<b>>", config = "issue-128-2.toml", syntax = "mwe", ext="")]
+struct HelloTemplate2 {
+    a: u32,
+    b: u32,
+}
+
+fn main() {}

--- a/testing/tests/ui/terminator-operator.stderr
+++ b/testing/tests/ui/terminator-operator.stderr
@@ -1,11 +1,11 @@
-error: a closing delimiter must not start with an operator: ">>"
+error: a closing delimiter must not start with an operator. The expression delimiter (">>") is also an operator
         --> testing/issue-128.toml
  --> tests/ui/terminator-operator.rs:4:49
   |
 4 | #[template(source = "<<a>> and <<b>>", config = "issue-128.toml", syntax = "mwe", ext="")]
   |                                                 ^^^^^^^^^^^^^^^^
 
-error: a closing delimiter must not start an with operator: ">>>" starts with ">>"
+error: a closing delimiter must not start an with operator. The expression delimiter (">>>") starts with the ">>" operator
         --> testing/issue-128-2.toml
   --> tests/ui/terminator-operator.rs:11:49
    |

--- a/testing/tests/ui/terminator-operator.stderr
+++ b/testing/tests/ui/terminator-operator.stderr
@@ -1,0 +1,13 @@
+error: a closing delimiter must not start with an operator: ">>"
+        --> testing/issue-128.toml
+ --> tests/ui/terminator-operator.rs:4:49
+  |
+4 | #[template(source = "<<a>> and <<b>>", config = "issue-128.toml", syntax = "mwe", ext="")]
+  |                                                 ^^^^^^^^^^^^^^^^
+
+error: a closing delimiter must not start an with operator: ">>>" starts with ">>"
+        --> testing/issue-128-2.toml
+  --> tests/ui/terminator-operator.rs:11:49
+   |
+11 | #[template(source = "<<a>> and <<b>>", config = "issue-128-2.toml", syntax = "mwe", ext="")]
+   |                                                 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Related issue: #128.