### PR TITLE
derive: replace `ahash` with `rustc-hash`

### DIFF
--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -33,9 +33,10 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 memchr = "2"
 mime = "0.3"
 mime_guess = "2"
-once_map = "0.4.18"
+once_map = { version = "0.4.18", default-features = false, features = ["std"] }
 proc-macro2 = "1"
 quote = "1"
+rustc-hash = "2.0.0"
 syn = "2.0.3"
 
 [dev-dependencies]

--- a/rinja_derive/src/heritage.rs
+++ b/rinja_derive/src/heritage.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use parser::node::{BlockDef, Macro};
 use parser::{Node, Parsed, WithSpan};
+use rustc_hash::FxBuildHasher;
 
 use crate::config::Config;
 use crate::{CompileError, FileInfo};
@@ -16,7 +17,7 @@ pub(crate) struct Heritage<'a> {
 impl Heritage<'_> {
     pub(crate) fn new<'n>(
         mut ctx: &'n Context<'n>,
-        contexts: &'n HashMap<&'n Arc<Path>, Context<'n>>,
+        contexts: &'n HashMap<&'n Arc<Path>, Context<'n>, FxBuildHasher>,
     ) -> Heritage<'n> {
         let mut blocks: BlockAncestry<'n> = ctx
             .blocks
@@ -35,15 +36,15 @@ impl Heritage<'_> {
     }
 }
 
-type BlockAncestry<'a> = HashMap<&'a str, Vec<(&'a Context<'a>, &'a BlockDef<'a>)>>;
+type BlockAncestry<'a> = HashMap<&'a str, Vec<(&'a Context<'a>, &'a BlockDef<'a>)>, FxBuildHasher>;
 
 #[derive(Clone)]
 pub(crate) struct Context<'a> {
     pub(crate) nodes: &'a [Node<'a>],
     pub(crate) extends: Option<Arc<Path>>,
-    pub(crate) blocks: HashMap<&'a str, &'a BlockDef<'a>>,
-    pub(crate) macros: HashMap<&'a str, &'a Macro<'a>>,
-    pub(crate) imports: HashMap<&'a str, Arc<Path>>,
+    pub(crate) blocks: HashMap<&'a str, &'a BlockDef<'a>, FxBuildHasher>,
+    pub(crate) macros: HashMap<&'a str, &'a Macro<'a>, FxBuildHasher>,
+    pub(crate) imports: HashMap<&'a str, Arc<Path>, FxBuildHasher>,
     pub(crate) path: Option<&'a Path>,
     pub(crate) parsed: &'a Parsed,
 }
@@ -53,9 +54,9 @@ impl Context<'_> {
         Context {
             nodes: &[],
             extends: None,
-            blocks: HashMap::new(),
-            macros: HashMap::new(),
-            imports: HashMap::new(),
+            blocks: HashMap::default(),
+            macros: HashMap::default(),
+            imports: HashMap::default(),
             path: None,
             parsed,
         }
@@ -67,9 +68,9 @@ impl Context<'_> {
         parsed: &'n Parsed,
     ) -> Result<Context<'n>, CompileError> {
         let mut extends = None;
-        let mut blocks = HashMap::new();
-        let mut macros = HashMap::new();
-        let mut imports = HashMap::new();
+        let mut blocks = HashMap::default();
+        let mut macros = HashMap::default();
+        let mut imports = HashMap::default();
         let mut nested = vec![parsed.nodes()];
         let mut top = true;
 

--- a/rinja_derive/src/input.rs
+++ b/rinja_derive/src/input.rs
@@ -9,6 +9,7 @@ use mime::Mime;
 use once_map::OnceMap;
 use parser::{Node, Parsed};
 use proc_macro2::Span;
