### PR TITLE
derive: in complex conditions, wrap terms in `as_bool()`

### DIFF
--- a/rinja/src/helpers.rs
+++ b/rinja/src/helpers.rs
@@ -147,3 +147,8 @@ impl FastWritable for Empty {
         Ok(())
     }
 }
+
+#[inline]
+pub fn as_bool<T: PrimitiveType<Value = bool>>(value: T) -> bool {
+    value.get()
+}

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -645,14 +645,9 @@ impl<'a> Generator<'a> {
                         }
                         buf.write(format_args!("= &{} {{", expr_buf.buf));
                     } else if cond_info.generate_condition {
-                        // The following syntax `*(&(...) as &bool)` is used to
-                        // trigger Rust's automatic dereferencing, to coerce
-                        // e.g. `&&&&&bool` to `bool`. First `&(...) as &bool`
-                        // coerces e.g. `&&&bool` to `&bool`. Then `*(&bool)`
-                        // finally dereferences it to `bool`.
-                        buf.write("*(&(");
+                        buf.write("rinja::helpers::as_bool(&(");
                         buf.write(this.visit_expr_root(ctx, expr)?);
-                        buf.write(") as &rinja::helpers::core::primitive::bool) {");
+                        buf.write(")) {");
                     }
                 } else if pos != 0 {
                     buf.write("} else {");

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -293,7 +293,7 @@ writer.write_str("bla")?;"#,
         "{% if x == 12 %}bli
          {%- else if x is defined %}12
          {%- else %}nope{% endif %}",
-        r#"if *(&(self.x == 12) as &rinja::helpers::core::primitive::bool) {
+        r#"if rinja::helpers::as_bool(&(self.x == 12)) {
 writer.write_str("bli")?;
 } else {
 writer.write_str("12")?;
@@ -306,7 +306,7 @@ writer.write_str("12")?;
     // are present.
     compare(
         "{% if y is defined || x == 12 %}{{x}}{% endif %}",
-        r"if *(&(self.x == 12) as &rinja::helpers::core::primitive::bool) {
+        r"if rinja::helpers::as_bool(&(self.x == 12)) {
     match (
         &((&&rinja::filters::AutoEscaper::new(&(self.x), rinja::filters::Text)).rinja_auto_escape()?),
     ) {
@@ -347,7 +347,7 @@ writer.write_str("12")?;
     compare(
         "{% if y is defined && y == 12 %}{{y}}{% else %}bli{% endif %}",
         r#"
-if *(&(self.y == 12) as &rinja::helpers::core::primitive::bool) {
+if rinja::helpers::as_bool(&(self.y == 12)) {
     match (
         &((&&rinja::filters::AutoEscaper::new(
             &(self.y),
@@ -418,7 +418,7 @@ match (
     // Ensure that the `!` is kept .
     compare(
         "{% if y is defined && !y %}bla{% endif %}",
-        r#"if *(&(!self.y) as &rinja::helpers::core::primitive::bool) {
+        r#"if rinja::helpers::as_bool(&(!self.y)) {
     writer.write_str("bla")?;
 }"#,
         &[("y", "bool")],
@@ -426,7 +426,7 @@ match (
     );
     compare(
         "{% if y is defined && !(y) %}bla{% endif %}",
-        r#"if *(&(!(self.y)) as &rinja::helpers::core::primitive::bool) {
+        r#"if rinja::helpers::as_bool(&(!(self.y))) {
     writer.write_str("bla")?;
 }"#,
         &[("y", "bool")],
@@ -434,7 +434,7 @@ match (
     );
     compare(
         "{% if y is not defined || !y %}bla{% endif %}",
-        r#"if *(&(!self.y) as &rinja::helpers::core::primitive::bool) {
+        r#"if rinja::helpers::as_bool(&(!self.y)) {
     writer.write_str("bla")?;
 }"#,
         &[("y", "bool")],
@@ -442,7 +442,7 @@ match (
     );
     compare(
         "{% if y is not defined || !(y) %}bla{% endif %}",
-        r#"if *(&(!(self.y)) as &rinja::helpers::core::primitive::bool) {
+        r#"if rinja::helpers::as_bool(&(!(self.y))) {
     writer.write_str("bla")?;
 }"#,
         &[("y", "bool")],
@@ -507,7 +507,7 @@ fn check_bool_conditions() {
     );
     compare(
         "{% if false || x == 12 %}{{x}}{% endif %}",
-        r"if *(&(self.x == 12) as &rinja::helpers::core::primitive::bool) {
+        r"if rinja::helpers::as_bool(&(self.x == 12)) {
     match (
         &((&&rinja::filters::AutoEscaper::new(
             &(self.x),
@@ -531,7 +531,7 @@ fn check_bool_conditions() {
     // condition.
     compare(
         "{% if y == 3 || (true || x == 12) %}{{x}}{% endif %}",
-        r"if *(&(self.y == 3 || (true)) as &rinja::helpers::core::primitive::bool) {
+        r"if rinja::helpers::as_bool(&(self.y == 3 || (true))) {
     match (
         &((&&rinja::filters::AutoEscaper::new(
             &(self.x),
@@ -569,7 +569,7 @@ fn check_bool_conditions() {
     );
     compare(
         "{% if y == 3 || (x == 12 || true) %}{{x}}{% endif %}",
-        r"if *(&(self.y == 3 || (self.x == 12 || true)) as &rinja::helpers::core::primitive::bool) {
+        r"if rinja::helpers::as_bool(&(self.y == 3 || (self.x == 12 || true))) {
     match (
         &((&&rinja::filters::AutoEscaper::new(
             &(self.x),

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -600,6 +600,17 @@ fn check_bool_conditions() {
         &[],
         3,
     );
+
+    // Complex condition
+    compare(
+        "{% if (a || !b) && !(c || !d) %}x{% endif %}",
+        r#"
+            if rinja::helpers::as_bool(&((self.a || !self.b) && !(self.c || !self.d))) {
+                writer.write_str("x")?;
+            }"#,
+        &[("a", "i32"), ("b", "i32"), ("c", "i32"), ("d", "i32")],
+        1,
+    );
 }
 
 #[test]


### PR DESCRIPTION
Before this PR, the whole condition in `{% if cond %}` got wrapped in `as_bool(&cond)`. With is PR, the individual terms in a binary operation `&&` or `||`, or unary operation `!` get wrapped in `as_bool()`.

Resolves #201.