### PR TITLE
Add doctests to filters

### DIFF
--- a/rinja/src/filters/builtin.rs
+++ b/rinja/src/filters/builtin.rs
@@ -20,6 +20,25 @@ const MAX_LEN: usize = 10_000;
 /// {{ value|fmt("{:?}") }}
 /// ```
 ///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ value|fmt("{:?}") }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example {
+///     value: (usize, usize),
+/// }
+///
+/// assert_eq!(
+///     Example { value: (3, 4) }.to_string(),
+///     "<div>(3, 4)</div>"
+/// );
+/// # }
+/// ```
+///
 /// Compare with [format](./fn.format.html).
 pub fn fmt() {}
 
@@ -34,6 +53,25 @@ pub fn fmt() {}
 /// {{ "{:?}{:?}"|format(value, other_value) }}
 /// ```
 ///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ "{:?}"|format(value) }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example {
+///     value: (usize, usize),
+/// }
+///
+/// assert_eq!(
+///     Example { value: (3, 4) }.to_string(),
+///     "<div>(3, 4)</div>"
+/// );
+/// # }
+/// ```
+///
 /// Compare with [fmt](./fn.fmt.html).
 pub fn format() {}
 
@@ -41,6 +79,25 @@ pub fn format() {}
 ///
 /// A single newline becomes an HTML line break `<br>` and a new line
 /// followed by a blank line becomes a paragraph break `<p>`.
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ example|linebreaks }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: "Foo\nBar\n\nBaz" }.to_string(),
+///     "<div><p>Foo<br/>Bar</p><p>Baz</p></div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn linebreaks(s: impl fmt::Display) -> Result<HtmlSafeOutput<String>, fmt::Error> {
     fn linebreaks(s: String) -> String {
@@ -83,6 +140,25 @@ pub fn linebreaksbr(s: impl fmt::Display) -> Result<HtmlSafeOutput<String>, fmt:
 /// A new line followed by a blank line becomes a paragraph break `<p>`.
 /// Paragraph tags only wrap content; empty paragraphs are removed.
 /// No `<br/>` tags are added.
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// {{ lines|paragraphbreaks }}
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     lines: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { lines: "Foo\nBar\n\nBaz" }.to_string(),
+///     "<p>Foo\nBar</p><p>Baz</p>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn paragraphbreaks(s: impl fmt::Display) -> Result<HtmlSafeOutput<String>, fmt::Error> {
     fn paragraphbreaks(s: String) -> String {
@@ -93,6 +169,30 @@ pub fn paragraphbreaks(s: impl fmt::Display) -> Result<HtmlSafeOutput<String>, f
 }
 
 /// Converts to lowercase
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ word|lower }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     word: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { word: "FOO" }.to_string(),
+///     "<div>foo</div>"
+/// );
+///
+/// assert_eq!(
+///     Example { word: "FooBar" }.to_string(),
+///     "<div>foobar</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn lower(s: impl fmt::Display) -> Result<String, fmt::Error> {
     fn lower(s: String) -> Result<String, fmt::Error> {
@@ -102,12 +202,61 @@ pub fn lower(s: impl fmt::Display) -> Result<String, fmt::Error> {
 }
 
 /// Alias for the `lower()` filter
+/// Converts to lowercase
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ word|lowercase }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     word: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { word: "FOO" }.to_string(),
+///     "<div>foo</div>"
+/// );
+///
+/// assert_eq!(
+///     Example { word: "FooBar" }.to_string(),
+///     "<div>foobar</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn lowercase(s: impl fmt::Display) -> Result<String, fmt::Error> {
     lower(s)
 }
 
 /// Converts to uppercase
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ word|upper }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     word: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { word: "foo" }.to_string(),
+///     "<div>FOO</div>"
+/// );
+///
+/// assert_eq!(
+///     Example { word: "FooBar" }.to_string(),
+///     "<div>FOOBAR</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn upper(s: impl fmt::Display) -> Result<String, fmt::Error> {
     fn upper(s: String) -> Result<String, fmt::Error> {
@@ -117,12 +266,56 @@ pub fn upper(s: impl fmt::Display) -> Result<String, fmt::Error> {
 }
 
 /// Alias for the `upper()` filter
+/// Converts to uppercase
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ word|upper }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     word: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { word: "foo" }.to_string(),
+///     "<div>FOO</div>"
+/// );
+///
+/// assert_eq!(
+///     Example { word: "FooBar" }.to_string(),
+///     "<div>FOOBAR</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn uppercase(s: impl fmt::Display) -> Result<String, fmt::Error> {
     upper(s)
 }
 
 /// Strip leading and trailing whitespace
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ example|trim }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: " Hello\tworld\t" }.to_string(),
+///     "<div>Hello\tworld</div>"
+/// );
+/// # }
+/// ```
 pub fn trim<T: fmt::Display>(s: T) -> Result<String> {
     struct Collector(String);
 
@@ -143,6 +336,25 @@ pub fn trim<T: fmt::Display>(s: T) -> Result<String> {
 }
 
 /// Limit string length, appends '...' if truncated
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ example|truncate(2) }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: "hello" }.to_string(),
+///     "<div>he...</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn truncate<S: fmt::Display>(
     source: S,