+use rustc_hash::FxBuildHasher;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 
@@ -144,7 +145,7 @@ impl TemplateInput<'_> {
 
     pub(crate) fn find_used_templates(
         &self,
-        map: &mut HashMap<Arc<Path>, Arc<Parsed>>,
+        map: &mut HashMap<Arc<Path>, Arc<Parsed>, FxBuildHasher>,
     ) -> Result<(), CompileError> {
         let (source, source_path) = match &self.source {
             Source::Source(s) => (s.clone(), None),
@@ -571,9 +572,9 @@ pub(crate) fn get_template_source(
     tpl_path: &Arc<Path>,
     import_from: Option<(&Arc<Path>, &str, &str)>,
 ) -> Result<Arc<str>, CompileError> {
-    static CACHE: OnceLock<OnceMap<Arc<Path>, Arc<str>>> = OnceLock::new();
+    static CACHE: OnceLock<OnceMap<Arc<Path>, Arc<str>, FxBuildHasher>> = OnceLock::new();
 
-    CACHE.get_or_init(OnceMap::new).get_or_try_insert_ref(
+    CACHE.get_or_init(OnceMap::default).get_or_try_insert_ref(
         tpl_path,
         (),
         Arc::clone,

--- a/rinja_derive/src/lib.rs
+++ b/rinja_derive/src/lib.rs
@@ -118,7 +118,7 @@ fn build_skeleton(ast: &syn::DeriveInput) -> Result<String, CompileError> {
     let template_args = TemplateArgs::fallback();
     let config = Config::new("", None, None, None)?;
     let input = TemplateInput::new(ast, config, &template_args)?;
-    let mut contexts = HashMap::new();
+    let mut contexts = HashMap::default();
     let parsed = parser::Parsed::default();
     contexts.insert(&input.path, Context::empty(&parsed));
     Generator::new(
@@ -168,10 +168,10 @@ fn build_template_inner(
     )?;
     let input = TemplateInput::new(ast, config, template_args)?;
 
-    let mut templates = HashMap::new();
+    let mut templates = HashMap::default();
     input.find_used_templates(&mut templates)?;
 
-    let mut contexts = HashMap::new();
+    let mut contexts = HashMap::default();
     for (path, parsed) in &templates {
         contexts.insert(path, Context::new(input.config, path, parsed)?);
     }

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -32,9 +32,10 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 memchr = "2"
 mime = "0.3"
 mime_guess = "2"
-once_map = "0.4.18"
+once_map = { version = "0.4.18", default-features = false, features = ["std"] }
 proc-macro2 = "1"
 quote = "1"
+rustc-hash = "2.0.0"
 syn = "2"
 
 [dev-dependencies]


### PR DESCRIPTION
`ahash` shines when you hash very long inputs, in excess of 1000 bytes. We only hash file names, variable names, block names … which should for all reasonable applications less than 100 bytes in length.

`rustc-hash` does not claim to be DoS-resistent like `ahash` is, but we only operate on trusted data, so this feature is not needed.

See also: <https://blog.goose.love/posts/rosetta-hashing/>.

The performance is mostly unchanged or slightly improved:

```text
hello_world             time:   [61.157 µs 61.336 µs 61.503 µs]
                        change: [-3.5829% -2.8333% -2.0098%] (p = 0.00 < 0.05)
                        Performance has improved.

item_info.html          time:   [69.987 µs 70.137 µs 70.277 µs]
                        change: [-2.5459% -2.1263% -1.7360%] (p = 0.00 < 0.05)
                        Performance has improved.

item_union.html         time:   [185.41 µs 185.80 µs 186.18 µs]
                        change: [-2.9272% -2.4197% -1.9278%] (p = 0.00 < 0.05)
                        Performance has improved.

page.html               time:   [747.83 µs 748.66 µs 749.58 µs]
                        change: [-0.3883% -0.1132% +0.1551%] (p = 0.43 > 0.05)
                        No change in performance detected.

print_item.html         time:   [158.28 µs 158.72 µs 159.28 µs]
                        change: [-1.9084% -1.4402% -0.9742%] (p = 0.00 < 0.05)
                        Change within noise threshold.

short_item_info.html    time:   [133.45 µs 133.66 µs 133.89 µs]
                        change: [-4.0600% -3.7956% -3.5459%] (p = 0.00 < 0.05)
                        Performance has improved.

sidebar.html            time:   [207.27 µs 207.74 µs 208.28 µs]
                        change: [-3.7883% -3.2903% -2.8108%] (p = 0.00 < 0.05)
                        Performance has improved.

source.html             time:   [122.85 µs 123.15 µs 123.53 µs]
                        change: [-1.0462% -0.5575% -0.0943%] (p = 0.03 < 0.05)
                        Change within noise threshold.

type_layout.html        time:   [158.98 µs 159.46 µs 160.00 µs]
                        change: [+0.5711% +0.9257% +1.2877%] (p = 0.00 < 0.05)
                        Change within noise threshold.

type_layout_size.html   time:   [75.699 µs 75.978 µs 76.250 µs]
                        change: [-2.6748% -1.9573% -1.0695%] (p = 0.00 < 0.05)
                        Performance has improved.
```