### PR TITLE
generator: better macro hygiene

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,6 @@
 [licenses]
 version = 2
-allow = ["Apache-2.0", "BSD-2-Clause", "MIT", "Unicode-DFS-2016"]
+allow = ["Apache-2.0", "MIT", "MIT-0", "Unicode-DFS-2016"]
 private = { ignore = true }
 
 [[licenses.clarify]]

--- a/rinja/src/helpers.rs
+++ b/rinja/src/helpers.rs
@@ -1,5 +1,3 @@
-#![doc(hidden)]
-
 use std::cell::Cell;
 use std::fmt;
 use std::iter::{Enumerate, Peekable};

--- a/rinja/src/helpers.rs
+++ b/rinja/src/helpers.rs
@@ -4,6 +4,10 @@ use std::cell::Cell;
 use std::fmt;
 use std::iter::{Enumerate, Peekable};
 
+// The re-exports are used in the generated code for macro hygiene. Even if the paths `::core` or
+// `::std` are shadowed, the generated code will still be able to access the crates.
+pub use {core, std};
+
 use crate::filters::FastWritable;
 
 pub struct TemplateLoop<I>

--- a/rinja/src/lib.rs
+++ b/rinja/src/lib.rs
@@ -67,6 +67,8 @@ mod html;
 use std::{fmt, io};
 
 pub use rinja_derive::Template;
+#[doc(hidden)]
+pub use {core, std};
 
 #[doc(hidden)]
 pub use crate as shared;

--- a/rinja/src/lib.rs
+++ b/rinja/src/lib.rs
@@ -67,8 +67,6 @@ mod html;
 use std::{fmt, io};
 
 pub use rinja_derive::Template;
-#[doc(hidden)]
-pub use {core, std};
 
 #[doc(hidden)]
 pub use crate as shared;

--- a/rinja/src/lib.rs
+++ b/rinja/src/lib.rs
@@ -61,6 +61,7 @@
 
 mod error;
 pub mod filters;
+#[doc(hidden)]
 pub mod helpers;
 mod html;
 

--- a/rinja_derive/src/config.rs
+++ b/rinja_derive/src/config.rs
@@ -12,7 +12,7 @@ use proc_macro2::Span;
 #[cfg(feature = "config")]
 use serde::Deserialize;
 