@@ -230,6 +442,25 @@ impl<W: fmt::Write> fmt::Write for TruncateWriter<W> {
 }
 
 /// Indent lines with `width` spaces
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ example|indent(4) }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: "hello\nfoo\nbar" }.to_string(),
+///     "<div>hello\n    foo\n    bar</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn indent(s: impl fmt::Display, width: usize) -> Result<String, fmt::Error> {
     fn indent(s: String, width: usize) -> Result<String, fmt::Error> {
@@ -252,6 +483,25 @@ pub fn indent(s: impl fmt::Display, width: usize) -> Result<String, fmt::Error> 
 }
 
 /// Joins iterable into a string separated by provided argument
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ example|join(", ") }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a [&'a str],
+/// }
+///
+/// assert_eq!(
+///     Example { example: &["foo", "bar", "bazz"] }.to_string(),
+///     "<div>foo, bar, bazz</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn join<I, S>(input: I, separator: S) -> Result<JoinFilter<I, S>, Infallible>
 where
@@ -297,6 +547,30 @@ where
 }
 
 /// Capitalize a value. The first character will be uppercase, all others lowercase.
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ example|capitalize }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: "hello" }.to_string(),
+///     "<div>Hello</div>"
+/// );
+///
+/// assert_eq!(
+///     Example { example: "hElLO" }.to_string(),
+///     "<div>Hello</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn capitalize(s: impl fmt::Display) -> Result<String, fmt::Error> {
     fn capitalize(s: String) -> Result<String, fmt::Error> {
@@ -313,6 +587,25 @@ pub fn capitalize(s: impl fmt::Display) -> Result<String, fmt::Error> {
 }
 
 /// Centers the value in a field of a given width
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>-{{ example|center(5) }}-</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: "a" }.to_string(),
+///     "<div>-  a  -</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn center<T: fmt::Display>(src: T, width: usize) -> Result<Center<T>, Infallible> {
     Ok(Center { src, width })
@@ -334,6 +627,25 @@ impl<T: fmt::Display> fmt::Display for Center<T> {
 }
 
 /// Count the words in that string.
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ example|wordcount }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: "rinja is sort of cool" }.to_string(),
+///     "<div>5</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn wordcount(s: impl fmt::Display) -> Result<usize, fmt::Error> {
     fn wordcount(s: String) -> Result<usize, fmt::Error> {
@@ -344,6 +656,25 @@ pub fn wordcount(s: impl fmt::Display) -> Result<usize, fmt::Error> {
 
 /// Return a title cased version of the value. Words will start with uppercase letters, all
 /// remaining characters are lowercase.
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ example|title }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: "hello WORLD" }.to_string(),
+///     "<div>Hello World</div>"
+/// );
+/// # }
+/// ```
 pub fn title(s: impl fmt::Display) -> Result<String, fmt::Error> {
     let s = try_to_string(s)?;
     let mut need_capitalization = true;

--- a/rinja/src/filters/escape.rs
+++ b/rinja/src/filters/escape.rs
@@ -10,6 +10,25 @@ use std::{borrow, str};
 /// Rinja will automatically insert the first (`Escaper`) argument,
 /// so this filter only takes a single argument of any type that implements
 /// `Display`.
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ example|safe }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: "<p>I'm Safe</p>" }.to_string(),
+///     "<div><p>I'm Safe</p></div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn safe<T, E>(text: T, escaper: E) -> Result<Safe<T>, Infallible> {
     let _ = escaper; // it should not be part of the interface that the `escaper` is unused
@@ -24,6 +43,25 @@ pub fn safe<T, E>(text: T, escaper: E) -> Result<Safe<T>, Infallible> {
 ///
 /// It is possible to optionally specify an escaper other than the default for
 /// the template's extension, like `{{ val|escape("txt") }}`.
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ example|escape }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: "Escape <>&" }.to_string(),
+///     "<div>Escape &#60;&#62;&#38;</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn escape<T, E>(text: T, escaper: E) -> Result<Safe<EscapeDisplay<T, E>>, Infallible> {
     Ok(Safe(EscapeDisplay(text, escaper)))
@@ -60,6 +98,25 @@ impl<W: Write, E: Escaper> Write for EscapeWriter<W, E> {
 }
 
 /// Alias for [`escape()`]
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ example|e }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: "Escape <>&" }.to_string(),
+///     "<div>Escape &#60;&#62;&#38;</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn e<T, E>(text: T, escaper: E) -> Result<Safe<EscapeDisplay<T, E>>, Infallible> {
     escape(text, escaper)

