### PR TITLE
Migrate to from Nom 7 to Winnow 0.3

### DIFF
--- a/rinja_parser/Cargo.toml
+++ b/rinja_parser/Cargo.toml
@@ -22,8 +22,8 @@ config = ["dep:serde"]
 
 [dependencies]
 memchr = "2"
-nom = { version = "7", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
+winnow = "0.3"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -1,14 +1,14 @@
 use std::collections::HashSet;
 use std::str;
 
+use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::complete::take_till;
 use winnow::character::complete::digit1;
 use winnow::combinator::{consumed, cut, fail, map, not, opt, peek, recognize, value};
-use winnow::error::ErrorKind;
+use winnow::error::{ErrorKind, ParseError as _};
 use winnow::multi::{fold_many0, many0, separated_list0, separated_list1};
 use winnow::sequence::{preceded, terminated};
-use winnow::{Parser, error_position};
 
 use crate::{
     CharLit, ErrorContext, Level, Num, ParseResult, PathOrIdentifier, StrLit, WithSpan, char_lit,
@@ -462,7 +462,7 @@ impl<'a> Suffix<'a> {
                 Some(Self::MacroCall(args)) => match expr.inner {
                     Expr::Path(path) => expr = WithSpan::new(Expr::RustMacro(path, args), i),
                     Expr::Var(name) => expr = WithSpan::new(Expr::RustMacro(vec![name], args), i),
-                    _ => return Err(winnow::Err::Cut(error_position!(i, ErrorKind::Tag))),
+                    _ => return Err(winnow::Err::from_error_kind(i, ErrorKind::Tag).cut()),
                 },
                 None => break,
             }

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -4,7 +4,7 @@ use std::str;
 use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::take_till0;
-use winnow::character::complete::digit1;
+use winnow::character::digit1;
 use winnow::combinator::{consumed, cut_err, fail, map, not, opt, peek, recognize, value};
 use winnow::error::{ErrorKind, ParseError as _};
 use winnow::multi::{fold_many0, many0, separated0, separated1};

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -3,7 +3,7 @@ use std::str;
 
 use winnow::Parser;
 use winnow::branch::alt;
-use winnow::bytes::complete::take_till;
+use winnow::bytes::take_till0;
 use winnow::character::complete::digit1;
 use winnow::combinator::{consumed, cut_err, fail, map, not, opt, peek, recognize, value};
 use winnow::error::{ErrorKind, ParseError as _};
@@ -558,6 +558,6 @@ impl<'a> Suffix<'a> {
     }
 
     fn r#try(i: &'a str) -> ParseResult<'a, Self> {
-        map(preceded(take_till(not_ws), '?'), |_| Self::Try).parse_next(i)
+        map(preceded(take_till0(not_ws), '?'), |_| Self::Try).parse_next(i)
     }
 }

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -7,7 +7,7 @@ use winnow::bytes::complete::take_till;
 use winnow::character::complete::digit1;
 use winnow::combinator::{consumed, cut_err, fail, map, not, opt, peek, recognize, value};
 use winnow::error::{ErrorKind, ParseError as _};
