### PR TITLE
derive: remove `once_map` dependency

### DIFF
--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -42,7 +42,6 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 memchr = "2"
 mime = "0.3"
 mime_guess = "2"
-once_map = { version = "0.4.18", default-features = false, features = ["std"] }
 proc-macro2 = "1"
 quote = "1"
 rustc-hash = "2.0.0"


### PR DESCRIPTION
This change removes 14 (transitive) dependencies:

* ahash, getrandom, hashbrown, lock_api, once_map, parking_lot, parking_lot_core, redox_syscall, scopeguard, smallvec, stable_deref_trait, wasi, zerocopy, zerocopy_derive

The new implementation is less generic, but on the other hand it's only 30 non-empty lines of code.

The benchmarks are just about unchanged.