-use crate::{CRATE, CompileError, FileInfo, OnceMap};
+use crate::{CompileError, FileInfo, OnceMap};
 
 #[derive(Debug)]
 pub(crate) struct Config {
@@ -182,7 +182,7 @@ impl Config {
         for (extensions, name) in DEFAULT_ESCAPERS {
             escapers.push((
                 str_set(extensions),
-                format!("{CRATE}::filters::{name}").into(),
+                format!("rinja::filters::{name}").into(),
             ));
         }
 
@@ -682,11 +682,11 @@ mod tests {
                 str_set(&[
                     "html", "htm", "j2", "jinja", "jinja2", "rinja", "svg", "xml"
                 ]),
-                "::rinja::filters::Html".into()
+                "rinja::filters::Html".into()
             ),
             (
                 str_set(&["md", "none", "txt", "yml", ""]),
-                "::rinja::filters::Text".into()
+                "rinja::filters::Text".into()
             ),
         ]);
     }

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -221,10 +221,10 @@ impl<'a> Generator<'a> {
         buf.write(
             "\
                 #[inline]\
-                fn write_into<RinjaW: ::core::fmt::Write + ?::core::marker::Sized>(\
-                    &self,\
-                    dest: &mut RinjaW,\
-                ) -> ::core::fmt::Result {\
+                fn write_into<RinjaW>(&self, dest: &mut RinjaW) -> ::core::fmt::Result \
+                where \
+                    RinjaW: ::core::fmt::Write + ?::core::marker::Sized,\
+                {\
                     rinja::Template::render_into(self, dest).map_err(|_| ::core::fmt::Error)\
                 }\
             }",

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -128,10 +128,10 @@ impl<'a> Generator<'a> {
         buf.write(
             "fn render_into<RinjaW>(&self, writer: &mut RinjaW) -> rinja::Result<()>\
             where \
-                RinjaW: rinja::core::fmt::Write + ?rinja::core::marker::Sized\
+                RinjaW: rinja::helpers::core::fmt::Write + ?rinja::helpers::core::marker::Sized\
             {\
                 use rinja::filters::{AutoEscape as _, WriteWritable as _};\
-                use rinja::core::fmt::Write as _;",
+                use rinja::helpers::core::fmt::Write as _;",
         );
 
         buf.set_discard(self.buf_writable.discard);
@@ -151,8 +151,8 @@ impl<'a> Generator<'a> {
             if path_is_valid {
                 let path = path.to_str().unwrap();
                 buf.write(format_args!(
-                    "const _: &[rinja::core::primitive::u8] =\
-                        rinja::core::include_bytes!({path:#?});",
+                    "const _: &[rinja::helpers::core::primitive::u8] =\
+                        rinja::helpers::core::include_bytes!({path:#?});",
                 ));
             }
         }
@@ -170,10 +170,11 @@ impl<'a> Generator<'a> {
             "\
                 rinja::Result::Ok(())\
             }}\
-            const EXTENSION: rinja::core::option::Option<&'static rinja::core::primitive::str> =\
-                rinja::core::option::Option::{:?};\
-            const SIZE_HINT: rinja::core::primitive::usize = {size_hint}usize;\
-            const MIME_TYPE: &'static rinja::core::primitive::str = {:?};",
+            const EXTENSION:\
+                rinja::helpers::core::option::Option<&'static rinja::helpers::core::primitive::str> =\
+                rinja::helpers::core::option::Option::{:?};\
+            const SIZE_HINT: rinja::helpers::core::primitive::usize = {size_hint}usize;\
+            const MIME_TYPE: &'static rinja::helpers::core::primitive::str = {:?};",
             self.input.extension(),
             self.input.mime_type,
         ));
@@ -187,19 +188,23 @@ impl<'a> Generator<'a> {
         let ident = &self.input.ast.ident;
         buf.write(format_args!(
             "\
-            /// Implement the [`format!()`][rinja::std::format] trait for [`{}`]\n\
+            /// Implement the [`format!()`][rinja::helpers::std::format] trait for [`{}`]\n\
             ///\n\
             /// Please be aware of the rendering performance notice in the \
                 [`Template`][rinja::Template] trait.\n\
             ",
             quote!(#ident),
         ));
-        self.write_header(buf, "rinja::core::fmt::Display", None);
+        self.write_header(buf, "rinja::helpers::core::fmt::Display", None);
         buf.write(
             "\
                 #[inline]\
-                fn fmt(&self, f: &mut rinja::core::fmt::Formatter<'_>) -> rinja::core::fmt::Result {\
-                    rinja::Template::render_into(self, f).map_err(|_| rinja::core::fmt::Error)\
+                fn fmt(\
+                    &self,\
+                    f: &mut rinja::helpers::core::fmt::Formatter<'_>\
+                ) -> rinja::helpers::core::fmt::Result {\
+                    rinja::Template::render_into(self, f)\
+                        .map_err(|_| rinja::helpers::core::fmt::Error)\
                 }\
             }",
         );
@@ -211,11 +216,12 @@ impl<'a> Generator<'a> {
         buf.write(
             "\
                 #[inline]\
-                fn write_into<RinjaW>(&self, dest: &mut RinjaW) -> rinja::core::fmt::Result \
+                fn write_into<RinjaW>(&self, dest: &mut RinjaW) -> rinja::helpers::core::fmt::Result \
                 where \
-                    RinjaW: rinja::core::fmt::Write + ?rinja::core::marker::Sized,\
+                    RinjaW: rinja::helpers::core::fmt::Write + ?rinja::helpers::core::marker::Sized,\
                 {\
-                    rinja::Template::render_into(self, dest).map_err(|_| rinja::core::fmt::Error)\
+                    rinja::Template::render_into(self, dest)\
+                        .map_err(|_| rinja::helpers::core::fmt::Error)\
                 }\
             }",
         );
@@ -646,7 +652,7 @@ impl<'a> Generator<'a> {
                         // finally dereferences it to `bool`.
                         buf.write("*(&(");
                         buf.write(this.visit_expr_root(ctx, expr)?);
-                        buf.write(") as &rinja::core::primitive::bool) {");
+                        buf.write(") as &rinja::helpers::core::primitive::bool) {");
                     }
                 } else if pos != 0 {
                     buf.write("} else {");
@@ -1001,7 +1007,7 @@ impl<'a> Generator<'a> {
         // build `FmtCell` that contains the inner block
         buf.write(format_args!(
             "let {FILTER_SOURCE} = rinja::helpers::FmtCell::new(\
-                |writer: &mut rinja::core::fmt::Formatter<'_>| -> rinja::Result<()> {{"
+                |writer: &mut rinja::helpers::core::fmt::Formatter<'_>| -> rinja::Result<()> {{"
         ));
         let size_hint = self.push_locals(|this| {
             this.prepare_ws(filter.ws1);
@@ -1033,7 +1039,7 @@ impl<'a> Generator<'a> {
             ),
         };
         buf.write(format_args!(
-            "if rinja::core::write!(writer, \"{{}}\", {filter_buf}).is_err() {{\
+            "if rinja::helpers::core::write!(writer, \"{{}}\", {filter_buf}).is_err() {{\
                 return {FILTER_SOURCE}.take_err();\
             }}"
         ));
@@ -1512,7 +1518,9 @@ impl<'a> Generator<'a> {
     ) -> Result<DisplayWrap, CompileError> {
         buf.write("rinja::helpers::get_primitive_value(&(");
         self.visit_expr(ctx, buf, expr)?;
-        buf.write(format_args!(")) as rinja::core::primitive::{target}"));
+        buf.write(format_args!(
+            ")) as rinja::helpers::core::primitive::{target}"
+        ));
         Ok(DisplayWrap::Unwrapped)
     }
 
@@ -1522,9 +1530,9 @@ impl<'a> Generator<'a> {
         buf: &mut Buffer,
         expr: &WithSpan<'_, Expr<'_>>,
     ) -> Result<DisplayWrap, CompileError> {
-        buf.write("rinja::core::result::Result::map_err(");
+        buf.write("rinja::helpers::core::result::Result::map_err(");
         self.visit_expr(ctx, buf, expr)?;
-        buf.write(", |err| rinja::shared::Error::Custom(rinja::core::convert::Into::into(err)))?");
+        buf.write(", |err| rinja::shared::Error::Custom(rinja::helpers::core::convert::Into::into(err)))?");
         Ok(DisplayWrap::Unwrapped)
     }
 
@@ -1885,7 +1893,7 @@ impl<'a> Generator<'a> {
     ) -> Result<DisplayWrap, CompileError> {
         if !args.is_empty() {
             if let Expr::StrLit(ref fmt) = *args[0] {
-                buf.write("rinja::std::format!(");
+                buf.write("rinja::helpers::std::format!(");
                 self.visit_str_lit(buf, fmt);
                 if args.len() > 1 {
                     buf.write(',');
@@ -1908,7 +1916,7 @@ impl<'a> Generator<'a> {
     ) -> Result<DisplayWrap, CompileError> {
         if let [_, arg2] = args {
             if let Expr::StrLit(ref fmt) = **arg2 {
-                buf.write("rinja::std::format!(");
+                buf.write("rinja::helpers::std::format!(");
                 self.visit_str_lit(buf, fmt);
                 buf.write(',');
                 self._visit_args(ctx, buf, &args[..1])?;
@@ -2097,7 +2105,7 @@ impl<'a> Generator<'a> {
                                 );\
                                 let _len = _cycle.len();\
                                 if _len == 0 {\
-                                    return rinja::core::result::Result::Err(rinja::Error::Fmt);\
+                                    return rinja::helpers::core::result::Result::Err(rinja::Error::Fmt);\
                                 }\
                                 _cycle[_loop_item.index % _len]\
                             })",

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -181,8 +181,9 @@ impl<'a> Generator<'a> {
             "\
                 rinja::Result::Ok(())\
             }}\
-            const EXTENSION: ::core::option::Option<&'static ::core::primitive::str> = {:?};\
-            const SIZE_HINT: ::core::primitive::usize = {size_hint};\
+            const EXTENSION: ::core::option::Option<&'static ::core::primitive::str> =\
+                ::core::option::Option::{:?};\
+            const SIZE_HINT: ::core::primitive::usize = {size_hint}usize;\
             const MIME_TYPE: &'static ::core::primitive::str = {:?};",
             self.input.extension(),
             self.input.mime_type,

--- a/rinja_derive/src/lib.rs
+++ b/rinja_derive/src/lib.rs
@@ -433,15 +433,3 @@ const BUILT_IN_FILTERS: &[&str] = &[
     "urlencode",
     "wordcount",
 ];
-
-const CRATE: &str = if cfg!(feature = "with-actix-web") {
-    "::rinja_actix"
-} else if cfg!(feature = "with-axum") {
-    "::rinja_axum"
-} else if cfg!(feature = "with-rocket") {
-    "::rinja_rocket"
-} else if cfg!(feature = "with-warp") {
-    "::rinja_warp"
-} else {
-    "::rinja"
-};

--- a/rinja_derive/src/lib.rs
+++ b/rinja_derive/src/lib.rs
@@ -148,7 +148,7 @@ fn compile_error(msgs: impl Iterator<Item = String>, span: Span) -> TokenStream 
         span =>
         const _: () = {
             extern crate #crate_ as rinja;
-            #(rinja::core::compile_error!(#msgs);)*
+            #(rinja::helpers::core::compile_error!(#msgs);)*
         };
     }
 }

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -46,36 +46,37 @@ struct Foo {{ {} }}"##,
             impl rinja::Template for Foo {
                 fn render_into<RinjaW>(&self, writer: &mut RinjaW) -> rinja::Result<()>
                 where
-                    RinjaW: rinja::core::fmt::Write + ?rinja::core::marker::Sized,
+                    RinjaW: rinja::helpers::core::fmt::Write + ?rinja::helpers::core::marker::Sized,
                 {
                     use rinja::filters::{AutoEscape as _, WriteWritable as _};
-                    use rinja::core::fmt::Write as _;
+                    use rinja::helpers::core::fmt::Write as _;
                     #expected
                     rinja::Result::Ok(())
                 }
-                const EXTENSION: rinja::core::option::Option<&'static rinja::core::primitive::str> =
-                    rinja::core::option::Option::Some("txt");
-                const SIZE_HINT: rinja::core::primitive::usize = #size_hint;
-                const MIME_TYPE: &'static rinja::core::primitive::str = "text/plain; charset=utf-8";
+                const EXTENSION:
+                    rinja::helpers::core::option::Option<&'static rinja::helpers::core::primitive::str> =
+                    rinja::helpers::core::option::Option::Some("txt");
+                const SIZE_HINT: rinja::helpers::core::primitive::usize = #size_hint;
+                const MIME_TYPE: &'static rinja::helpers::core::primitive::str = "text/plain; charset=utf-8";
             }
 
-            /// Implement the [`format!()`][rinja::std::format] trait for [`Foo`]
+            /// Implement the [`format!()`][rinja::helpers::std::format] trait for [`Foo`]
             ///
             /// Please be aware of the rendering performance notice in the [`Template`][rinja::Template] trait.
-            impl rinja::core::fmt::Display for Foo {
+            impl rinja::helpers::core::fmt::Display for Foo {
                 #[inline]
-                fn fmt(&self, f: &mut rinja::core::fmt::Formatter<'_>) -> rinja::core::fmt::Result {
-                    rinja::Template::render_into(self, f).map_err(|_| rinja::core::fmt::Error)
+                fn fmt(&self, f: &mut rinja::helpers::core::fmt::Formatter<'_>) -> rinja::helpers::core::fmt::Result {
+                    rinja::Template::render_into(self, f).map_err(|_| rinja::helpers::core::fmt::Error)
                 }
             }
 
             impl rinja::filters::FastWritable for Foo {
                 #[inline]
-                fn write_into<RinjaW>(&self, dest: &mut RinjaW) -> rinja::core::fmt::Result
+                fn write_into<RinjaW>(&self, dest: &mut RinjaW) -> rinja::helpers::core::fmt::Result
                 where
-                    RinjaW: rinja::core::fmt::Write + ?rinja::core::marker::Sized,
+                    RinjaW: rinja::helpers::core::fmt::Write + ?rinja::helpers::core::marker::Sized,
                 {
-                    rinja::Template::render_into(self, dest).map_err(|_| rinja::core::fmt::Error)
+                    rinja::Template::render_into(self, dest).map_err(|_| rinja::helpers::core::fmt::Error)
                 }
             }
         };
@@ -194,9 +195,9 @@ fn check_if_let() {
     compare(
         r#"{% include "include1.html" %}"#,
         &format!(
-            r#"const _: &[rinja::core::primitive::u8] = rinja::core::include_bytes!({path1:#?});
-            const _: &[rinja::core::primitive::u8] = rinja::core::include_bytes!({path2:#?});
-            const _: &[rinja::core::primitive::u8] = rinja::core::include_bytes!({path3:#?});
+            r#"const _: &[rinja::helpers::core::primitive::u8] = rinja::helpers::core::include_bytes!({path1:#?});
+            const _: &[rinja::helpers::core::primitive::u8] = rinja::helpers::core::include_bytes!({path2:#?});
+            const _: &[rinja::helpers::core::primitive::u8] = rinja::helpers::core::include_bytes!({path3:#?});
             writer.write_str("3333")?;"#
         ),
         &[],
@@ -292,7 +293,7 @@ writer.write_str("bla")?;"#,
         "{% if x == 12 %}bli
          {%- else if x is defined %}12
          {%- else %}nope{% endif %}",
-        r#"if *(&(self.x == 12) as &rinja::core::primitive::bool) {
+        r#"if *(&(self.x == 12) as &rinja::helpers::core::primitive::bool) {
 writer.write_str("bli")?;
 } else {
 writer.write_str("12")?;
@@ -305,7 +306,7 @@ writer.write_str("12")?;
     // are present.
     compare(
         "{% if y is defined || x == 12 %}{{x}}{% endif %}",
-        r"if *(&(self.x == 12) as &rinja::core::primitive::bool) {
+        r"if *(&(self.x == 12) as &rinja::helpers::core::primitive::bool) {
     match (
         &((&&rinja::filters::AutoEscaper::new(&(self.x), rinja::filters::Text)).rinja_auto_escape()?),
     ) {
@@ -346,7 +347,7 @@ writer.write_str("12")?;
     compare(
         "{% if y is defined && y == 12 %}{{y}}{% else %}bli{% endif %}",
         r#"
-if *(&(self.y == 12) as &rinja::core::primitive::bool) {
+if *(&(self.y == 12) as &rinja::helpers::core::primitive::bool) {
     match (
         &((&&rinja::filters::AutoEscaper::new(
             &(self.y),
@@ -417,7 +418,7 @@ match (
     // Ensure that the `!` is kept .
     compare(
         "{% if y is defined && !y %}bla{% endif %}",
-        r#"if *(&(!self.y) as &rinja::core::primitive::bool) {
+        r#"if *(&(!self.y) as &rinja::helpers::core::primitive::bool) {
     writer.write_str("bla")?;
 }"#,
         &[("y", "bool")],
@@ -425,7 +426,7 @@ match (
     );
     compare(
         "{% if y is defined && !(y) %}bla{% endif %}",
-        r#"if *(&(!(self.y)) as &rinja::core::primitive::bool) {
+        r#"if *(&(!(self.y)) as &rinja::helpers::core::primitive::bool) {
     writer.write_str("bla")?;
 }"#,
         &[("y", "bool")],
@@ -433,7 +434,7 @@ match (
     );
     compare(
         "{% if y is not defined || !y %}bla{% endif %}",
-        r#"if *(&(!self.y) as &rinja::core::primitive::bool) {
+        r#"if *(&(!self.y) as &rinja::helpers::core::primitive::bool) {
     writer.write_str("bla")?;
 }"#,
         &[("y", "bool")],
@@ -441,7 +442,7 @@ match (
     );
     compare(
         "{% if y is not defined || !(y) %}bla{% endif %}",
-        r#"if *(&(!(self.y)) as &rinja::core::primitive::bool) {
+        r#"if *(&(!(self.y)) as &rinja::helpers::core::primitive::bool) {
     writer.write_str("bla")?;
 }"#,
         &[("y", "bool")],
@@ -506,7 +507,7 @@ fn check_bool_conditions() {
     );
     compare(
         "{% if false || x == 12 %}{{x}}{% endif %}",
-        r"if *(&(self.x == 12) as &rinja::core::primitive::bool) {
+        r"if *(&(self.x == 12) as &rinja::helpers::core::primitive::bool) {
     match (
         &((&&rinja::filters::AutoEscaper::new(
             &(self.x),
@@ -530,7 +531,7 @@ fn check_bool_conditions() {
     // condition.
     compare(
         "{% if y == 3 || (true || x == 12) %}{{x}}{% endif %}",
-        r"if *(&(self.y == 3 || (true)) as &rinja::core::primitive::bool) {
+        r"if *(&(self.y == 3 || (true)) as &rinja::helpers::core::primitive::bool) {
     match (
         &((&&rinja::filters::AutoEscaper::new(
             &(self.x),
@@ -568,7 +569,7 @@ fn check_bool_conditions() {
     );
     compare(
         "{% if y == 3 || (x == 12 || true) %}{{x}}{% endif %}",
-        r"if *(&(self.y == 3 || (self.x == 12 || true)) as &rinja::core::primitive::bool) {
+        r"if *(&(self.y == 3 || (self.x == 12 || true)) as &rinja::helpers::core::primitive::bool) {
     match (
         &((&&rinja::filters::AutoEscaper::new(
             &(self.x),

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -71,10 +71,10 @@ struct Foo {{ {} }}"##,
 
             impl rinja::filters::FastWritable for Foo {
                 #[inline]
-                fn write_into<RinjaW: ::core::fmt::Write + ?::core::marker::Sized>(
-                    &self,
-                    dest: &mut RinjaW,
-                ) -> ::core::fmt::Result {
+                fn write_into<RinjaW>(&self, dest: &mut RinjaW) -> ::core::fmt::Result
+                where
+                    RinjaW: ::core::fmt::Write + ?::core::marker::Sized,
+                {
                     rinja::Template::render_into(self, dest).map_err(|_| ::core::fmt::Error)
                 }
             }

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -41,38 +41,44 @@ struct Foo {{ {} }}"##,
     let size_hint = proc_macro2::Literal::usize_unsuffixed(size_hint);
     let expected: proc_macro2::TokenStream = expected.parse().unwrap();
     let expected: syn::File = syn::parse_quote! {
-        impl ::rinja::Template for Foo {
-            fn render_into<RinjaW>(&self, writer: &mut RinjaW) -> ::rinja::Result<()>
-            where
-                RinjaW: ::core::fmt::Write + ?::core::marker::Sized,
-            {
-                use ::rinja::filters::{AutoEscape as _, WriteWritable as _};
-                use ::core::fmt::Write as _;
-                #expected
-                ::rinja::Result::Ok(())
+        const _: () = {
+            extern crate rinja as rinja;
+
+            impl rinja::Template for Foo {
+                fn render_into<RinjaW>(&self, writer: &mut RinjaW) -> rinja::Result<()>
+                where
+                    RinjaW: ::core::fmt::Write + ?::core::marker::Sized,
+                {
+                    use rinja::filters::{AutoEscape as _, WriteWritable as _};
+                    use ::core::fmt::Write as _;
+                    #expected
+                    rinja::Result::Ok(())
+                }
+                const EXTENSION: ::core::option::Option<&'static ::core::primitive::str> = Some("txt");
+                const SIZE_HINT: ::core::primitive::usize = #size_hint;
+                const MIME_TYPE: &'static ::core::primitive::str = "text/plain; charset=utf-8";
             }
-            const EXTENSION: ::core::option::Option<&'static ::core::primitive::str> = Some("txt");
-            const SIZE_HINT: ::core::primitive::usize = #size_hint;
-            const MIME_TYPE: &'static ::core::primitive::str = "text/plain; charset=utf-8";
-        }
-        /// Implement the [`format!()`][::std::format] trait for [`Foo`]
-        ///
-        /// Please be aware of the rendering performance notice in the [`Template`][::rinja::Template] trait.
-        impl ::core::fmt::Display for Foo {
-            #[inline]
-            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                ::rinja::Template::render_into(self, f).map_err(|_| ::core::fmt::Error)
+
+            /// Implement the [`format!()`][::std::format] trait for [`Foo`]
+            ///
+            /// Please be aware of the rendering performance notice in the [`Template`][rinja::Template] trait.
+            impl ::core::fmt::Display for Foo {
+                #[inline]
+                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                    rinja::Template::render_into(self, f).map_err(|_| ::core::fmt::Error)
+                }
             }
-        }
-        impl ::rinja::filters::FastWritable for Foo {
-            #[inline]
-            fn write_into<RinjaW: ::core::fmt::Write + ?::core::marker::Sized>(
-                &self,
-                dest: &mut RinjaW,
-            ) -> ::core::fmt::Result {
-                ::rinja::Template::render_into(self, dest).map_err(|_| ::core::fmt::Error)
+
+            impl rinja::filters::FastWritable for Foo {
+                #[inline]
+                fn write_into<RinjaW: ::core::fmt::Write + ?::core::marker::Sized>(
+                    &self,
+                    dest: &mut RinjaW,
+                ) -> ::core::fmt::Result {
+                    rinja::Template::render_into(self, dest).map_err(|_| ::core::fmt::Error)
+                }
             }
-        }
+        };
     };
 
     let expected = prettyplease::unparse(&expected);
@@ -135,10 +141,10 @@ fn check_if_let() {
         "{% if let Some(query) = s && !query.is_empty() %}{{query}}{% endif %}",
         r"if let Some(query,) = &self.s && !query.is_empty() {
     match (
-        &((&&::rinja::filters::AutoEscaper::new(&(query), ::rinja::filters::Text)).rinja_auto_escape()?),
+        &((&&rinja::filters::AutoEscaper::new(&(query), rinja::filters::Text)).rinja_auto_escape()?),
     ) {
         (expr0,) => {
-            (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
         }
     }
 }",
@@ -152,10 +158,10 @@ fn check_if_let() {
         "{% if let Some(s) = s %}{{ s }}{% endif %}",
         r"if let Some(s,) = &self.s {
     match (
-        &((&&::rinja::filters::AutoEscaper::new(&(s), ::rinja::filters::Text)).rinja_auto_escape()?),
+        &((&&rinja::filters::AutoEscaper::new(&(s), rinja::filters::Text)).rinja_auto_escape()?),
     ) {
         (expr0,) => {
-            (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
         }
     }
 }",
@@ -169,10 +175,10 @@ fn check_if_let() {
         "{% if let Some(s) = s && !s.is_empty() %}{{s}}{% endif %}",
         r"if let Some(s,) = &self.s && !s.is_empty() {
     match (
-        &((&&::rinja::filters::AutoEscaper::new(&(s), ::rinja::filters::Text)).rinja_auto_escape()?),
+        &((&&rinja::filters::AutoEscaper::new(&(s), rinja::filters::Text)).rinja_auto_escape()?),
     ) {
         (expr0,) => {
-            (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
         }
     }
 }",
@@ -301,10 +307,10 @@ writer.write_str("12")?;
         "{% if y is defined || x == 12 %}{{x}}{% endif %}",
         r"if *(&(self.x == 12) as &::core::primitive::bool) {
     match (
-        &((&&::rinja::filters::AutoEscaper::new(&(self.x), ::rinja::filters::Text)).rinja_auto_escape()?),
+        &((&&rinja::filters::AutoEscaper::new(&(self.x), rinja::filters::Text)).rinja_auto_escape()?),
     ) {
         (expr0,) => {
-            (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
         }
     }
 }
@@ -315,10 +321,10 @@ writer.write_str("12")?;
     compare(
         "{% if y is defined || x == 12 %}{{x}}{% endif %}",
         r"match (
-    &((&&::rinja::filters::AutoEscaper::new(&(self.x), ::rinja::filters::Text)).rinja_auto_escape()?),
+    &((&&rinja::filters::AutoEscaper::new(&(self.x), rinja::filters::Text)).rinja_auto_escape()?),
 ) {
     (expr0,) => {
-        (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+        (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
     }
 }
 ",
@@ -342,14 +348,14 @@ writer.write_str("12")?;
         r#"
 if *(&(self.y == 12) as &::core::primitive::bool) {
     match (
-        &((&&::rinja::filters::AutoEscaper::new(
+        &((&&rinja::filters::AutoEscaper::new(
             &(self.y),
-            ::rinja::filters::Text,
+            rinja::filters::Text,
         ))
             .rinja_auto_escape()?),
     ) {
         (expr0,) => {
-            (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
         }
     }
 } else {
@@ -364,14 +370,14 @@ if *(&(self.y == 12) as &::core::primitive::bool) {
         "{% if y is defined %}{{y}}{% else %}bli{% endif %}",
         r"
 match (
-    &((&&::rinja::filters::AutoEscaper::new(
+    &((&&rinja::filters::AutoEscaper::new(
         &(self.y),
-        ::rinja::filters::Text,
+        rinja::filters::Text,
     ))
         .rinja_auto_escape()?),
 ) {
     (expr0,) => {
-        (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+        (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
     }
 }
 ",
@@ -488,10 +494,10 @@ fn check_bool_conditions() {
     compare(
         "{% if true || x == 12 %}{{x}}{% endif %}",
         r"match (
-    &((&&::rinja::filters::AutoEscaper::new(&(self.x), ::rinja::filters::Text)).rinja_auto_escape()?),
+    &((&&rinja::filters::AutoEscaper::new(&(self.x), rinja::filters::Text)).rinja_auto_escape()?),
 ) {
     (expr0,) => {
-        (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+        (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
     }
 }
 ",
@@ -502,14 +508,14 @@ fn check_bool_conditions() {
         "{% if false || x == 12 %}{{x}}{% endif %}",
         r"if *(&(self.x == 12) as &::core::primitive::bool) {
     match (
-        &((&&::rinja::filters::AutoEscaper::new(
+        &((&&rinja::filters::AutoEscaper::new(
             &(self.x),
-            ::rinja::filters::Text,
+            rinja::filters::Text,
         ))
             .rinja_auto_escape()?),
     ) {
         (expr0,) => {
-            (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
         }
     }
 }
@@ -526,14 +532,14 @@ fn check_bool_conditions() {
         "{% if y == 3 || (true || x == 12) %}{{x}}{% endif %}",
         r"if *(&(self.y == 3 || (true)) as &::core::primitive::bool) {
     match (
-        &((&&::rinja::filters::AutoEscaper::new(
+        &((&&rinja::filters::AutoEscaper::new(
             &(self.x),
-            ::rinja::filters::Text,
+            rinja::filters::Text,
         ))
             .rinja_auto_escape()?),
     ) {
         (expr0,) => {
-            (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
         }
     }
 }
@@ -546,14 +552,14 @@ fn check_bool_conditions() {
     compare(
         "{% if (true || x == 12) || y == 3 %}{{x}}{% endif %}",
         r"match (
-    &((&&::rinja::filters::AutoEscaper::new(
+    &((&&rinja::filters::AutoEscaper::new(
         &(self.x),
-        ::rinja::filters::Text,
+        rinja::filters::Text,
     ))
         .rinja_auto_escape()?),
 ) {
     (expr0,) => {
-        (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+        (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
     }
 }
 ",
@@ -564,14 +570,14 @@ fn check_bool_conditions() {
         "{% if y == 3 || (x == 12 || true) %}{{x}}{% endif %}",
         r"if *(&(self.y == 3 || (self.x == 12 || true)) as &::core::primitive::bool) {
     match (
-        &((&&::rinja::filters::AutoEscaper::new(
+        &((&&rinja::filters::AutoEscaper::new(
             &(self.x),
-            ::rinja::filters::Text,
+            rinja::filters::Text,
         ))
             .rinja_auto_escape()?),
     ) {
         (expr0,) => {
-            (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+            (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
         }
     }
 }
@@ -741,21 +747,21 @@ fn test_pluralize() {
         r"{{dogs}} dog{{dogs|pluralize}}",
         r#"
         match (
-            &((&&::rinja::filters::AutoEscaper::new(
+            &((&&rinja::filters::AutoEscaper::new(
                 &(self.dogs),
-                ::rinja::filters::Text,
+                rinja::filters::Text,
             ))
                 .rinja_auto_escape()?),
-            &(::rinja::filters::pluralize(
+            &(rinja::filters::pluralize(
                 &(self.dogs),
-                ::rinja::helpers::Empty,
-                ::rinja::filters::Safe("s"),
+                rinja::helpers::Empty,
+                rinja::filters::Safe("s"),
             )?),
         ) {
             (expr0, expr3) => {
-                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
                 writer.write_str(" dog")?;
-                (&&::rinja::filters::Writable(expr3)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr3)).rinja_write(writer)?;
             }
         }"#,
         &[("dogs", "i8")],
@@ -765,21 +771,21 @@ fn test_pluralize() {
         r#"{{dogs}} dog{{dogs|pluralize("go")}}"#,
         r#"
         match (
-            &((&&::rinja::filters::AutoEscaper::new(
+            &((&&rinja::filters::AutoEscaper::new(
                 &(self.dogs),
-                ::rinja::filters::Text,
+                rinja::filters::Text,
             ))
                 .rinja_auto_escape()?),
-            &(::rinja::filters::pluralize(
+            &(rinja::filters::pluralize(
                 &(self.dogs),
-                ::rinja::filters::Safe("go"),
-                ::rinja::filters::Safe("s"),
+                rinja::filters::Safe("go"),
+                rinja::filters::Safe("s"),
             )?),
         ) {
             (expr0, expr3) => {
-                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
                 writer.write_str(" dog")?;
-                (&&::rinja::filters::Writable(expr3)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr3)).rinja_write(writer)?;
             }
         }"#,
         &[("dogs", "i8")],
@@ -789,21 +795,21 @@ fn test_pluralize() {
         r#"{{mice}} {{mice|pluralize("mouse", "mice")}}"#,
         r#"
         match (
-            &((&&::rinja::filters::AutoEscaper::new(
+            &((&&rinja::filters::AutoEscaper::new(
                 &(self.mice),
-                ::rinja::filters::Text,
+                rinja::filters::Text,
             ))
                 .rinja_auto_escape()?),
-            &(::rinja::filters::pluralize(
+            &(rinja::filters::pluralize(
                 &(self.mice),
-                ::rinja::filters::Safe("mouse"),
-                ::rinja::filters::Safe("mice"),
+                rinja::filters::Safe("mouse"),
+                rinja::filters::Safe("mice"),
             )?),
         ) {
             (expr0, expr2) => {
-                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
                 writer.write_str(" ")?;
-                (&&::rinja::filters::Writable(expr2)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr2)).rinja_write(writer)?;
             }
         }"#,
         &[("dogs", "i8")],
@@ -814,22 +820,22 @@ fn test_pluralize() {
         r"{{count|pluralize(one, count)}}",
         r"
         match (
-            &(::rinja::filters::pluralize(
+            &(rinja::filters::pluralize(
                 &(self.count),
-                (&&::rinja::filters::AutoEscaper::new(
+                (&&rinja::filters::AutoEscaper::new(
                     &(self.one),
-                    ::rinja::filters::Text,
+                    rinja::filters::Text,
                 ))
                     .rinja_auto_escape()?,
-                (&&::rinja::filters::AutoEscaper::new(
+                (&&rinja::filters::AutoEscaper::new(
                     &(self.count),
-                    ::rinja::filters::Text,
+                    rinja::filters::Text,
                 ))
                     .rinja_auto_escape()?,
             )?),
         ) {
             (expr0,) => {
-                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
             }
         }
         ",
@@ -841,11 +847,11 @@ fn test_pluralize() {
         r"{{0|pluralize(sg, pl)}}",
         r"
         match (
-            &((&&::rinja::filters::AutoEscaper::new(&(self.pl), ::rinja::filters::Text))
+            &((&&rinja::filters::AutoEscaper::new(&(self.pl), rinja::filters::Text))
                 .rinja_auto_escape()?),
         ) {
             (expr0,) => {
-                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
             }
         }
         ",
@@ -856,11 +862,11 @@ fn test_pluralize() {
         r"{{1|pluralize(sg, pl)}}",
         r"
         match (
-            &((&&::rinja::filters::AutoEscaper::new(&(self.sg), ::rinja::filters::Text))
+            &((&&rinja::filters::AutoEscaper::new(&(self.sg), rinja::filters::Text))
                 .rinja_auto_escape()?),
         ) {
             (expr0,) => {
-                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
             }
         }
         ",
@@ -871,9 +877,9 @@ fn test_pluralize() {
     compare(
         r#"{{0|pluralize("sg", "pl")}}"#,
         r#"
-        match (&(::rinja::filters::Safe("pl")),) {
+        match (&(rinja::filters::Safe("pl")),) {
             (expr0,) => {
-                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
             }
         }
         "#,
@@ -883,9 +889,9 @@ fn test_pluralize() {
     compare(
         r#"{{1|pluralize("sg", "pl")}}"#,
         r#"
-        match (&(::rinja::filters::Safe("sg")),) {
+        match (&(rinja::filters::Safe("sg")),) {
             (expr0,) => {
-                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
             }
         }
         "#,
@@ -896,9 +902,9 @@ fn test_pluralize() {
     compare(
         r"{{0|pluralize}}",
         r#"
-        match (&(::rinja::filters::Safe("s")),) {
+        match (&(rinja::filters::Safe("s")),) {
             (expr0,) => {
-                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
             }
         }
         "#,
@@ -908,9 +914,9 @@ fn test_pluralize() {
     compare(
         r"{{1|pluralize}}",
         r"
-        match (&(::rinja::helpers::Empty),) {
+        match (&(rinja::helpers::Empty),) {
             (expr0,) => {
-                (&&::rinja::filters::Writable(expr0)).rinja_write(writer)?;
+                (&&rinja::filters::Writable(expr0)).rinja_write(writer)?;
             }
         }
         ",

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -46,36 +46,36 @@ struct Foo {{ {} }}"##,
             impl rinja::Template for Foo {
                 fn render_into<RinjaW>(&self, writer: &mut RinjaW) -> rinja::Result<()>
                 where
-                    RinjaW: ::core::fmt::Write + ?::core::marker::Sized,
+                    RinjaW: rinja::core::fmt::Write + ?rinja::core::marker::Sized,
                 {
                     use rinja::filters::{AutoEscape as _, WriteWritable as _};
-                    use ::core::fmt::Write as _;
+                    use rinja::core::fmt::Write as _;
                     #expected
                     rinja::Result::Ok(())
                 }
-                const EXTENSION: ::core::option::Option<&'static ::core::primitive::str> =
-                    ::core::option::Option::Some("txt");
-                const SIZE_HINT: ::core::primitive::usize = #size_hint;
-                const MIME_TYPE: &'static ::core::primitive::str = "text/plain; charset=utf-8";
+                const EXTENSION: rinja::core::option::Option<&'static rinja::core::primitive::str> =
+                    rinja::core::option::Option::Some("txt");
+                const SIZE_HINT: rinja::core::primitive::usize = #size_hint;
+                const MIME_TYPE: &'static rinja::core::primitive::str = "text/plain; charset=utf-8";
             }
 
-            /// Implement the [`format!()`][::std::format] trait for [`Foo`]
+            /// Implement the [`format!()`][rinja::std::format] trait for [`Foo`]
             ///
             /// Please be aware of the rendering performance notice in the [`Template`][rinja::Template] trait.
-            impl ::core::fmt::Display for Foo {
+            impl rinja::core::fmt::Display for Foo {
                 #[inline]
-                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    rinja::Template::render_into(self, f).map_err(|_| ::core::fmt::Error)
+                fn fmt(&self, f: &mut rinja::core::fmt::Formatter<'_>) -> rinja::core::fmt::Result {
+                    rinja::Template::render_into(self, f).map_err(|_| rinja::core::fmt::Error)
                 }
             }
 
             impl rinja::filters::FastWritable for Foo {
                 #[inline]
-                fn write_into<RinjaW>(&self, dest: &mut RinjaW) -> ::core::fmt::Result
+                fn write_into<RinjaW>(&self, dest: &mut RinjaW) -> rinja::core::fmt::Result
                 where
-                    RinjaW: ::core::fmt::Write + ?::core::marker::Sized,
+                    RinjaW: rinja::core::fmt::Write + ?rinja::core::marker::Sized,
                 {
-                    rinja::Template::render_into(self, dest).map_err(|_| ::core::fmt::Error)
+                    rinja::Template::render_into(self, dest).map_err(|_| rinja::core::fmt::Error)
                 }
             }
         };
@@ -194,9 +194,9 @@ fn check_if_let() {
     compare(
         r#"{% include "include1.html" %}"#,
         &format!(
-            r#"const _: &[::core::primitive::u8] = ::core::include_bytes!({path1:#?});
-            const _: &[::core::primitive::u8] = ::core::include_bytes!({path2:#?});
-            const _: &[::core::primitive::u8] = ::core::include_bytes!({path3:#?});
+            r#"const _: &[rinja::core::primitive::u8] = rinja::core::include_bytes!({path1:#?});
+            const _: &[rinja::core::primitive::u8] = rinja::core::include_bytes!({path2:#?});
+            const _: &[rinja::core::primitive::u8] = rinja::core::include_bytes!({path3:#?});
             writer.write_str("3333")?;"#
         ),
         &[],
@@ -292,7 +292,7 @@ writer.write_str("bla")?;"#,
         "{% if x == 12 %}bli
          {%- else if x is defined %}12
          {%- else %}nope{% endif %}",
-        r#"if *(&(self.x == 12) as &::core::primitive::bool) {
+        r#"if *(&(self.x == 12) as &rinja::core::primitive::bool) {
 writer.write_str("bli")?;
 } else {
 writer.write_str("12")?;
@@ -305,7 +305,7 @@ writer.write_str("12")?;
     // are present.
     compare(
         "{% if y is defined || x == 12 %}{{x}}{% endif %}",
-        r"if *(&(self.x == 12) as &::core::primitive::bool) {
+        r"if *(&(self.x == 12) as &rinja::core::primitive::bool) {
     match (
         &((&&rinja::filters::AutoEscaper::new(&(self.x), rinja::filters::Text)).rinja_auto_escape()?),
     ) {
@@ -346,7 +346,7 @@ writer.write_str("12")?;
     compare(
         "{% if y is defined && y == 12 %}{{y}}{% else %}bli{% endif %}",
         r#"
-if *(&(self.y == 12) as &::core::primitive::bool) {
+if *(&(self.y == 12) as &rinja::core::primitive::bool) {
     match (
         &((&&rinja::filters::AutoEscaper::new(
             &(self.y),
@@ -417,7 +417,7 @@ match (
     // Ensure that the `!` is kept .
     compare(
         "{% if y is defined && !y %}bla{% endif %}",
-        r#"if *(&(!self.y) as &::core::primitive::bool) {
+        r#"if *(&(!self.y) as &rinja::core::primitive::bool) {
     writer.write_str("bla")?;
 }"#,
         &[("y", "bool")],
@@ -425,7 +425,7 @@ match (
     );
     compare(
         "{% if y is defined && !(y) %}bla{% endif %}",
-        r#"if *(&(!(self.y)) as &::core::primitive::bool) {
+        r#"if *(&(!(self.y)) as &rinja::core::primitive::bool) {
     writer.write_str("bla")?;
 }"#,
         &[("y", "bool")],
@@ -433,7 +433,7 @@ match (
     );
     compare(
         "{% if y is not defined || !y %}bla{% endif %}",
-        r#"if *(&(!self.y) as &::core::primitive::bool) {
+        r#"if *(&(!self.y) as &rinja::core::primitive::bool) {
     writer.write_str("bla")?;
 }"#,
         &[("y", "bool")],
@@ -441,7 +441,7 @@ match (
     );
     compare(
         "{% if y is not defined || !(y) %}bla{% endif %}",
-        r#"if *(&(!(self.y)) as &::core::primitive::bool) {
+        r#"if *(&(!(self.y)) as &rinja::core::primitive::bool) {
     writer.write_str("bla")?;
 }"#,
         &[("y", "bool")],
@@ -506,7 +506,7 @@ fn check_bool_conditions() {
     );
     compare(
         "{% if false || x == 12 %}{{x}}{% endif %}",
-        r"if *(&(self.x == 12) as &::core::primitive::bool) {
+        r"if *(&(self.x == 12) as &rinja::core::primitive::bool) {
     match (
         &((&&rinja::filters::AutoEscaper::new(
             &(self.x),
@@ -530,7 +530,7 @@ fn check_bool_conditions() {
     // condition.
     compare(
         "{% if y == 3 || (true || x == 12) %}{{x}}{% endif %}",
-        r"if *(&(self.y == 3 || (true)) as &::core::primitive::bool) {
+        r"if *(&(self.y == 3 || (true)) as &rinja::core::primitive::bool) {
     match (
         &((&&rinja::filters::AutoEscaper::new(
             &(self.x),
@@ -568,7 +568,7 @@ fn check_bool_conditions() {
     );
     compare(
         "{% if y == 3 || (x == 12 || true) %}{{x}}{% endif %}",
-        r"if *(&(self.y == 3 || (self.x == 12 || true)) as &::core::primitive::bool) {
+        r"if *(&(self.y == 3 || (self.x == 12 || true)) as &rinja::core::primitive::bool) {
     match (
         &((&&rinja::filters::AutoEscaper::new(
             &(self.x),

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -38,7 +38,6 @@ struct Foo {{ {} }}"##,
     };
     let generated: syn::File = syn::parse2(generated).unwrap();
 
-    let size_hint = proc_macro2::Literal::usize_unsuffixed(size_hint);
     let expected: proc_macro2::TokenStream = expected.parse().unwrap();
     let expected: syn::File = syn::parse_quote! {
         const _: () = {
@@ -54,7 +53,8 @@ struct Foo {{ {} }}"##,
                     #expected
                     rinja::Result::Ok(())
                 }
-                const EXTENSION: ::core::option::Option<&'static ::core::primitive::str> = Some("txt");
+                const EXTENSION: ::core::option::Option<&'static ::core::primitive::str> =
+                    ::core::option::Option::Some("txt");
                 const SIZE_HINT: ::core::primitive::usize = #size_hint;
                 const MIME_TYPE: &'static ::core::primitive::str = "text/plain; charset=utf-8";
             }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -17,6 +17,9 @@ rinja = { path = "../rinja", version = "0.3.4" }
 
 serde_json = { version = "1.0", optional = true }
 
+# intentionally shadow the name `::core` to test if the generated code still works fine
+core = { package = "intentionally-empty", version = "1.0.0" }
+
 [dev-dependencies]
 rinja = { path = "../rinja", version = "0.3.4", features = ["code-in-doc", "serde_json"] }
 

--- a/testing/tests/filter_block.rs
+++ b/testing/tests/filter_block.rs
@@ -207,7 +207,7 @@ hello
         {% set y = 12 %}
 
     {% filter wordcount %}
-        {%- include "../Cargo.toml" +%}
+        {%- include "../test_trim.toml" +%}
         y is {{ y }}
     {% endfilter %}
 {%- endblock body %}
@@ -233,7 +233,7 @@ fn filter_block_include() {
     <body class=""><h1>Metadata</h1>
         
 
-    105</body>
+    7</body>
 </html>"#
     );
 }

--- a/testing/tests/no_implicit_prelude.rs
+++ b/testing/tests/no_implicit_prelude.rs
@@ -1,0 +1,15 @@
+#![no_implicit_prelude]
+
+use ::rinja::Template;
+
+#[derive(Template)]
+#[template(path = "hello.html")]
+struct HelloTemplate<'a> {
+    name: &'a str,
+}
+
+#[test]
+fn main() {
+    let hello = HelloTemplate { name: "world" };
+    ::std::assert_eq!("Hello, world!", hello.render().unwrap());
+}


### PR DESCRIPTION
* import an alias `rinja`, so we need less string concatenation at runtime
* work fine in a `#![no_implicit_prelude]` context, even if `std` and/or `core` are shadowed

This PR is done in anticipation of #191, but IMHO it is also a good change on its own.

Once the new feature is added (which probably will take quite some time), we can replace `extern crate #CRATE as rinja` with `use #macro_input as rinja` whereby `macro_input` is the identifier `$crate` of the macro.