### PR TITLE
filters: escape arguments to `pluralize` at compile time

### DIFF
--- a/rinja/src/filters/builtin.rs
+++ b/rinja/src/filters/builtin.rs
@@ -611,6 +611,31 @@ pub fn title(s: impl fmt::Display) -> Result<String, fmt::Error> {
 /// );
 /// # }
 /// ```
+///
+/// ## Arguments get escaped
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// You are number {{ number|pluralize("<b>ONE</b>", number) }}!
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Number {
+///     number: usize
+/// }
+///
+/// assert_eq!(
+///     Number { number: 1 }.to_string(),
+///     "You are number &#60;b&#62;ONE&#60;/b&#62;!",
+/// );
+/// assert_eq!(
+///     Number { number: 9000 }.to_string(),
+///     "You are number 9000!",
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn pluralize<C, S, P>(count: C, singular: S, plural: P) -> Result<Pluralize<S, P>, C::Error>
 where

--- a/rinja/src/helpers.rs
+++ b/rinja/src/helpers.rs
@@ -4,6 +4,8 @@ use std::cell::Cell;
 use std::fmt;
 use std::iter::{Enumerate, Peekable};
 
+use crate::filters::FastWritable;
+
 pub struct TemplateLoop<I>
 where
     I: Iterator,
@@ -127,4 +129,22 @@ primitive_type! {
     f32, f64,
     i8, i16, i32, i64, i128, isize,
     u8, u16, u32, u64, u128, usize,
+}
+
+/// An empty element, so nothing will be written.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Empty;
+
+impl fmt::Display for Empty {
+    #[inline]
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
+impl FastWritable for Empty {
+    #[inline]
+    fn write_into<W: fmt::Write + ?Sized>(&self, _: &mut W) -> fmt::Result {
+        Ok(())
+    }
 }

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -1596,7 +1596,7 @@ impl<'a> Generator<'a> {
             buf.write(format_args!("{CRATE}::filters::pluralize("));
             self._visit_arg(ctx, buf, count)?;
             for value in [sg, pl] {
-                buf.write(", ");
+                buf.write(',');
                 self._visit_auto_escaped_arg(ctx, buf, value)?;
             }
             buf.write(format_args!(")?"));

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -21,10 +21,21 @@ struct Foo {{ {} }}"##,
             .collect::<Vec<_>>()
             .join(","),
     );
-    let generated = build_template(&syn::parse_str::<syn::DeriveInput>(&jinja).unwrap())
-        .unwrap()
-        .parse()
-        .unwrap();
+
+    let generated = build_template(&syn::parse_str::<syn::DeriveInput>(&jinja).unwrap()).unwrap();
+    let generated = match generated.parse() {
+        Ok(generated) => generated,
+        Err(err) => panic!(
+            "\n\
+            === Invalid code generated ===\n\
+            \n\
+            {generated}\n\
+            \n\
+            === Error ===\n\
+            \n\
+            {err}"
+        ),
+    };
     let generated: syn::File = syn::parse2(generated).unwrap();
 
     let size_hint = proc_macro2::Literal::usize_unsuffixed(size_hint);

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -731,3 +731,187 @@ fn test_code_in_comment() {
     let generated = build_template(&ast).unwrap();
     assert!(!generated.contains("compile_error"));
 }
+
+#[test]
+fn test_pluralize() {
+    compare(
+        r#"{{dogs}} dog{{dogs|pluralize}}"#,
+        r#"
+        match (
+            &((&&::rinja::filters::AutoEscaper::new(
+                &(self.dogs),
+                ::rinja::filters::Text,
+            ))
+                .rinja_auto_escape()?),
+            &(::rinja::filters::pluralize(
+                &(self.dogs),
+                ::rinja::helpers::Empty,
+                ::rinja::filters::Safe("s"),
+            )?),
+        ) {
+            (expr0, expr3) => {
+                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                writer.write_str(" dog")?;
+                (&&::rinja::filters::Writable(expr3)).rinja_write(writer)?;
+            }
+        }"#,
+        &[("dogs", "i8")],
+        10,
+    );
+    compare(
+        r#"{{dogs}} dog{{dogs|pluralize("go")}}"#,
+        r#"
+        match (
+            &((&&::rinja::filters::AutoEscaper::new(
+                &(self.dogs),
+                ::rinja::filters::Text,
+            ))
+                .rinja_auto_escape()?),
+            &(::rinja::filters::pluralize(
+                &(self.dogs),
+                ::rinja::filters::Safe("go"),
+                ::rinja::filters::Safe("s"),
+            )?),
+        ) {
+            (expr0, expr3) => {
+                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                writer.write_str(" dog")?;
+                (&&::rinja::filters::Writable(expr3)).rinja_write(writer)?;
+            }
+        }"#,
+        &[("dogs", "i8")],
+        10,
+    );
+    compare(
+        r#"{{mice}} {{mice|pluralize("mouse", "mice")}}"#,
+        r#"
+        match (
+            &((&&::rinja::filters::AutoEscaper::new(
+                &(self.mice),
+                ::rinja::filters::Text,
+            ))
+                .rinja_auto_escape()?),
+            &(::rinja::filters::pluralize(
+                &(self.mice),
+                ::rinja::filters::Safe("mouse"),
+                ::rinja::filters::Safe("mice"),
+            )?),
+        ) {
+            (expr0, expr2) => {
+                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                writer.write_str(" ")?;
+                (&&::rinja::filters::Writable(expr2)).rinja_write(writer)?;
+            }
+        }"#,
+        &[("dogs", "i8")],
+        7,
+    );
+
+    compare(
+        r#"{{count|pluralize(one, count)}}"#,
+        r#"
+        match (
+            &(::rinja::filters::pluralize(
+                &(self.count),
+                (&&::rinja::filters::AutoEscaper::new(
+                    &(self.one),
+                    ::rinja::filters::Text,
+                ))
+                    .rinja_auto_escape()?,
+                (&&::rinja::filters::AutoEscaper::new(
+                    &(self.count),
+                    ::rinja::filters::Text,
+                ))
+                    .rinja_auto_escape()?,
+            )?),
+        ) {
+            (expr0,) => {
+                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            }
+        }
+        "#,
+        &[("count", "i8"), ("one", "&'static str")],
+        3,
+    );
+
+    compare(
+        r#"{{0|pluralize(sg, pl)}}"#,
+        r#"
+        match (
+            &((&&::rinja::filters::AutoEscaper::new(&(self.pl), ::rinja::filters::Text))
+                .rinja_auto_escape()?),
+        ) {
+            (expr0,) => {
+                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            }
+        }
+        "#,
+        &[("sg", "&'static str"), ("pl", "&'static str")],
+        3,
+    );
+    compare(
+        r#"{{1|pluralize(sg, pl)}}"#,
+        r#"
+        match (
+            &((&&::rinja::filters::AutoEscaper::new(&(self.sg), ::rinja::filters::Text))
+                .rinja_auto_escape()?),
+        ) {
+            (expr0,) => {
+                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            }
+        }
+        "#,
+        &[("sg", "&'static str"), ("pl", "&'static str")],
+        3,
+    );
+
+    compare(
+        r#"{{0|pluralize("sg", "pl")}}"#,
+        r#"
+        match (&(::rinja::filters::Safe("pl")),) {
+            (expr0,) => {
+                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            }
+        }
+        "#,
+        &[],
+        3,
+    );
+    compare(
+        r#"{{1|pluralize("sg", "pl")}}"#,
+        r#"
+        match (&(::rinja::filters::Safe("sg")),) {
+            (expr0,) => {
+                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            }
+        }
+        "#,
+        &[],
+        3,
+    );
+
+    compare(
+        r#"{{0|pluralize}}"#,
+        r#"
+        match (&(::rinja::filters::Safe("s")),) {
+            (expr0,) => {
+                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            }
+        }
+        "#,
+        &[],
+        3,
+    );
+    compare(
+        r#"{{1|pluralize}}"#,
+        r#"
+        match (&(::rinja::helpers::Empty),) {
+            (expr0,) => {
+                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            }
+        }
+        "#,
+        &[],
+        3,
+    );
+}

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -137,7 +137,7 @@ pub struct WithSpan<'a, T> {
 }
 
 impl<'a, T> WithSpan<'a, T> {
-    pub fn new(inner: T, span: &'a str) -> Self {
+    pub const fn new(inner: T, span: &'a str) -> Self {
         Self { inner, span }
     }
 

--- a/testing/tests/ui/pluralize.rs
+++ b/testing/tests/ui/pluralize.rs
@@ -1,0 +1,12 @@
+use rinja::Template;
+
+#[derive(Template)]
+#[template(
+    ext = "html",
+    source = "{{ input|pluralize }}",
+)]
+struct Pluralize {
+    input: &'static str,
+}
+
+fn main() {}

--- a/testing/tests/ui/pluralize.stderr
+++ b/testing/tests/ui/pluralize.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `str: PluralizeCount` is not satisfied
+ --> tests/ui/pluralize.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^ the trait `PluralizeCount` is not implemented for `str`, which is required by `&str: PluralizeCount`
+  |
+  = help: the following other types implement trait `PluralizeCount`:
+            &T
+            Arc<T>
+            Box<T>
+            MutexGuard<'_, T>
+            NonZero<i128>
+            NonZero<i16>
+            NonZero<i32>
+            NonZero<i64>
+          and $N others
+  = note: required for `&str` to implement `PluralizeCount`
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
We can tell at compile time how to escape `""` or `"s"`. The former does not need to write anything, the latter does not need to be escaped.