### PR TITLE
Acually remove `once_map` dependency

### DIFF
--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -38,7 +38,6 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 memchr = "2"
 mime = "0.3"
 mime_guess = "2"
-once_map = { version = "0.4.18", default-features = false, features = ["std"] }
 proc-macro2 = "1"
 quote = "1"
 rustc-hash = "2.0.0"


### PR DESCRIPTION
It was only removed from `rinja_derive_standalone` before.