### PR TITLE
Improve error message for unclosed items

### DIFF
--- a/testing/tests/ui/end-block.rs
+++ b/testing/tests/ui/end-block.rs
@@ -1,0 +1,61 @@
+use rinja::Template;
+
+#[derive(Template)]
+#[template(
+    ext = "html",
+    source = "{% if x %}{% if x %}{% endif %}",
+)]
+struct EndIf {
+    x: bool,
+}
+
+#[derive(Template)]
+#[template(
+    ext = "html",
+    source = "{% if x %}",
+)]
+struct EndIf2 {
+    x: bool,
+}
+
+#[derive(Template)]
+#[template(
+    ext = "html",
+    source = "{% match x %}",
+)]
+struct EndMatch {
+    x: bool,
+}
+
+#[derive(Template)]
+#[template(
+    ext = "html",
+    source = "{% for a in x %}",
+)]
+struct EndFor {
+    x: [u32; 2],
+}
+
+#[derive(Template)]
+#[template(
+    ext = "html",
+    source = "{% macro bla %}",
+)]
+struct EndMacro;
+
+#[derive(Template)]
+#[template(
+    ext = "html",
+    source = "{% filter bla %}",
+)]
+struct EndFilter;
+
+#[derive(Template)]
+#[template(
+    ext = "html",
+    source = "{% block bla %}",
+)]
+struct EndBlock;
+
+fn main() {
+}

--- a/testing/tests/ui/end-block.stderr
+++ b/testing/tests/ui/end-block.stderr
@@ -1,0 +1,55 @@
+error: expected `endif` to terminate `if` node, found nothing
+ --> <source attribute>:1:2
+       " if x %}{% if x %}{% endif %}"
+ --> tests/ui/end-block.rs:6:14
+  |
+6 |     source = "{% if x %}{% if x %}{% endif %}",
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected `endif` to terminate `if` node, found nothing
+ --> <source attribute>:1:2
+       " if x %}"
+  --> tests/ui/end-block.rs:15:14
+   |
+15 |     source = "{% if x %}",
+   |              ^^^^^^^^^^^^
+
+error: expected `endmatch` to terminate `match` node, found nothing
+ --> <source attribute>:1:2
+       " match x %}"
+  --> tests/ui/end-block.rs:24:14
+   |
+24 |     source = "{% match x %}",
+   |              ^^^^^^^^^^^^^^^
+
+error: expected `endfor` to terminate `for` node, found nothing
+ --> <source attribute>:1:2
+       " for a in x %}"
+  --> tests/ui/end-block.rs:33:14
+   |
+33 |     source = "{% for a in x %}",
+   |              ^^^^^^^^^^^^^^^^^^
+
+error: expected `endmacro` to terminate `macro` node, found nothing
+ --> <source attribute>:1:2
+       " macro bla %}"
+  --> tests/ui/end-block.rs:42:14
+   |
+42 |     source = "{% macro bla %}",
+   |              ^^^^^^^^^^^^^^^^^
+
+error: expected `endfilter` to terminate `filter` node, found nothing
+ --> <source attribute>:1:2
+       " filter bla %}"
+  --> tests/ui/end-block.rs:49:14
+   |
+49 |     source = "{% filter bla %}",
+   |              ^^^^^^^^^^^^^^^^^^
+
+error: expected `endblock` to terminate `block` node, found nothing
+ --> <source attribute>:1:2
+       " block bla %}"
+  --> tests/ui/end-block.rs:56:14
+   |
+56 |     source = "{% block bla %}",
+   |              ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Goes from:

```
error: failed to parse template source
         --> <source attribute>:4:11
       ""
  --> src/main.rs:7:14
   |
7  |       source = r#"
   |  ______________^
8  | | {% if x %}
9  | | {% if x %}
10 | | {% endif %}"#,
   | |_____________^
```

to:

```
error: expected `endif` to terminate `if` node, found nothing
         --> <source attribute>:2:2
       " if x == 1 %}\n{% if x == 2 %}\n{% endif %}\n\nbla\n"
  --> src/main.rs:7:14
   |
7  |       source = r#"
   |  ______________^
8  | | {% if x == 1 %}
9  | | {% if x == 2 %}
10 | | {% endif %}
11 | |
12 | | bla
13 | | "#,
   | |__^
```