--- a/rinja/src/filters/json.rs
+++ b/rinja/src/filters/json.rs
@@ -20,6 +20,26 @@ use super::FastWritable;
 /// To use it in HTML attributes, you can either use it in quotation marks `"{{data|json}}"` as is,
 /// or in apostrophes with the (optional) safe filter `'{{data|json|safe}}'`.
 /// In HTML texts the output of e.g. `<pre>{{data|json|safe}}</pre>` is safe, too.
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div><li data-extra='{{data|json|safe}}'>Example</li></div>
+/// /// ```
+///
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     data: Vec<&'a str>,
+/// }
+///
+/// assert_eq!(
+///     Example { data: vec!["foo", "bar"] }.to_string(),
+///     "<div><li data-extra='[\"foo\",\"bar\"]'>Example</li></div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn json(value: impl Serialize) -> Result<impl fmt::Display, Infallible> {
     Ok(ToJson { value })
@@ -36,6 +56,29 @@ pub fn json(value: impl Serialize) -> Result<impl fmt::Display, Infallible> {
 ///
 /// In rinja's template language, this filter is called `|json`, too. The right function is
 /// automatically selected depending on whether an `indent` argument was provided or not.
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{data|json(4)|safe}}</div>
+/// /// ```
+///
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     data: Vec<&'a str>,
+/// }
+///
+/// assert_eq!(
+///     Example { data: vec!["foo", "bar"] }.to_string(),
+///     "<div>[
+///     \"foo\",
+///     \"bar\"
+/// ]</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn json_pretty(
     value: impl Serialize,

--- a/rinja/src/filters/num_traits.rs
+++ b/rinja/src/filters/num_traits.rs
@@ -4,6 +4,24 @@ use num_traits::cast::NumCast;
 use crate::{Error, Result};
 
 /// Absolute value
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ -2|abs }}</div>
+/// /// ```
+///
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example;
+///
+/// assert_eq!(
+///     Example.to_string(),
+///     "<div>2</div>"
+/// );
+/// # }
+/// ```
 pub fn abs<T: Signed>(number: T) -> Result<T> {
     Ok(number.abs())
 }

--- a/rinja/src/filters/urlencode.rs
+++ b/rinja/src/filters/urlencode.rs
@@ -37,6 +37,25 @@ const URLENCODE_SET: &AsciiSet = &URLENCODE_STRICT_SET.remove(b'/');
 /// To encode `/` as well, see [`urlencode_strict`](./fn.urlencode_strict.html).
 ///
 /// [`urlencode_strict`]: ./fn.urlencode_strict.html
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <div>{{ example|urlencode }}</div>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: "hello?world" }.to_string(),
+///     "<div>hello%3Fworld</div>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn urlencode<T>(s: T) -> Result<HtmlSafeOutput<UrlencodeFilter<T>>, Infallible> {
     Ok(HtmlSafeOutput(UrlencodeFilter(s, URLENCODE_SET)))
@@ -56,6 +75,25 @@ pub fn urlencode<T>(s: T) -> Result<HtmlSafeOutput<UrlencodeFilter<T>>, Infallib
 /// ```
 ///
 /// If you want to preserve `/`, see [`urlencode`](./fn.urlencode.html).
+///
+/// ```
+/// # #[cfg(feature = "code-in-doc")] {
+/// # use rinja::Template;
+/// /// ```jinja
+/// /// <a href='{{ example|urlencode_strict }}'>Example</a>
+/// /// ```
+/// #[derive(Template)]
+/// #[template(ext = "html", in_doc = true)]
+/// struct Example<'a> {
+///     example: &'a str,
+/// }
+///
+/// assert_eq!(
+///     Example { example: "/hello/world" }.to_string(),
+///     "<a href='%2Fhello%2Fworld'>Example</a>"
+/// );
+/// # }
+/// ```
 #[inline]
 pub fn urlencode_strict<T>(s: T) -> Result<HtmlSafeOutput<UrlencodeFilter<T>>, Infallible> {
     Ok(HtmlSafeOutput(UrlencodeFilter(s, URLENCODE_STRICT_SET)))


### PR DESCRIPTION
This PR advances work towards resolving #185. The basic structures of the doctests in this PR follow the example given in that issue. A few items I have not resolved prior to raising this PR:

- I was unable to find a way use variables in the `abs` doctest. I was running into an issue where the `Template` macro wanted to use a reference to an `isize` or `i32`, but the `Signed` trait is not implemented for a reference to those types. So, I just did a static example.
- Similarly for the `filters::num_traits`, I was not able to get examples for `into_f64` or `into_isize` working. My tests would just return the same number passed in unchanged. For example, if I passed in a `3` as a variable, I would get a `3` as the return and it would not be formatted as a `f64` (in the `into_f64` example). 

I am happy to continue working on this issue, especially if there is any feedback or guidance to incorporate into a future PR based on the work to date. Many thanks!