### PR TITLE
ci: fix a few typos and add check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -179,3 +179,9 @@ jobs:
         working-directory: fuzzing
         env:
           RUSTFLAGS: '-Ctarget-feature=-crt-static'
+
+  Typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@master

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,26 @@
+[default]
+locale = "en-us"
+
+[files]
+extend-exclude = [
+    # generated files
+    "book/ethicalads-theme.css",
+    "fuzzing/fuzz/artifacts/",
+    "fuzzing/fuzz/corpus/",
+    "target/",
+    "rinja_parser/tests/*.txt",
+    # fillter texts
+    "rinja/benches/strings.inc",
+    # too many false positives
+    "testing/tests/gen_ws_tests.py",
+]
+
+[default.extend-words]
+# French words
+exemple = "exemple"
+existant = "existant"
+# used in tests
+Ba = "Ba"
+fo = "fo"
+Fo = "Fo"
+sur = "sur"

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -54,7 +54,7 @@ Hello
 To be noted, if one of the trimmed characters is a newline, then the only
 character remaining will be a newline.
 
-If you want this to be the default behaviour, you can set `whitespace` to
+If you want this to be the default behavior, you can set `whitespace` to
 `"minimize"`.
 
 To be noted: you can also configure `whitespace` directly into the `template`

--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -196,7 +196,7 @@ struct MyTemplate {
 
 However, since we'll need to define this function every time we create an
 instance of `MyTemplate`, it's probably not the most ideal way to associate
-some behaviour for our template.
+some behavior for our template.
 
 ### Static functions
 

--- a/examples/actix-web-app/src/main.rs
+++ b/examples/actix-web-app/src/main.rs
@@ -55,7 +55,7 @@ enum Error {
 ///
 /// The same type is used by actix-web as part of the URL, and in rinja to select what content to
 /// show, and also as an HTML attribute in `<html lang=`. To make it possible to use the same type
-/// for three diffent use cases, we use a few derive macros:
+/// for three different use cases, we use a few derive macros:
 ///
 ///  * `Default` to have a default/fallback language.
 ///  * `Debug` is not strictly needed, but it might aid debugging.
@@ -105,7 +105,7 @@ async fn not_found_handler(req: HttpRequest) -> Result<impl Responder> {
     }
 }
 
-/// The is first page your user hits does not contain language infomation, so we redirect them
+/// The is first page your user hits does not contain language information, so we redirect them
 /// to a URL that does contain the default language.
 #[get("/")]
 async fn start_handler(req: HttpRequest) -> Result<impl Responder> {
@@ -139,7 +139,7 @@ async fn index_handler(
     // `{% if lang !=`, the former to select the text of a specific language, e.g. in the `<title>`;
     // and the latter to display references to all other available languages except the currently
     // selected one.
-    // The field `name` will contain the value of the query paramater of the same name.
+    // The field `name` will contain the value of the query parameter of the same name.
     // In `IndexHandlerQuery` we annotated the field with `#[serde(default)]`, so if the value is
     // absent, an empty string is selected by default, which is visible to the user an empty
     // `<input type="text" />` element.

--- a/rinja/benches/escape.rs
+++ b/rinja/benches/escape.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rinja::filters::{escape, Html};
 
 criterion_main!(benches);
@@ -9,66 +9,11 @@ fn functions(c: &mut Criterion) {
 }
 
 fn escaping(b: &mut criterion::Bencher<'_>) {
-    let string_long = r#"
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris consequat tellus sit
-    amet ornare fermentum. Etiam nec erat ante. In at metus a orci mollis scelerisque.
-    Sed eget ultrices turpis, at sollicitudin erat. Integer hendrerit nec magna quis
-    venenatis. Vivamus non dolor hendrerit, vulputate velit sed, varius nunc. Quisque
-    in pharetra mi. Sed ullamcorper nibh malesuada commodo porttitor. Ut scelerisque
-    sodales felis quis dignissim. Morbi aliquam finibus justo, sit amet consectetur
-    mauris efficitur sit amet. Donec posuere turpis felis, eu lacinia magna accumsan
-    quis. Fusce egestas lacus vel fermentum tincidunt. Phasellus a nulla eget lectus
-    placerat commodo at eget nisl. Fusce cursus dui quis purus accumsan auctor.
-    Donec iaculis felis quis metus consectetur porttitor.
-<p>
-    Etiam nibh mi, <b>accumsan</b> quis purus sed, posuere fermentum lorem. In pulvinar porta
-    maximus. Fusce tincidunt lacinia tellus sit amet tincidunt. Aliquam lacus est, pulvinar
-    non metus a, <b>facilisis</b> ultrices quam. Nulla feugiat leo in cursus eleifend. Suspendisse
-    eget nisi ac justo sagittis interdum id a ipsum. Nulla mauris justo, scelerisque ac
-    rutrum vitae, consequat vel ex.
-</p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p>
-<p>
-    Sed sollicitudin <b>sem</b> mauris, at rutrum nibh egestas vel. Ut eu nisi tellus. Praesent dignissim
-    orci elementum, mattis turpis eget, maximus ante. Suspendisse luctus eu felis a tempor. Morbi
-    ac risus vitae sem molestie ullamcorper. Curabitur ligula augue, sollicitudin quis maximus vel,
-    facilisis sed nibh. Aenean auctor magna sem, id rutrum metus convallis quis. Nullam non arcu
-    dictum, lobortis erat quis, rhoncus est. Suspendisse venenatis, mi sed venenatis vehicula,
-    tortor dolor egestas lectus, et efficitur turpis odio non augue. Integer velit sapien, dictum
-    non egestas vitae, hendrerit sed quam. Phasellus a nunc eu erat varius imperdiet. Etiam id
-    sollicitudin turpis, vitae molestie orci. Quisque ornare magna quis metus rhoncus commodo.
-    Phasellus non mauris velit.
-</p>
-<p>
-    Etiam dictum tellus ipsum, nec varius quam ornare vel. Cras vehicula diam nec sollicitudin
-    ultricies. Pellentesque rhoncus sagittis nisl id facilisis. Nunc viverra convallis risus ut
-    luctus. Aliquam vestibulum <b>efficitur massa</b>, id tempus nisi posuere a. Aliquam scelerisque
-    elit justo. Nullam a ante felis. Cras vitae lorem eu nisi feugiat hendrerit. Maecenas vitae
-    suscipit leo, lacinia dignissim lacus. Sed eget volutpat mi. In eu bibendum neque. Pellentesque
-    finibus velit a fermentum rhoncus. Maecenas leo purus, eleifend eu lacus a, condimentum sagittis
-    justo.
-</p>"#;
-    let string_short = "Lorem ipsum dolor sit amet,<foo>bar&foo\"bar\\foo/bar";
-    let empty = "";
-    let no_escape = "Lorem ipsum dolor sit amet,";
-    let no_escape_long = r#"
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin scelerisque eu urna in aliquet.
-Phasellus ac nulla a urna sagittis consequat id quis est. Nullam eu ex eget erat accumsan dictum
-ac lobortis urna. Etiam fermentum ut quam at dignissim. Curabitur vestibulum luctus tellus, sit
-amet lobortis augue tempor faucibus. Nullam sed felis eget odio elementum euismod in sit amet massa.
-Vestibulum sagittis purus sit amet eros auctor, sit amet pharetra purus dapibus. Donec ornare metus
-vel dictum porta. Etiam ut nisl nisi. Nullam rutrum porttitor mi. Donec aliquam ac ipsum eget
-hendrerit. Cras faucibus, eros ut pharetra imperdiet, est tellus aliquet felis, eget convallis
-lacus ipsum eget quam. Vivamus orci lorem, maximus ac mi eget, bibendum vulputate massa. In
-vestibulum dui hendrerit, vestibulum lacus sit amet, posuere erat. Vivamus euismod massa diam,
-vulputate euismod lectus vestibulum nec. Donec sit amet massa magna. Nunc ipsum nulla, euismod
-quis lacus at, gravida maximus elit. Duis tristique, nisl nullam.
-    "#;
-
     b.iter(|| {
-        format!("{}", escape(string_long, Html).unwrap());
-        format!("{}", escape(string_short, Html).unwrap());
-        format!("{}", escape(empty, Html).unwrap());
-        format!("{}", escape(no_escape, Html).unwrap());
-        format!("{}", escape(no_escape_long, Html).unwrap());
+        for &s in black_box(STRINGS) {
+            format!("{}", escape(s, Html).unwrap());
+        }
     });
 }
+
+const STRINGS: &[&str] = include!("strings.inc");

--- a/rinja/benches/strings.inc
+++ b/rinja/benches/strings.inc
@@ -1,0 +1,69 @@
+{
+    const STRING_LONG: &str = r#"
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris consequat tellus sit
+    amet ornare fermentum. Etiam nec erat ante. In at metus a orci mollis scelerisque.
+    Sed eget ultrices turpis, at sollicitudin erat. Integer hendrerit nec magna quis
+    venenatis. Vivamus non dolor hendrerit, vulputate velit sed, varius nunc. Quisque
+    in pharetra mi. Sed ullamcorper nibh malesuada commodo porttitor. Ut scelerisque
+    sodales felis quis dignissim. Morbi aliquam finibus justo, sit amet consectetur
+    mauris efficitur sit amet. Donec posuere turpis felis, eu lacinia magna accumsan
+    quis. Fusce egestas lacus vel fermentum tincidunt. Phasellus a nulla eget lectus
+    placerat commodo at eget nisl. Fusce cursus dui quis purus accumsan auctor.
+    Donec iaculis felis quis metus consectetur porttitor.
+<p>
+    Etiam nibh mi, <b>accumsan</b> quis purus sed, posuere fermentum lorem. In pulvinar porta
+    maximus. Fusce tincidunt lacinia tellus sit amet tincidunt. Aliquam lacus est, pulvinar
+    non metus a, <b>facilisis</b> ultrices quam. Nulla feugiat leo in cursus eleifend. Suspendisse
+    eget nisi ac justo sagittis interdum id a ipsum. Nulla mauris justo, scelerisque ac
+    rutrum vitae, consequat vel ex.
+</p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p>
+<p>
+    Sed sollicitudin <b>sem</b> mauris, at rutrum nibh egestas vel. Ut eu nisi tellus. Praesent dignissim
+    orci elementum, mattis turpis eget, maximus ante. Suspendisse luctus eu felis a tempor. Morbi
+    ac risus vitae sem molestie ullamcorper. Curabitur ligula augue, sollicitudin quis maximus vel,
+    facilisis sed nibh. Aenean auctor magna sem, id rutrum metus convallis quis. Nullam non arcu
+    dictum, lobortis erat quis, rhoncus est. Suspendisse venenatis, mi sed venenatis vehicula,
+    tortor dolor egestas lectus, et efficitur turpis odio non augue. Integer velit sapien, dictum
+    non egestas vitae, hendrerit sed quam. Phasellus a nunc eu erat varius imperdiet. Etiam id
+    sollicitudin turpis, vitae molestie orci. Quisque ornare magna quis metus rhoncus commodo.
+    Phasellus non mauris velit.
+</p>
+<p>
+    Etiam dictum tellus ipsum, nec varius quam ornare vel. Cras vehicula diam nec sollicitudin
+    ultricies. Pellentesque rhoncus sagittis nisl id facilisis. Nunc viverra convallis risus ut
+    luctus. Aliquam vestibulum <b>efficitur massa</b>, id tempus nisi posuere a. Aliquam scelerisque
+    elit justo. Nullam a ante felis. Cras vitae lorem eu nisi feugiat hendrerit. Maecenas vitae
+    suscipit leo, lacinia dignissim lacus. Sed eget volutpat mi. In eu bibendum neque. Pellentesque
+    finibus velit a fermentum rhoncus. Maecenas leo purus, eleifend eu lacus a, condimentum sagittis
+    justo.
+</p>"#;
+
+    const STRING_SHORT: &str = "Lorem ipsum dolor sit amet,<foo>bar&foo\"bar\\foo/bar";
+
+    const EMPTY: &str = "";
+
+    const NO_ESCAPE: &str = "Lorem ipsum dolor sit amet,";
+
+    const NO_ESCAPE_LONG: &str = r#"
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin scelerisque eu urna in aliquet.
+Phasellus ac nulla a urna sagittis consequat id quis est. Nullam eu ex eget erat accumsan dictum
+ac lobortis urna. Etiam fermentum ut quam at dignissim. Curabitur vestibulum luctus tellus, sit
+amet lobortis augue tempor faucibus. Nullam sed felis eget odio elementum euismod in sit amet massa.
+Vestibulum sagittis purus sit amet eros auctor, sit amet pharetra purus dapibus. Donec ornare metus
+vel dictum porta. Etiam ut nisl nisi. Nullam rutrum porttitor mi. Donec aliquam ac ipsum eget
+hendrerit. Cras faucibus, eros ut pharetra imperdiet, est tellus aliquet felis, eget convallis
+lacus ipsum eget quam. Vivamus orci lorem, maximus ac mi eget, bibendum vulputate massa. In
+vestibulum dui hendrerit, vestibulum lacus sit amet, posuere erat. Vivamus euismod massa diam,
+vulputate euismod lectus vestibulum nec. Donec sit amet massa magna. Nunc ipsum nulla, euismod
+quis lacus at, gravida maximus elit. Duis tristique, nisl nullam.
+    "#;
+
+    const STRINGS: &[&str] = &[
+        STRING_LONG,
+        STRING_SHORT,
+        EMPTY,
+        NO_ESCAPE,
+        NO_ESCAPE_LONG,
+    ];
+    STRINGS
+}

--- a/rinja/benches/to-json.rs
+++ b/rinja/benches/to-json.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rinja::Template;
 
 criterion_main!(benches);
@@ -18,7 +18,7 @@ fn escape_json(b: &mut criterion::Bencher<'_>) {
 
     b.iter(|| {
         let mut len = 0;
-        for &s in STRINGS {
+        for &s in black_box(STRINGS) {
             len += Tmpl(s).to_string().len();
         }
         len
@@ -32,7 +32,7 @@ fn escape_json_pretty(b: &mut criterion::Bencher<'_>) {
 
     b.iter(|| {
         let mut len = 0;
-        for &s in STRINGS {
+        for &s in black_box(STRINGS) {
             len += Tmpl(s).to_string().len();
         }
         len
@@ -46,7 +46,7 @@ fn escape_json_for_html(b: &mut criterion::Bencher<'_>) {
 
     b.iter(|| {
         let mut len = 0;
-        for &s in STRINGS {
+        for &s in black_box(STRINGS) {
             len += Tmpl(s).to_string().len();
         }
         len
@@ -60,65 +60,11 @@ fn escape_json_for_html_pretty(b: &mut criterion::Bencher<'_>) {
 
     b.iter(|| {
         let mut len = 0;
-        for &s in STRINGS {
+        for &s in black_box(STRINGS) {
             len += Tmpl(s).to_string().len();
         }
         len
     });
 }
 
-const STRINGS: &[&str] = &[STRING_LONG, STRING_SHORT, EMPTY, NO_ESCAPE, NO_ESCAPE_LONG];
-const STRING_LONG: &str = r#"
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris consequat tellus sit
-amet ornare fermentum. Etiam nec erat ante. In at metus a orci mollis scelerisque.
-Sed eget ultrices turpis, at sollicitudin erat. Integer hendrerit nec magna quis
-venenatis. Vivamus non dolor hendrerit, vulputate velit sed, varius nunc. Quisque
-in pharetra mi. Sed ullamcorper nibh malesuada commodo porttitor. Ut scelerisque
-sodales felis quis dignissim. Morbi aliquam finibus justo, sit amet consectetur
-mauris efficitur sit amet. Donec posuere turpis felis, eu lacinia magna accumsan
-quis. Fusce egestas lacus vel fermentum tincidunt. Phasellus a nulla eget lectus
-placerat commodo at eget nisl. Fusce cursus dui quis purus accumsan auctor.
-Donec iaculis felis quis metus consectetur porttitor.
-<p>
-Etiam nibh mi, <b>accumsan</b> quis purus sed, posuere fermentum lorem. In pulvinar porta
-maximus. Fusce tincidunt lacinia tellus sit amet tincidunt. Aliquam lacus est, pulvinar
-non metus a, <b>facilisis</b> ultrices quam. Nulla feugiat leo in cursus eleifend. Suspendisse
-eget nisi ac justo sagittis interdum id a ipsum. Nulla mauris justo, scelerisque ac
-rutrum vitae, consequat vel ex.
-</p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p>
-<p>
-Sed sollicitudin <b>sem</b> mauris, at rutrum nibh egestas vel. Ut eu nisi tellus. Praesent dignissim
-orci elementum, mattis turpis eget, maximus ante. Suspendisse luctus eu felis a tempor. Morbi
-ac risus vitae sem molestie ullamcorper. Curabitur ligula augue, sollicitudin quis maximus vel,
-facilisis sed nibh. Aenean auctor magna sem, id rutrum metus convallis quis. Nullam non arcu
-dictum, lobortis erat quis, rhoncus est. Suspendisse venenatis, mi sed venenatis vehicula,
-tortor dolor egestas lectus, et efficitur turpis odio non augue. Integer velit sapien, dictum
-non egestas vitae, hendrerit sed quam. Phasellus a nunc eu erat varius imperdiet. Etiam id
-sollicitudin turpis, vitae molestie orci. Quisque ornare magna quis metus rhoncus commodo.
-Phasellus non mauris velit.
-</p>
-<p>
-Etiam dictum tellus ipsum, nec varius quam ornare vel. Cras vehicula diam nec sollicitudin
-ultricies. Pellentesque rhoncus sagittis nisl id facilisis. Nunc viverra convallis risus ut
-luctus. Aliquam vestibulum <b>efficitur massa</b>, id tempus nisi posuere a. Aliquam scelerisque
-elit justo. Nullam a ante felis. Cras vitae lorem eu nisi feugiat hendrerit. Maecenas vitae
-suscipit leo, lacinia dignissim lacus. Sed eget volutpat mi. In eu bibendum neque. Pellentesque
-finibus velit a fermentum rhoncus. Maecenas leo purus, eleifend eu lacus a, condimentum sagittis
-justo.
-</p>"#;
-const STRING_SHORT: &str = "Lorem ipsum dolor sit amet,<foo>bar&foo\"bar\\foo/bar";
-const EMPTY: &str = "";
-const NO_ESCAPE: &str = "Lorem ipsum dolor sit amet,";
-const NO_ESCAPE_LONG: &str = r#"
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin scelerisque eu urna in aliquet.
-Phasellus ac nulla a urna sagittis consequat id quis est. Nullam eu ex eget erat accumsan dictum
-ac lobortis urna. Etiam fermentum ut quam at dignissim. Curabitur vestibulum luctus tellus, sit
-amet lobortis augue tempor faucibus. Nullam sed felis eget odio elementum euismod in sit amet massa.
-Vestibulum sagittis purus sit amet eros auctor, sit amet pharetra purus dapibus. Donec ornare metus
-vel dictum porta. Etiam ut nisl nisi. Nullam rutrum porttitor mi. Donec aliquam ac ipsum eget
-hendrerit. Cras faucibus, eros ut pharetra imperdiet, est tellus aliquet felis, eget convallis
-lacus ipsum eget quam. Vivamus orci lorem, maximus ac mi eget, bibendum vulputate massa. In
-vestibulum dui hendrerit, vestibulum lacus sit amet, posuere erat. Vivamus euismod massa diam,
-vulputate euismod lectus vestibulum nec. Donec sit amet massa magna. Nunc ipsum nulla, euismod
-quis lacus at, gravida maximus elit. Duis tristique, nisl nullam.
-"#;
+const STRINGS: &[&str] = include!("strings.inc");

--- a/rinja_derive/src/config.rs
+++ b/rinja_derive/src/config.rs
@@ -337,7 +337,7 @@ impl RawConfig<'_> {
 #[cfg_attr(feature = "config", derive(Deserialize))]
 #[cfg_attr(feature = "config", serde(field_identifier, rename_all = "lowercase"))]
 pub(crate) enum WhitespaceHandling {
-    /// The default behaviour. It will leave the whitespace characters "as is".
+    /// The default behavior. It will leave the whitespace characters "as is".
     #[default]
     Preserve,
     /// It'll remove all the whitespace characters before and after the jinja block.

--- a/rinja_derive/src/input.rs
+++ b/rinja_derive/src/input.rs
@@ -433,7 +433,7 @@ impl TemplateArgs {
     }
 }
 
-/// Try to find the souce in the comment, in a `rinja` code block.
+/// Try to find the source in the comment, in a `rinja` code block.
 ///
 /// This is only done if no path or source was given in the `#[template]` attribute.
 fn source_from_docs(


### PR DESCRIPTION
This PR adds `_typos.toml`, which lets `typos` ignore generated data. ~~Some filler texts are "fixed", too. It does not matter what the actual text is.~~

Resolves #70.
