### PR TITLE
"object safe" is now "dyn-compatible"

### DIFF
--- a/rinja/src/lib.rs
+++ b/rinja/src/lib.rs
@@ -174,9 +174,11 @@ impl<T: Template + ?Sized> Template for &T {
     const MIME_TYPE: &'static str = T::MIME_TYPE;
 }
 
-/// Object-safe wrapper trait around [`Template`] implementers
+/// [`dyn`-compatible] wrapper trait around [`Template`] implementers
 ///
-/// This trades reduced performance (mostly due to writing into `dyn Write`) for object safety.
+/// This trades reduced performance (mostly due to writing into `dyn Write`) for dyn-compatibility.
+///
+/// [`dyn`-compatible]: <https://doc.rust-lang.org/stable/reference/items/traits.html#object-safety>
 pub trait DynTemplate {
     /// Helper method which allocates a new `String` and renders into it
     fn dyn_render(&self) -> Result<String>;


### PR DESCRIPTION
The phrase was changed in <https://github.com/rust-lang/rust/issues/130852>.