### PR TITLE
derive: no panics, less work, more compatibility

### DIFF
--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -2284,7 +2284,7 @@ impl Buffer {
         const OPEN: &str = r#"writer.write_str(""#;
         const CLOSE: &str = r#"")?;"#;
 
-        if !self.discard {
+        if !s.is_empty() && !self.discard {
             if !self.last_was_write_str {
                 self.last_was_write_str = true;
                 self.buf.push_str(OPEN);

--- a/rinja_derive/src/input.rs
+++ b/rinja_derive/src/input.rs
@@ -344,22 +344,17 @@ impl TemplateArgs {
                 None => unreachable!("not possible in syn::Meta::NameValue(…)"),
             };
 
-            let value = match &pair.value {
-                syn::Expr::Lit(lit) => lit,
-                syn::Expr::Group(group) => match &*group.expr {
-                    syn::Expr::Lit(lit) => lit,
+            let mut value_expr = &pair.value;
+            let value = loop {
+                match value_expr {
+                    syn::Expr::Lit(lit) => break lit,
+                    syn::Expr::Group(group) => value_expr = &group.expr,
                     v => {
                         return Err(CompileError::no_file_info(
                             format!("unsupported argument value type for `{ident}`"),
                             Some(v.span()),
                         ));
                     }
-                },
-                v => {
-                    return Err(CompileError::no_file_info(
-                        format!("unsupported argument value type for `{ident}`"),
-                        Some(v.span()),
-                    ));
                 }
             };
 

--- a/rinja_derive/src/input.rs
+++ b/rinja_derive/src/input.rs
@@ -53,9 +53,9 @@ impl TemplateInput<'_> {
         // Validate the `source` and `ext` value together, since they are
         // related. In case `source` was used instead of `path`, the value
         // of `ext` is merged into a synthetic `path` value here.
-        let &(ref source, source_span) = source
-            .as_ref()
-            .expect("template path or source not found in attributes");
+        let &(ref source, source_span) = source.as_ref().ok_or_else(|| {
+            CompileError::new("template `path` or `source` not found in attributes", None)
+        })?;
         let path = match (&source, &ext) {
             (Source::Path(path), _) => config.find_template(path, None, None)?,
             (&Source::Source(_), Some(ext)) => {


### PR DESCRIPTION
Some minor stuff I found while implementing #127; extracted from there.

* allow any amount of invisible delimiters: more compatibility with generated TokenStreams
* don't panic if source+path are missing: print an error message instead
* don't write empty string: because even printing nothing causes work