### PR TITLE
Update crates version to `0.3.4`

### DIFF
--- a/examples/actix-web-app/Cargo.toml
+++ b/examples/actix-web-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-app"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -10,7 +10,7 @@ publish = false
 # and actix-web as your web-framework.
 # rinja_actix makes it easy to use rinja templates as `Responder` of an actix-web request.
 # The rendered template is simply the response of your handler!
-rinja_actix = { version = "0.3.3", path = "../../rinja_actix" }
+rinja_actix = { version = "0.3.4", path = "../../rinja_actix" }
 actix-web = { version = "4.8.0", default-features = false, features = ["macros"] }
 tokio = { version = "1.38.0", features = ["sync", "rt-multi-thread"] }
 

--- a/rinja/Cargo.toml
+++ b/rinja/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja"
-version = "0.3.3"
+version = "0.3.4"
 description = "Type-safe, compiled Jinja-like templates for Rust"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -37,7 +37,7 @@ with-rocket = ["rinja_derive/with-rocket"]
 with-warp = ["rinja_derive/with-warp"]
 
 [dependencies]
-rinja_derive = { version = "=0.3.3", path = "../rinja_derive" }
+rinja_derive = { version = "=0.3.4", path = "../rinja_derive" }
 
 humansize = { version = "2", optional = true }
 num-traits = { version = "0.2.6", optional = true }

--- a/rinja_actix/Cargo.toml
+++ b/rinja_actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_actix"
-version = "0.3.3"
+version = "0.3.4"
 description = "Actix-Web integration for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
 [dependencies]
-rinja = { version = "0.3.3", path = "../rinja", default-features = false, features = ["with-actix-web"] }
+rinja = { version = "0.3.4", path = "../rinja", default-features = false, features = ["with-actix-web"] }
 
 actix-web = { version = "4", default-features = false }
 

--- a/rinja_axum/Cargo.toml
+++ b/rinja_axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_axum"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 rust-version = "1.71"
 description = "Axum integration for Rinja templates"
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
 [dependencies]
-rinja = { version = "0.3.3", path = "../rinja", default-features = false, features = ["with-axum"] }
+rinja = { version = "0.3.4", path = "../rinja", default-features = false, features = ["with-axum"] }
 
 axum-core = "0.4"
 http = "1.0"

--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_derive"
-version = "0.3.3"
+version = "0.3.4"
 description = "Procedural macro package for Rinja"
 homepage = "https://github.com/rinja-rs/rinja"
 repository = "https://github.com/rinja-rs/rinja"
@@ -30,7 +30,7 @@ with-rocket = []
 with-warp = []
 
 [dependencies]
-parser = { package = "rinja_parser", version = "=0.3.3", path = "../rinja_parser" }
+parser = { package = "rinja_parser", version = "=0.3.4", path = "../rinja_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
 pulldown-cmark = { version = "0.12.0", optional = true, default-features = false }

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_derive_standalone"
-version = "0.3.3"
+version = "0.3.4"
 description = "Procedural macro package for Rinja"
 homepage = "https://github.com/rinja-rs/rinja"
 repository = "https://github.com/rinja-rs/rinja"
@@ -30,7 +30,7 @@ with-rocket = []
 with-warp = []
 
 [dependencies]
-parser = { package = "rinja_parser", version = "=0.3.3", path = "../rinja_parser" }
+parser = { package = "rinja_parser", version = "=0.3.4", path = "../rinja_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
 pulldown-cmark = { version = "0.12.0", optional = true, default-features = false }

--- a/rinja_parser/Cargo.toml
+++ b/rinja_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_parser"
-version = "0.3.3"
+version = "0.3.4"
 description = "Parser for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]

--- a/rinja_rocket/Cargo.toml
+++ b/rinja_rocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_rocket"
-version = "0.3.3"
+version = "0.3.4"
 description = "Rocket integration for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
 [dependencies]
-rinja = { version = "0.3.3", path = "../rinja", default-features = false, features = ["with-rocket"] }
+rinja = { version = "0.3.4", path = "../rinja", default-features = false, features = ["with-rocket"] }
 
 rocket = { version = "0.5", default-features = false }
 

--- a/rinja_warp/Cargo.toml
+++ b/rinja_warp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_warp"
-version = "0.3.3"
+version = "0.3.4"
 description = "Warp integration for Rinja templates"
 documentation = "https://docs.rs/rinja"
 keywords = ["markup", "template", "jinja2", "html"]
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
 [dependencies]
-rinja = { version = "0.3.3", path = "../rinja", default-features = false, features = ["with-warp"] }
+rinja = { version = "0.3.4", path = "../rinja", default-features = false, features = ["with-warp"] }
 
 warp = { version = "0.3", default-features = false }
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinja_testing"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["rinja-rs developers"]
 workspace = ".."
 edition = "2021"
@@ -13,12 +13,12 @@ code-in-doc = ["rinja/code-in-doc"]
 serde_json = ["dep:serde_json", "rinja/serde_json"]
 
 [dependencies]
-rinja = { path = "../rinja", version = "0.3.3" }
+rinja = { path = "../rinja", version = "0.3.4" }
 
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-rinja = { path = "../rinja", version = "0.3.3", features = ["code-in-doc", "serde_json"] }
+rinja = { path = "../rinja", version = "0.3.4", features = ["code-in-doc", "serde_json"] }
 
 criterion = "0.5"
 phf = { version = "0.11", features = ["macros" ] }


### PR DESCRIPTION
I don't think https://github.com/rinja-rs/rinja/pull/180 will go through easily and it's not a blocker here so I'll go ahead with the release in the time being.