### PR TITLE
Unify trait impl for reference wrapper types

### DIFF
--- a/rinja/src/filters/builtin.rs
+++ b/rinja/src/filters/builtin.rs
@@ -1,6 +1,8 @@
 use std::cell::Cell;
 use std::convert::Infallible;
 use std::fmt::{self, Write};
+use std::ops::Deref;
+use std::pin::Pin;
 
 use super::escape::{FastWritable, HtmlSafeOutput};
 use crate::{Error, Result};
@@ -837,6 +839,19 @@ const _: () = {
             fn is_singular(&self) -> Result<bool, Self::Error> {
                 <T>::is_singular(self)
             }
+        }
+    }
+
+    impl<T> PluralizeCount for Pin<T>
+    where
+        T: Deref,
+        <T as Deref>::Target: PluralizeCount,
+    {
+        type Error = <<T as Deref>::Target as PluralizeCount>::Error;
+
+        #[inline]
+        fn is_singular(&self) -> Result<bool, Self::Error> {
+            self.as_ref().get_ref().is_singular()
         }
     }
 

--- a/rinja/src/filters/builtin.rs
+++ b/rinja/src/filters/builtin.rs
@@ -829,32 +829,15 @@ pub trait PluralizeCount {
 }
 
 const _: () = {
-    // implement PluralizeCount for a list of reference wrapper types to PluralizeCount
-    macro_rules! impl_pluralize_count_for_ref {
-        ($T:ident => $($ty:ty)*) => { $(
-            impl<T: PluralizeCount + ?Sized> PluralizeCount for $ty {
-                type Error = <T as PluralizeCount>::Error;
+    crate::impl_for_ref! {
+        impl PluralizeCount for T {
+            type Error = T::Error;
 
-                #[inline]
-                fn is_singular(&self) -> Result<bool, Self::Error> {
-                    <T as PluralizeCount>::is_singular(self)
-                }
+            #[inline]
+            fn is_singular(&self) -> Result<bool, Self::Error> {
+                <T>::is_singular(self)
             }
-        )* };
-    }
-
-    impl_pluralize_count_for_ref! {
-        T =>
-        &T
-        Box<T>
-        std::cell::Ref<'_, T>
-        std::cell::RefMut<'_, T>
-        std::pin::Pin<&T>
-        std::rc::Rc<T>
-        std::sync::Arc<T>
-        std::sync::MutexGuard<'_, T>
-        std::sync::RwLockReadGuard<'_, T>
-        std::sync::RwLockWriteGuard<'_, T>
+        }
     }
 
     /// implement `PluralizeCount` for unsigned integer types

--- a/rinja/src/filters/escape.rs
+++ b/rinja/src/filters/escape.rs
@@ -1,5 +1,7 @@
 use std::convert::Infallible;
 use std::fmt::{self, Formatter, Write};
+use std::ops::Deref;
+use std::pin::Pin;
 use std::{borrow, str};
 
 /// Marks a string (or other `Display` type) as safe
@@ -508,6 +510,17 @@ const _: () = {
             fn write_into<W: fmt::Write + ?Sized>(&self, dest: &mut W) -> fmt::Result {
                 <T>::write_into(self, dest)
             }
+        }
+    }
+
+    impl<T> FastWritable for Pin<T>
+    where
+        T: Deref,
+        <T as Deref>::Target: FastWritable,
+    {
+        #[inline]
+        fn write_into<W: fmt::Write + ?Sized>(&self, dest: &mut W) -> fmt::Result {
+            self.as_ref().get_ref().write_into(dest)
         }
     }
 

--- a/rinja/src/filters/escape.rs
+++ b/rinja/src/filters/escape.rs
@@ -502,30 +502,13 @@ pub trait FastWritable {
 }
 
 const _: () = {
-    // implement FastWritable for a list of reference wrapper types to FastWritable+?Sized
-    macro_rules! impl_for_ref {
-        ($T:ident => $($ty:ty)*) => { $(
-            impl<$T: FastWritable + ?Sized> FastWritable for $ty {
-                #[inline]
-                fn write_into<W: fmt::Write + ?Sized>(&self, dest: &mut W) -> fmt::Result {
-                    <$T>::write_into(self, dest)
-                }
+    crate::impl_for_ref! {
+        impl FastWritable for T {
+            #[inline]
+            fn write_into<W: fmt::Write + ?Sized>(&self, dest: &mut W) -> fmt::Result {
+                <T>::write_into(self, dest)
             }
-        )* };
-    }
-
-    impl_for_ref! {
-        T =>
-        &T
-        Box<T>
-        std::cell::Ref<'_, T>
-        std::cell::RefMut<'_, T>
-        std::pin::Pin<&T>
-        std::rc::Rc<T>
-        std::sync::Arc<T>
-        std::sync::MutexGuard<'_, T>
-        std::sync::RwLockReadGuard<'_, T>
-        std::sync::RwLockWriteGuard<'_, T>
+        }
     }
 
     impl<T: FastWritable + ToOwned> FastWritable for borrow::Cow<'_, T> {

--- a/rinja/src/filters/json.rs
+++ b/rinja/src/filters/json.rs
@@ -1,4 +1,6 @@
 use std::convert::Infallible;
+use std::ops::Deref;
+use std::pin::Pin;
 use std::{fmt, io, str};
 
 use serde::Serialize;
@@ -150,6 +152,17 @@ crate::impl_for_ref! {
         fn as_indent(&self) -> &str {
             <T>::as_indent(self)
         }
+    }
+}
+
+impl<T> AsIndent for Pin<T>
+where
+    T: Deref,
+    <T as Deref>::Target: AsIndent,
+{
+    #[inline]
+    fn as_indent(&self) -> &str {
+        self.as_ref().get_ref().as_indent()
     }
 }
 

--- a/rinja/src/filters/json.rs
+++ b/rinja/src/filters/json.rs
@@ -144,30 +144,13 @@ impl<T: AsIndent + ToOwned + ?Sized> AsIndent for std::borrow::Cow<'_, T> {
     }
 }
 
-// implement AsIdent for a list of reference wrapper types to AsIdent
-macro_rules! impl_as_ident_for_ref {
-    ($T:ident => $($ty:ty)*) => { $(
-        impl<T: AsIndent + ?Sized> AsIndent for $ty {
-            #[inline]
-            fn as_indent(&self) -> &str {
-                <T>::as_indent(self)
-            }
+crate::impl_for_ref! {
+    impl AsIndent for T {
+        #[inline]
+        fn as_indent(&self) -> &str {
+            <T>::as_indent(self)
         }
-    )* };
-}
-
-impl_as_ident_for_ref! {
-    T =>
-    &T
-    Box<T>
-    std::cell::Ref<'_, T>
-    std::cell::RefMut<'_, T>
-    std::pin::Pin<&T>
-    std::rc::Rc<T>
-    std::sync::Arc<T>
-    std::sync::MutexGuard<'_, T>
-    std::sync::RwLockReadGuard<'_, T>
-    std::sync::RwLockWriteGuard<'_, T>
+    }
 }
 
 impl<S: Serialize> FastWritable for ToJson<S> {

--- a/rinja/src/helpers.rs
+++ b/rinja/src/helpers.rs
@@ -132,6 +132,28 @@ crate::impl_for_ref! {
     }
 }
 
+/// Implement [`PrimitiveType`] for [`Cell<T>`]
+///
+/// ```
+/// # use std::cell::Cell;
+/// # use rinja::Template;
+/// #[derive(Template)]
+/// #[template(ext = "txt", source = "{{ value as u16 }}")]
+/// struct Test<'a> {
+///     value: &'a Cell<i16>
+/// }
+///
+/// assert_eq!(Test { value: &Cell::new(-1) }.to_string(), "65535");
+/// ```
+impl<T: PrimitiveType + Copy> PrimitiveType for Cell<T> {
+    type Value = T::Value;
+
+    #[inline]
+    fn get(&self) -> Self::Value {
+        self.get().get()
+    }
+}
+
 /// An empty element, so nothing will be written.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Empty;

--- a/rinja/src/helpers.rs
+++ b/rinja/src/helpers.rs
@@ -95,19 +95,10 @@ pub fn get_primitive_value<T: PrimitiveType>(value: &T) -> T::Value {
     value.get()
 }
 
-pub trait PrimitiveType: Copy {
-    type Value: Copy;
+pub trait PrimitiveType {
+    type Value;
 
-    fn get(self) -> Self::Value;
-}
-
-impl<T: PrimitiveType> PrimitiveType for &T {
-    type Value = T::Value;
-
-    #[inline]
-    fn get(self) -> Self::Value {
-        T::get(*self)
-    }
+    fn get(&self) -> Self::Value;
 }
 
 macro_rules! primitive_type {
@@ -116,8 +107,8 @@ macro_rules! primitive_type {
             type Value = $ty;
 
             #[inline]
-            fn get(self) -> Self::Value {
-                self
+            fn get(&self) -> Self::Value {
+                *self
             }
         }
     )*};
@@ -128,6 +119,17 @@ primitive_type! {
     f32, f64,
     i8, i16, i32, i64, i128, isize,
     u8, u16, u32, u64, u128, usize,
+}
+
+crate::impl_for_ref! {
+    impl PrimitiveType for T {
+        type Value = T::Value;
+
+        #[inline]
+        fn get(&self) -> Self::Value {
+            <T>::get(self)
+        }
+    }
 }
 
 /// An empty element, so nothing will be written.

--- a/rinja/src/lib.rs
+++ b/rinja/src/lib.rs
@@ -240,8 +240,6 @@ macro_rules! impl_for_ref {
                 Box<T>
                 std::cell::Ref<'_, T>
                 std::cell::RefMut<'_, T>
-                std::pin::Pin<&T>
-                std::pin::Pin<&mut T>
                 std::rc::Rc<T>
                 std::sync::Arc<T>
                 std::sync::MutexGuard<'_, T>
@@ -250,9 +248,9 @@ macro_rules! impl_for_ref {
             ] $body
         }
     };
-    (impl<$T:ident> $Trait:ident for [$($ty:ty)*] $body:tt) => { $(
-        impl<$T: $Trait + ?Sized> $Trait for $ty $body
-    )+ }
+    (impl<$T:ident> $Trait:ident for [$($ty:ty)*] $body:tt) => {
+        $(impl<$T: $Trait + ?Sized> $Trait for $ty $body)*
+    }
 }
 
 pub(crate) use impl_for_ref;

--- a/rinja/src/lib.rs
+++ b/rinja/src/lib.rs
@@ -230,6 +230,33 @@ impl fmt::Display for dyn DynTemplate {
     }
 }
 
+/// Implement the trait `$Trait` for a list of reference (wrapper) types to `$T: $Trait + ?Sized`
+macro_rules! impl_for_ref {
+    (impl $Trait:ident for $T:ident $body:tt) => {
+        crate::impl_for_ref! {
+            impl<$T> $Trait for [
+                &T
+                &mut T
+                Box<T>
+                std::cell::Ref<'_, T>
+                std::cell::RefMut<'_, T>
+                std::pin::Pin<&T>
+                std::pin::Pin<&mut T>
+                std::rc::Rc<T>
+                std::sync::Arc<T>
+                std::sync::MutexGuard<'_, T>
+                std::sync::RwLockReadGuard<'_, T>
+                std::sync::RwLockWriteGuard<'_, T>
+            ] $body
+        }
+    };
+    (impl<$T:ident> $Trait:ident for [$($ty:ty)*] $body:tt) => { $(
+        impl<$T: $Trait + ?Sized> $Trait for $ty $body
+    )+ }
+}
+
+pub(crate) use impl_for_ref;
+
 #[cfg(test)]
 mod tests {
     use std::fmt;

--- a/testing/tests/ui/pluralize.stderr
+++ b/testing/tests/ui/pluralize.stderr
@@ -6,13 +6,13 @@ error[E0277]: the trait bound `str: PluralizeCount` is not satisfied
   |
   = help: the following other types implement trait `PluralizeCount`:
             &T
+            &mut T
             Arc<T>
             Box<T>
             MutexGuard<'_, T>
             NonZero<i128>
             NonZero<i16>
             NonZero<i32>
-            NonZero<i64>
           and $N others
   = note: required for `&str` to implement `PluralizeCount`
   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This changes makes sure that no implementation is forgotten and deduplicates some code.