-use winnow::multi::{fold_many0, many0, separated_list0, separated_list1};
+use winnow::multi::{fold_many0, many0, separated0, separated1};
 use winnow::sequence::{preceded, terminated};
 
 use crate::{
@@ -83,8 +83,7 @@ impl<'a> Expr<'a> {
         preceded(
             ws('('),
             cut_err(terminated(
-                separated_list0(
-                    ',',
+                separated0(
                     ws(move |i| {
                         // Needed to prevent borrowing it twice between this closure and the one
                         // calling `Self::named_arguments`.
@@ -113,6 +112,7 @@ impl<'a> Expr<'a> {
                             Ok((i, expr))
                         }
                     }),
+                    ',',
                 ),
                 (opt(ws(',')), ')'),
             )),
@@ -324,7 +324,7 @@ impl<'a> Expr<'a> {
             ws('['),
             cut_err(terminated(
                 opt(terminated(
-                    separated_list1(',', ws(move |i| Self::parse(i, level))),
+                    separated1(ws(move |i| Self::parse(i, level)), ','),
                     ws(opt(',')),
                 )),
                 ']',

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -5,7 +5,7 @@ use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::take_till0;
 use winnow::character::digit1;
-use winnow::combinator::{consumed, cut_err, fail, map, not, opt, peek, value};
+use winnow::combinator::{cut_err, fail, map, not, opt, peek, value};
 use winnow::error::{ErrorKind, ParseError as _};
 use winnow::multi::{fold_many0, many0, separated0, separated1};
 use winnow::sequence::{preceded, terminated};
@@ -356,7 +356,7 @@ impl<'a> Expr<'a> {
 
     fn num(i: &'a str) -> ParseResult<'a, WithSpan<'a, Self>> {
         let start = i;
-        let (i, (full, num)) = consumed(num_lit).parse_next(i)?;
+        let (i, (num, full)) = num_lit.with_recognized().parse_next(i)?;
         Ok((i, WithSpan::new(Expr::NumLit(full, num), start)))
     }
 

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -5,7 +5,7 @@ use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::take_till0;
 use winnow::character::digit1;
-use winnow::combinator::{consumed, cut_err, fail, map, not, opt, peek, recognize, value};
+use winnow::combinator::{consumed, cut_err, fail, map, not, opt, peek, value};
 use winnow::error::{ErrorKind, ParseError as _};
 use winnow::multi::{fold_many0, many0, separated0, separated1};
 use winnow::sequence::{preceded, terminated};
@@ -525,7 +525,7 @@ impl<'a> Suffix<'a> {
         preceded(
             (ws('!'), '('),
             cut_err(terminated(
-                map(recognize(nested_parenthesis), Self::MacroCall),
+                map(nested_parenthesis.recognize(), Self::MacroCall),
                 ')',
             )),
         )

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -7,7 +7,7 @@ use winnow::character::complete::digit1;
 use winnow::combinator::{consumed, cut, fail, map, not, opt, peek, recognize, value};
 use winnow::error::ErrorKind;
 use winnow::multi::{fold_many0, many0, separated_list0, separated_list1};
-use winnow::sequence::{pair, preceded, terminated, tuple};
+use winnow::sequence::{pair, preceded, terminated};
 use winnow::{Parser, error_position};
 
 use crate::{
@@ -114,7 +114,7 @@ impl<'a> Expr<'a> {
                         }
                     }),
                 ),
-                tuple((opt(ws(',')), ')')),
+                (opt(ws(',')), ')'),
             )),
         )
         .parse_next(i)
@@ -135,7 +135,7 @@ impl<'a> Expr<'a> {
 
         let (_, level) = level.nest(i)?;
         let (i, (argument, _, value)) =
-            tuple((identifier, ws('='), move |i| Self::parse(i, level))).parse_next(i)?;
+            (identifier, ws('='), move |i| Self::parse(i, level)).parse_next(i)?;
         if named_arguments.insert(argument) {
             Ok((
                 i,

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -12,8 +12,8 @@ use std::{fmt, str};
 
 use winnow::Parser;
 use winnow::branch::alt;
-use winnow::bytes::any;
-use winnow::bytes::complete::{escaped, is_not, tag, take_till, take_while_m_n, take_while1};
+use winnow::bytes::complete::{escaped, tag, take_till, take_while_m_n, take_while1};
+use winnow::bytes::{any, take_till1};
 use winnow::character::complete::{one_of, satisfy};
 use winnow::combinator::{consumed, cut_err, fail, map, not, opt, recognize, value};
 use winnow::error::{ErrorKind, FromExternalError};
@@ -479,7 +479,7 @@ pub struct StrLit<'a> {
 }
 
 fn str_lit_without_prefix(i: &str) -> ParseResult<'_> {
-    let (i, s) = delimited('"', opt(escaped(is_not("\\\""), '\\', any)), '"').parse_next(i)?;
+    let (i, s) = delimited('"', opt(escaped(take_till1("\\\""), '\\', any)), '"').parse_next(i)?;
     Ok((i, s.unwrap_or_default()))
 }
 
@@ -510,7 +510,7 @@ fn char_lit(i: &str) -> Result<(&str, CharLit<'_>), ParseErr<'_>> {
     let start = i;
     let (i, (b_prefix, s)) = (
         opt('b'),
-        delimited('\'', opt(escaped(is_not("\\\'"), '\\', any)), '\''),
+        delimited('\'', opt(escaped(take_till1("\\\'"), '\\', any)), '\''),
     )
         .parse_next(i)?;
 

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -14,7 +14,7 @@ use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::complete::{escaped, tag, take_while_m_n, take_while1};
 use winnow::bytes::{any, take_till0, take_till1};
-use winnow::character::complete::{one_of, satisfy};
+use winnow::character::complete::one_of;
 use winnow::combinator::{consumed, cut_err, fail, map, not, opt, recognize, value};
 use winnow::error::{ErrorKind, FromExternalError};
 use winnow::multi::{many0, many1};
@@ -441,8 +441,8 @@ fn separated_digits(radix: u32, start: bool) -> impl Fn(&str) -> ParseResult<'_>
                 true => Ok((i, ())),
                 false => many0('_').parse_next(i),
             },
-            satisfy(|ch| ch.is_digit(radix)),
-            many0(satisfy(|ch| ch == '_' || ch.is_digit(radix))).map(|()| ()),
+            one_of(|ch: char| ch.is_digit(radix)),
+            many0(one_of(|ch: char| ch == '_' || ch.is_digit(radix))).map(|()| ()),
         ))
         .parse_next(i)
     }

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -12,9 +12,8 @@ use std::{fmt, str};
 
 use winnow::Parser;
 use winnow::branch::alt;
-use winnow::bytes::complete::{escaped, tag, take_while_m_n, take_while1};
-use winnow::bytes::{any, take_till0, take_till1};
-use winnow::character::complete::one_of;
+use winnow::bytes::{any, one_of, tag, take_till0, take_till1, take_while_m_n, take_while1};
+use winnow::character::escaped;
 use winnow::combinator::{consumed, cut_err, fail, map, not, opt, recognize, value};
 use winnow::error::{ErrorKind, FromExternalError};
 use winnow::multi::{many0, many1};

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -286,8 +286,8 @@ fn not_ws(c: char) -> bool {
 }
 
 fn ws<'a, O>(
-    inner: impl FnMut(&'a str) -> ParseResult<'a, O>,
-) -> impl FnMut(&'a str) -> ParseResult<'a, O> {
+    inner: impl Parser<&'a str, O, ErrorContext<'a>>,
+) -> impl Parser<&'a str, O, ErrorContext<'a>> {
     delimited(take_till(not_ws), inner, take_till(not_ws))
 }
 
@@ -295,8 +295,8 @@ fn ws<'a, O>(
 /// Returns tuple that would be returned when parsing `end`.
 fn skip_till<'a, 'b, O>(
     candidate_finder: impl crate::memchr_splitter::Splitter,
-    end: impl FnMut(&'a str) -> ParseResult<'a, O>,
-) -> impl FnMut(&'a str) -> ParseResult<'a, (&'a str, O)> {
+    end: impl Parser<&'a str, O, ErrorContext<'a>>,
+) -> impl Parser<&'a str, (&'a str, O), ErrorContext<'a>> {
     let mut next = alt((map(end, Some), map(anychar, |_| None)));
     move |start: &'a str| {
         let mut i = start;
@@ -318,7 +318,7 @@ fn skip_till<'a, 'b, O>(
     }
 }
 
-fn keyword<'a>(k: &'a str) -> impl FnMut(&'a str) -> ParseResult<'a> {
+fn keyword<'a>(k: &'a str) -> impl Parser<&'a str, &'a str, ErrorContext<'a>> {
     move |i: &'a str| -> ParseResult<'a> {
         let (j, v) = identifier.parse_next(i)?;
         if k == v { Ok((j, v)) } else { fail(i) }

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -16,7 +16,7 @@ use winnow::bytes::complete::{escaped, is_not, tag, take_till, take_while_m_n, t
 use winnow::character::complete::{anychar, one_of, satisfy};
 use winnow::combinator::{consumed, cut, fail, map, not, opt, recognize, value};
 use winnow::error::{ErrorKind, FromExternalError};
-use winnow::multi::{many0_count, many1};
+use winnow::multi::{many0, many1};
 use winnow::sequence::{delimited, preceded};
 use winnow::stream::AsChar;
 
@@ -437,11 +437,11 @@ fn separated_digits(radix: u32, start: bool) -> impl Fn(&str) -> ParseResult<'_>
     move |i| {
         recognize((
             |i| match start {
-                true => Ok((i, 0)),
-                false => many0_count('_').parse_next(i),
+                true => Ok((i, ())),
+                false => many0('_').parse_next(i),
             },
             satisfy(|ch| ch.is_digit(radix)),
-            many0_count(satisfy(|ch| ch == '_' || ch.is_digit(radix))),
+            many0(satisfy(|ch| ch == '_' || ch.is_digit(radix))).map(|()| ()),
         ))
         .parse_next(i)
     }

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -14,7 +14,7 @@ use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::complete::{escaped, is_not, tag, take_till, take_while_m_n, take_while1};
 use winnow::character::complete::{anychar, one_of, satisfy};
-use winnow::combinator::{consumed, cut, fail, map, not, opt, recognize, value};
+use winnow::combinator::{consumed, cut_err, fail, map, not, opt, recognize, value};
 use winnow::error::{ErrorKind, FromExternalError};
 use winnow::multi::{many0, many1};
 use winnow::sequence::{delimited, preceded};
@@ -885,7 +885,7 @@ fn filter<'a>(
 
     if !had_spaces {
         *level = level.nest(i)?.1;
-        cut((ws(identifier), opt(|i| Expr::arguments(i, *level, false)))).parse_next(j)
+        cut_err((ws(identifier), opt(|i| Expr::arguments(i, *level, false)))).parse_next(j)
     } else {
         Err(winnow::error::ErrMode::Cut(ErrorContext::new(
             "the filter operator `|` must not be preceded by any whitespace characters\n\

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -12,8 +12,9 @@ use std::{fmt, str};
 
 use winnow::Parser;
 use winnow::branch::alt;
+use winnow::bytes::any;
 use winnow::bytes::complete::{escaped, is_not, tag, take_till, take_while_m_n, take_while1};
-use winnow::character::complete::{anychar, one_of, satisfy};
+use winnow::character::complete::{one_of, satisfy};
 use winnow::combinator::{consumed, cut_err, fail, map, not, opt, recognize, value};
 use winnow::error::{ErrorKind, FromExternalError};
 use winnow::multi::{many0, many1};
@@ -297,7 +298,7 @@ fn skip_till<'a, 'b, O>(
     candidate_finder: impl crate::memchr_splitter::Splitter,
     end: impl Parser<&'a str, O, ErrorContext<'a>>,
 ) -> impl Parser<&'a str, (&'a str, O), ErrorContext<'a>> {
-    let mut next = alt((map(end, Some), map(anychar, |_| None)));
+    let mut next = alt((map(end, Some), map(any, |_| None)));
     move |start: &'a str| {
         let mut i = start;
         loop {
@@ -478,7 +479,7 @@ pub struct StrLit<'a> {
 }
 
 fn str_lit_without_prefix(i: &str) -> ParseResult<'_> {
-    let (i, s) = delimited('"', opt(escaped(is_not("\\\""), '\\', anychar)), '"').parse_next(i)?;
+    let (i, s) = delimited('"', opt(escaped(is_not("\\\""), '\\', any)), '"').parse_next(i)?;
     Ok((i, s.unwrap_or_default()))
 }
 
@@ -509,7 +510,7 @@ fn char_lit(i: &str) -> Result<(&str, CharLit<'_>), ParseErr<'_>> {
     let start = i;
     let (i, (b_prefix, s)) = (
         opt('b'),
-        delimited('\'', opt(escaped(is_not("\\\'"), '\\', anychar)), '\''),
+        delimited('\'', opt(escaped(is_not("\\\'"), '\\', any)), '\''),
     )
         .parse_next(i)?;
 

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -616,7 +616,7 @@ impl<'a> Char<'a> {
                     ),
                     map(
                         tuple((
-                            tag("u{"),
+                            "u{",
                             take_while_m_n(1, 6, |c: char| c.is_ascii_hexdigit()),
                             char('}'),
                         )),
@@ -636,8 +636,8 @@ enum PathOrIdentifier<'a> {
 }
 
 fn path_or_identifier(i: &str) -> ParseResult<'_, PathOrIdentifier<'_>> {
-    let root = ws(opt(tag("::")));
-    let tail = opt(many1(preceded(ws(tag("::")), identifier)).map(|v: Vec<_>| v));
+    let root = ws(opt("::"));
+    let tail = opt(many1(preceded(ws("::"), identifier)).map(|v: Vec<_>| v));
 
     let (i, (root, start, rest)) = tuple((root, identifier, tail)).parse_next(i)?;
     let rest = rest.as_deref().unwrap_or_default();

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -12,8 +12,8 @@ use std::{fmt, str};
 
 use winnow::Parser;
 use winnow::branch::alt;
-use winnow::bytes::complete::{escaped, tag, take_till, take_while_m_n, take_while1};
-use winnow::bytes::{any, take_till1};
+use winnow::bytes::complete::{escaped, tag, take_while_m_n, take_while1};
+use winnow::bytes::{any, take_till0, take_till1};
 use winnow::character::complete::{one_of, satisfy};
 use winnow::combinator::{consumed, cut_err, fail, map, not, opt, recognize, value};
 use winnow::error::{ErrorKind, FromExternalError};
@@ -289,7 +289,7 @@ fn not_ws(c: char) -> bool {
 fn ws<'a, O>(
     inner: impl Parser<&'a str, O, ErrorContext<'a>>,
 ) -> impl Parser<&'a str, O, ErrorContext<'a>> {
-    delimited(take_till(not_ws), inner, take_till(not_ws))
+    delimited(take_till0(not_ws), inner, take_till0(not_ws))
 }
 
 /// Skips input until `end` was found, but does not consume it.
@@ -880,7 +880,7 @@ fn filter<'a>(
     i: &'a str,
     level: &mut Level,
 ) -> ParseResult<'a, (&'a str, Option<Vec<WithSpan<'a, Expr<'a>>>>)> {
-    let (j, _) = take_till(not_ws).parse_next(i)?;
+    let (j, _) = take_till0(not_ws).parse_next(i)?;
     let had_spaces = i.len() != j.len();
     let (j, _) = ('|', not('|')).parse_next(j)?;
 

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -797,7 +797,7 @@ impl<'a> Call<'a> {
             cut_node(
                 Some("call"),
                 tuple((
-                    opt(tuple((ws(identifier), ws(tag("::"))))),
+                    opt(tuple((ws(identifier), ws("::")))),
                     ws(identifier),
                     opt(ws(|nested| Expr::arguments(nested, s.level.get(), true))),
                     opt(Whitespace::parse),

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -7,7 +7,7 @@ use winnow::character::complete::anychar;
 use winnow::combinator::{
     consumed, cut_err, eof, fail, map, map_opt, not, opt, peek, recognize, value,
 };
-use winnow::multi::{many0, separated_list0, separated_list1};
+use winnow::multi::{many0, separated0, separated1};
 use winnow::sequence::{delimited, preceded};
 
 use crate::memchr_splitter::{Splitter1, Splitter2, Splitter3};
@@ -332,7 +332,7 @@ impl<'a> When<'a> {
             cut_node(
                 Some("match-when"),
                 (
-                    separated_list1('|', ws(|i| Target::parse(i, s))),
+                    separated1(ws(|i| Target::parse(i, s)), '|'),
                     opt(Whitespace::parse),
                     |i| s.tag_block_end(i),
                     cut_node(Some("match-when"), |i| Node::many(i, s)),
@@ -595,7 +595,7 @@ impl<'a> Macro<'a> {
         fn parameters(i: &str) -> ParseResult<'_, Vec<&str>> {
             delimited(
                 ws('('),
-                separated_list0(',', ws(identifier)),
+                separated0(ws(identifier), ','),
                 (opt(ws(',')), ')'),
             )
             .parse_next(i)

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -3,9 +3,7 @@ use std::str;
 use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::{any, tag, take_till0};
-use winnow::combinator::{
-    consumed, cut_err, eof, fail, map, map_opt, not, opt, peek, recognize, value,
-};
+use winnow::combinator::{consumed, cut_err, eof, fail, map, map_opt, not, opt, peek, value};
 use winnow::multi::{many0, separated0, separated1};
 use winnow::sequence::{delimited, preceded};
 
@@ -1007,7 +1005,7 @@ impl<'a> Lit<'a> {
             tag(s.syntax.expr_start),
         ));
 
-        let (i, content) = opt(recognize(skip_till(candidate_finder, p_start))).parse_next(i)?;
+        let (i, content) = opt(skip_till(candidate_finder, p_start).recognize()).parse_next(i)?;
         let (i, content) = match content {
             Some("") => {
                 // {block,comment,expr}_start follows immediately.

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -3,7 +3,7 @@ use std::str;
 use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::complete::{tag, take_till};
-use winnow::character::complete::{anychar, char};
+use winnow::character::complete::anychar;
 use winnow::combinator::{
     complete, consumed, cut, eof, fail, map, map_opt, not, opt, peek, recognize, value,
 };
@@ -328,7 +328,7 @@ impl<'a> When<'a> {
             cut_node(
                 Some("match-when"),
                 tuple((
-                    separated_list1(char('|'), ws(|i| Target::parse(i, s))),
+                    separated_list1('|', ws(|i| Target::parse(i, s))),
                     opt(Whitespace::parse),
                     |i| s.tag_block_end(i),
                     cut_node(Some("match-when"), |i| Node::many(i, s)),
@@ -414,7 +414,7 @@ impl<'a> CondTest<'a> {
             opt(delimited(
                 ws(alt((keyword("let"), keyword("set")))),
                 ws(|i| Target::parse(i, s)),
-                ws(char('=')),
+                ws('='),
             )),
             ws(|i| Expr::parse(i, s.level.get())),
         )
@@ -590,9 +590,9 @@ impl<'a> Macro<'a> {
     fn parse(i: &'a str, s: &State<'_>) -> ParseResult<'a, WithSpan<'a, Self>> {
         fn parameters(i: &str) -> ParseResult<'_, Vec<&str>> {
             delimited(
-                ws(char('(')),
-                separated_list0(char(','), ws(identifier)),
-                tuple((opt(ws(char(','))), char(')'))),
+                ws('('),
+                separated_list0(',', ws(identifier)),
+                tuple((opt(ws(',')), ')')),
             )
             .parse_next(i)
         }
@@ -1084,10 +1084,7 @@ impl<'a> Let<'a> {
                 Some("let"),
                 tuple((
                     ws(|i| Target::parse(i, s)),
-                    opt(preceded(
-                        ws(char('=')),
-                        ws(|i| Expr::parse(i, s.level.get())),
-                    )),
+                    opt(preceded(ws('='), ws(|i| Expr::parse(i, s.level.get())))),
                     opt(Whitespace::parse),
                 )),
             ),

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -2,8 +2,7 @@ use std::str;
 
 use winnow::Parser;
 use winnow::branch::alt;
-use winnow::bytes::complete::tag;
-use winnow::bytes::{any, take_till0};
+use winnow::bytes::{any, tag, take_till0};
 use winnow::combinator::{
     consumed, cut_err, eof, fail, map, map_opt, not, opt, peek, recognize, value,
 };

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -2,8 +2,8 @@ use std::str;
 
 use winnow::Parser;
 use winnow::branch::alt;
-use winnow::bytes::any;
-use winnow::bytes::complete::{tag, take_till};
+use winnow::bytes::complete::tag;
+use winnow::bytes::{any, take_till0};
 use winnow::combinator::{
     consumed, cut_err, eof, fail, map, map_opt, not, opt, peek, recognize, value,
 };
@@ -89,7 +89,7 @@ impl<'a> Node<'a> {
         let (j, tag) = preceded(
             |i| s.tag_block_start(i),
             peek(preceded(
-                (opt(Whitespace::parse), take_till(not_ws)),
+                (opt(Whitespace::parse), take_till0(not_ws)),
                 identifier,
             )),
         )

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -5,7 +5,7 @@ use winnow::branch::alt;
 use winnow::bytes::complete::{tag, take_till};
 use winnow::character::complete::anychar;
 use winnow::combinator::{
-    consumed, cut, eof, fail, map, map_opt, not, opt, peek, recognize, value,
+    consumed, cut_err, eof, fail, map, map_opt, not, opt, peek, recognize, value,
 };
 use winnow::multi::{many0, separated_list0, separated_list1};
 use winnow::sequence::{delimited, preceded};
@@ -214,7 +214,7 @@ fn cut_node<'a, O>(
     kind: Option<&'static str>,
     inner: impl Parser<&'a str, O, ErrorContext<'a>>,
 ) -> impl Parser<&'a str, O, ErrorContext<'a>> {
-    let mut inner = cut(inner);
+    let mut inner = cut_err(inner);
     move |i: &'a str| {
         let result = inner.parse_next(i);
         if let Err(winnow::error::ErrMode::Cut(err) | winnow::error::ErrMode::Backtrack(err)) =

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -8,7 +8,7 @@ use winnow::combinator::{
     complete, consumed, cut, eof, fail, map, map_opt, not, opt, peek, recognize, value,
 };
 use winnow::multi::{many0, separated_list0, separated_list1};
-use winnow::sequence::{delimited, pair, preceded};
+use winnow::sequence::{delimited, preceded};
 
 use crate::memchr_splitter::{Splitter1, Splitter2, Splitter3};
 use crate::{
@@ -87,7 +87,7 @@ impl<'a> Node<'a> {
         let (j, tag) = preceded(
             |i| s.tag_block_start(i),
             peek(preceded(
-                pair(opt(Whitespace::parse), take_till(not_ws)),
+                (opt(Whitespace::parse), take_till(not_ws)),
                 identifier,
             )),
         )
@@ -162,7 +162,7 @@ impl<'a> Node<'a> {
             |i| s.tag_expr_start(i),
             cut_node(
                 None,
-                pair(
+                (
                     opt(Whitespace::parse),
                     ws(|i| Expr::parse(i, s.level.get())),
                 ),
@@ -172,7 +172,7 @@ impl<'a> Node<'a> {
 
         let (i, (nws, closed)) = cut_node(
             None,
-            pair(
+            (
                 opt(Whitespace::parse),
                 alt((value(true, |i| s.tag_expr_end(i)), value(false, ws(eof)))),
             ),
@@ -292,7 +292,7 @@ impl<'a> When<'a> {
     fn when(i: &'a str, s: &State<'_>) -> ParseResult<'a, WithSpan<'a, Self>> {
         let start = i;
         let endwhen = map(
-            consumed(ws(pair(
+            consumed(ws((
                 delimited(
                     |i| s.tag_block_start(i),
                     opt(Whitespace::parse),
@@ -410,7 +410,7 @@ impl<'a> CondTest<'a> {
     }
 
     fn parse_cond(i: &'a str, s: &State<'_>) -> ParseResult<'a, Self> {
-        let (i, (target, expr)) = pair(
+        let (i, (target, expr)) = (
             opt(delimited(
                 ws(alt((keyword("let"), keyword("set")))),
                 ws(|i| Target::parse(i, s)),
@@ -418,7 +418,7 @@ impl<'a> CondTest<'a> {
             )),
             ws(|i| Expr::parse(i, s.level.get())),
         )
-        .parse_next(i)?;
+            .parse_next(i)?;
         let contains_bool_lit_or_is_defined = expr.contains_bool_lit_or_is_defined();
         Ok((i, Self {
             target,
@@ -761,7 +761,7 @@ impl<'a> Import<'a> {
                 (
                     ws(str_lit_without_prefix),
                     ws(keyword("as")),
-                    cut_node(Some("import"), pair(ws(identifier), opt(Whitespace::parse))),
+                    cut_node(Some("import"), (ws(identifier), opt(Whitespace::parse))),
                 ),
             ),
         );
@@ -1180,7 +1180,7 @@ impl<'a> Include<'a> {
             ws(keyword("include")),
             cut_node(
                 Some("include"),
-                pair(ws(str_lit_without_prefix), opt(Whitespace::parse)),
+                (ws(str_lit_without_prefix), opt(Whitespace::parse)),
             ),
         );
         let (i, (pws, _, (path, nws))) = p.parse_next(i)?;
@@ -1211,7 +1211,7 @@ impl<'a> Extends<'a> {
             ws(keyword("extends")),
             cut_node(
                 Some("extends"),
-                pair(ws(str_lit_without_prefix), opt(Whitespace::parse)),
+                (ws(str_lit_without_prefix), opt(Whitespace::parse)),
             ),
         )
             .parse_next(i)?;

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -3,7 +3,7 @@ use std::str;
 use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::{any, tag, take_till0};
-use winnow::combinator::{cut_err, eof, fail, map_opt, not, opt, peek};
+use winnow::combinator::{cut_err, eof, fail, not, opt, peek};
 use winnow::multi::{many0, separated0, separated1};
 use winnow::sequence::{delimited, preceded};
 
@@ -435,7 +435,7 @@ pub enum Whitespace {
 
 impl Whitespace {
     fn parse(i: &str) -> ParseResult<'_, Self> {
-        map_opt(any, Self::parse_char).parse_next(i)
+        any.verify_map(Self::parse_char).parse_next(i)
     }
 
     fn parse_char(c: char) -> Option<Self> {

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -5,7 +5,7 @@ use winnow::branch::alt;
 use winnow::bytes::complete::{tag, take_till};
 use winnow::character::complete::anychar;
 use winnow::combinator::{
-    complete, consumed, cut, eof, fail, map, map_opt, not, opt, peek, recognize, value,
+    consumed, cut, eof, fail, map, map_opt, not, opt, peek, recognize, value,
 };
 use winnow::multi::{many0, separated_list0, separated_list1};
 use winnow::sequence::{delimited, preceded};
@@ -39,7 +39,7 @@ pub enum Node<'a> {
 
 impl<'a> Node<'a> {
     pub(super) fn parse_template(i: &'a str, s: &State<'_>) -> ParseResult<'a, Vec<Self>> {
-        let (i, result) = match complete(|i| Self::many(i, s)).parse_next(i) {
+        let (i, result) = match (|i| Self::many(i, s)).parse_next(i) {
             Ok((i, result)) => (i, result),
             Err(err) => {
                 if let winnow::Err::Backtrack(err) | winnow::Err::Cut(err) = &err {

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -2,8 +2,8 @@ use std::str;
 
 use winnow::Parser;
 use winnow::branch::alt;
+use winnow::bytes::any;
 use winnow::bytes::complete::{tag, take_till};
-use winnow::character::complete::anychar;
 use winnow::combinator::{
     consumed, cut_err, eof, fail, map, map_opt, not, opt, peek, recognize, value,
 };
@@ -441,7 +441,7 @@ pub enum Whitespace {
 
 impl Whitespace {
     fn parse(i: &str) -> ParseResult<'_, Self> {
-        map_opt(anychar, Self::parse_char).parse_next(i)
+        map_opt(any, Self::parse_char).parse_next(i)
     }
 
     fn parse_char(c: char) -> Option<Self> {

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -210,8 +210,8 @@ impl<'a> Node<'a> {
 
 fn cut_node<'a, O>(
     kind: Option<&'static str>,
-    inner: impl FnMut(&'a str) -> ParseResult<'a, O>,
-) -> impl FnMut(&'a str) -> ParseResult<'a, O> {
+    inner: impl Parser<&'a str, O, ErrorContext<'a>>,
+) -> impl Parser<&'a str, O, ErrorContext<'a>> {
     let mut inner = cut(inner);
     move |i: &'a str| {
         let result = inner.parse_next(i);

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -1,6 +1,5 @@
 use winnow::Parser;
 use winnow::branch::alt;
-use winnow::bytes::complete::tag;
 use winnow::character::complete::{char, one_of};
 use winnow::combinator::{consumed, map, map_res, opt};
 use winnow::multi::separated_list1;
@@ -32,8 +31,7 @@ impl<'a> Target<'a> {
     /// Parses multiple targets with `or` separating them
     pub(super) fn parse(i: &'a str, s: &State<'_>) -> ParseResult<'a, Self> {
         map(
-            separated_list1(ws(tag("or")), |i| s.nest(i, |i| Self::parse_one(i, s)))
-                .map(|v: Vec<_>| v),
+            separated_list1(ws("or"), |i| s.nest(i, |i| Self::parse_one(i, s))).map(|v: Vec<_>| v),
             |mut opts| match opts.len() {
                 1 => opts.pop().unwrap(),
                 _ => Self::OrChain(opts),
@@ -177,7 +175,7 @@ impl<'a> Target<'a> {
 
     fn rest(start: &'a str) -> ParseResult<'a, Self> {
         let (i, (ident, _)) =
-            tuple((opt(tuple((identifier, ws(char('@'))))), tag(".."))).parse_next(start)?;
+            tuple((opt(tuple((identifier, ws(char('@'))))), "..")).parse_next(start)?;
         Ok((
             i,
             Self::Rest(WithSpan::new(ident.map(|(ident, _)| ident), start)),

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -3,7 +3,7 @@ use winnow::branch::alt;
 use winnow::character::complete::{char, one_of};
 use winnow::combinator::{consumed, map, map_res, opt};
 use winnow::multi::separated_list1;
-use winnow::sequence::{pair, preceded};
+use winnow::sequence::preceded;
 
 use crate::{
     CharLit, ErrorContext, Num, ParseErr, ParseResult, PathOrIdentifier, State, StrLit, WithSpan,
@@ -155,7 +155,7 @@ impl<'a> Target<'a> {
         }
 
         let (i, (src, target)) =
-            pair(identifier, opt(preceded(ws(':'), |i| Self::parse(i, s))))(init_i)?;
+            (identifier, opt(preceded(ws(':'), |i| Self::parse(i, s)))).parse_next(init_i)?;
 
         if src == "_" {
             return Err(winnow::Err::Cut(ErrorContext::new(
@@ -216,7 +216,7 @@ fn collect_targets<'a, T>(
         )));
     };
 
-    let (i, (has_comma, has_end)) = pair(opt_comma, opt_end).parse_next(i)?;
+    let (i, (has_comma, has_end)) = (opt_comma, opt_end).parse_next(i)?;
     if !has_end {
         let msg = match has_comma {
             true => format!("expected member, or `{delim}` as terminator"),

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -3,7 +3,7 @@ use winnow::branch::alt;
 use winnow::character::complete::{char, one_of};
 use winnow::combinator::{consumed, map, map_res, opt};
 use winnow::multi::separated_list1;
-use winnow::sequence::{pair, preceded, tuple};
+use winnow::sequence::{pair, preceded};
 
 use crate::{
     CharLit, ErrorContext, Num, ParseErr, ParseResult, PathOrIdentifier, State, StrLit, WithSpan,
@@ -172,7 +172,7 @@ impl<'a> Target<'a> {
     }
 
     fn rest(start: &'a str) -> ParseResult<'a, Self> {
-        let (i, (ident, _)) = tuple((opt(tuple((identifier, ws('@')))), "..")).parse_next(start)?;
+        let (i, (ident, _)) = (opt((identifier, ws('@'))), "..").parse_next(start)?;
         Ok((
             i,
             Self::Rest(WithSpan::new(ident.map(|(ident, _)| ident), start)),

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -1,6 +1,6 @@
 use winnow::Parser;
 use winnow::branch::alt;
-use winnow::character::complete::{char, one_of};
+use winnow::character::complete::one_of;
 use winnow::combinator::{consumed, map, map_res, opt};
 use winnow::multi::separated1;
 use winnow::sequence::preceded;
@@ -200,7 +200,7 @@ fn collect_targets<'a, T>(
     mut one: impl FnMut(&'a str, &State<'_>) -> ParseResult<'a, T>,
 ) -> ParseResult<'a, (bool, Vec<T>)> {
     let opt_comma = |i| map(ws(opt(',')), |o| o.is_some()).parse_next(i);
-    let mut opt_end = |i| map(ws(opt(char(delim))), |o| o.is_some()).parse_next(i);
+    let mut opt_end = |i| map(ws(opt(one_of(delim))), |o| o.is_some()).parse_next(i);
 
     let (i, has_end) = opt_end.parse_next(i)?;
     if has_end {

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -1,6 +1,6 @@
 use winnow::Parser;
 use winnow::branch::alt;
-use winnow::character::complete::one_of;
+use winnow::bytes::one_of;
 use winnow::combinator::{consumed, map, map_res, opt};
 use winnow::multi::separated1;
 use winnow::sequence::preceded;

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -1,7 +1,7 @@
 use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::one_of;
-use winnow::combinator::{map_res, opt};
+use winnow::combinator::opt;
 use winnow::multi::separated1;
 use winnow::sequence::preceded;
 
@@ -75,11 +75,12 @@ impl<'a> Target<'a> {
         }
 
         let path = |i| {
-            map_res(path_or_identifier, |v| match v {
-                PathOrIdentifier::Path(v) => Ok(v),
-                PathOrIdentifier::Identifier(v) => Err(v),
-            })
-            .parse_next(i)
+            path_or_identifier
+                .map_res(|v| match v {
+                    PathOrIdentifier::Path(v) => Ok(v),
+                    PathOrIdentifier::Identifier(v) => Err(v),
+                })
+                .parse_next(i)
         };
 
         // match structs


### PR DESCRIPTION
Benefits over Nom
- Maintained
- Ergonomics ([1](https://epage.github.io/blog/2023/02/winnow-toml-edit-combine-nom/#winnow), [2](https://epage.github.io/blog/2023/07/winnow-0-5-the-fastest-rust-parser-combinator-library/))
- Performance ([3](https://epage.github.io/blog/2023/07/winnow-0-5-the-fastest-rust-parser-combinator-library/#numbers))

Winnow is at 0.6 but the 0.4->0.5 upgrade is rough enough (and this is a low enough priority) that I've been taking a while on this which has led to dealing with too many merge conflicts.  I'm starting off with just Winnow 0.3 as this last round of merge conflicts already had me rewrite a large number of commits that I want something in sooner than later.

There is a decent chance that future upgrades will improve performance further

<details>

<summary>Performance:</summary>

```
     Running benches/from_str.rs (/home/epage/src/personal/rinja/target/release/deps/from_str-453ae6795003ee85)
Gnuplot not found, using plotters backend
librustdoc/all          time:   [183.26 µs 183.71 µs 184.18 µs]
                        thrpt:  [76.669 MiB/s 76.866 MiB/s 77.053 MiB/s]
                 change:
                        time:   [-16.432% -15.530% -14.572%] (p = 0.00 < 0.05)
                        thrpt:  [+17.057% +18.386% +19.662%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
librustdoc/item_info    time:   [3.1356 µs 3.1388 µs 3.1415 µs]
                        thrpt:  [50.089 MiB/s 50.133 MiB/s 50.185 MiB/s]
                 change:
                        time:   [-17.301% -16.994% -16.637%] (p = 0.00 < 0.05)
                        thrpt:  [+19.958% +20.473% +20.921%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) low severe
  3 (3.00%) low mild
  5 (5.00%) high severe
librustdoc/item_union   time:   [18.955 µs 19.113 µs 19.301 µs]
                        thrpt:  [51.140 MiB/s 51.642 MiB/s 52.073 MiB/s]
                 change:
                        time:   [-14.048% -13.083% -11.600%] (p = 0.00 < 0.05)
                        thrpt:  [+13.122% +15.052% +16.344%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  3 (3.00%) high severe
librustdoc/page         time:   [91.669 µs 91.894 µs 92.136 µs]
                        thrpt:  [67.208 MiB/s 67.384 MiB/s 67.549 MiB/s]
                 change:
                        time:   [-15.574% -15.175% -14.731%] (p = 0.00 < 0.05)
                        thrpt:  [+17.276% +17.889% +18.448%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
librustdoc/print_item   time:   [10.168 µs 10.187 µs 10.205 µs]
                        thrpt:  [92.521 MiB/s 92.676 MiB/s 92.855 MiB/s]
                 change:
                        time:   [-17.705% -17.536% -17.363%] (p = 0.00 < 0.05)
                        thrpt:  [+21.011% +21.264% +21.514%]
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  7 (7.00%) low severe
  7 (7.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
librustdoc/short_item_info
                        time:   [10.968 µs 10.985 µs 11.008 µs]
                        thrpt:  [82.305 MiB/s 82.477 MiB/s 82.606 MiB/s]
                 change:
                        time:   [-11.565% -11.330% -11.054%] (p = 0.00 < 0.05)
                        thrpt:  [+12.428% +12.778% +13.077%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
librustdoc/sidebar      time:   [21.856 µs 21.875 µs 21.896 µs]
                        thrpt:  [56.359 MiB/s 56.413 MiB/s 56.463 MiB/s]
                 change:
                        time:   [-17.757% -16.668% -15.597%] (p = 0.00 < 0.05)
                        thrpt:  [+18.479% +20.002% +21.591%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
librustdoc/source       time:   [7.5811 µs 7.5986 µs 7.6122 µs]
                        thrpt:  [96.844 MiB/s 97.017 MiB/s 97.241 MiB/s]
                 change:
                        time:   [-17.455% -17.335% -17.224%] (p = 0.00 < 0.05)
                        thrpt:  [+20.807% +20.970% +21.146%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) low severe
  5 (5.00%) low mild
  2 (2.00%) high mild
librustdoc/type_layout_size
                        time:   [4.9870 µs 4.9936 µs 5.0009 µs]
                        thrpt:  [54.159 MiB/s 54.238 MiB/s 54.310 MiB/s]
                 change:
                        time:   [-9.9132% -9.5887% -9.2205%] (p = 0.00 < 0.05)
                        thrpt:  [+10.157% +10.606% +11.004%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
librustdoc/type_layout  time:   [17.952 µs 18.117 µs 18.302 µs]
                        thrpt:  [147.10 MiB/s 148.60 MiB/s 149.97 MiB/s]
                 change:
                        time:   [-12.943% -12.385% -11.870%] (p = 0.00 < 0.05)
                        thrpt:  [+13.468% +14.135% +14.867%]
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  1 (1.00%) low severe
  15 (15.00%) low mild
  1 (1.00%) high mild
```

</details>