### PR TITLE
Upgrade from Winnow 0.3 to 0.4

### DIFF
--- a/rinja_parser/Cargo.toml
+++ b/rinja_parser/Cargo.toml
@@ -23,7 +23,7 @@ config = ["dep:serde"]
 [dependencies]
 memchr = "2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-winnow = "0.3"
+winnow = "0.4"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -6,7 +6,7 @@ use winnow::branch::alt;
 use winnow::bytes::{one_of, tag, take_till0};
 use winnow::character::digit1;
 use winnow::combinator::{cut_err, fail, fold_repeat, not, opt, peek, repeat};
-use winnow::error::{ErrorKind, ParseError as _};
+use winnow::error::{ErrorKind, ParserError as _};
 use winnow::multi::{separated0, separated1};
 use winnow::sequence::{preceded, terminated};
 

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -5,9 +5,9 @@ use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::{one_of, tag, take_till0};
 use winnow::character::digit1;
-use winnow::combinator::{cut_err, fail, not, opt, peek};
+use winnow::combinator::{cut_err, fail, not, opt, peek, repeat};
 use winnow::error::{ErrorKind, ParseError as _};
-use winnow::multi::{fold_many0, many0, separated0, separated1};
+use winnow::multi::{fold_many0, separated0, separated1};
 use winnow::sequence::{preceded, terminated};
 
 use crate::{
@@ -21,7 +21,7 @@ macro_rules! expr_prec_layer {
             let (_, level) = level.nest(i)?;
             let start = i;
             let (i, left) = Self::$inner(i, level)?;
-            let (i, right) = many0((ws($op), |i| Self::$inner(i, level)))
+            let (i, right) = repeat(0.., (ws($op), |i| Self::$inner(i, level)))
                 .map(|v: Vec<_>| v)
                 .parse_next(i)?;
             Ok((
@@ -257,7 +257,7 @@ impl<'a> Expr<'a> {
         let (_, nested) = level.nest(i)?;
         let start = i;
         let (i, (ops, mut expr)) = (
-            many0(ws(alt(("!", "-", "*", "&")))).map(|v: Vec<_>| v),
+            repeat(0.., ws(alt(("!", "-", "*", "&")))).map(|v: Vec<_>| v),
             |i| Suffix::parse(i, nested),
         )
             .parse_next(i)?;

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -8,7 +8,7 @@ use winnow::combinator::{
     terminated,
 };
 use winnow::error::{ErrorKind, ParserError as _};
-use winnow::token::{one_of, tag, take_till0};
+use winnow::token::take_till0;
 
 use crate::{
     CharLit, ErrorContext, Level, Num, ParseResult, PathOrIdentifier, StrLit, WithSpan, char_lit,
@@ -172,7 +172,7 @@ impl<'a> Expr<'a> {
     expr_prec_layer!(or, and, "||");
     expr_prec_layer!(and, compare, "&&");
     expr_prec_layer!(compare, bor, alt(("==", "!=", ">=", ">", "<=", "<",)));
-    expr_prec_layer!(bor, bxor, tag("bitor").value("|"));
+    expr_prec_layer!(bor, bxor, "bitor".value("|"));
     expr_prec_layer!(bxor, band, token_xor);
     expr_prec_layer!(band, shifts, token_bitand);
     expr_prec_layer!(shifts, addsub, alt((">>", "<<")));
@@ -399,7 +399,7 @@ impl<'a> Expr<'a> {
 }
 
 fn token_xor(i: &str) -> ParseResult<'_> {
-    let (i, good) = alt((keyword("xor").value(true), one_of('^').value(false))).parse_next(i)?;
+    let (i, good) = alt((keyword("xor").value(true), '^'.value(false))).parse_next(i)?;
     if good {
         Ok((i, "^"))
     } else {

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -5,9 +5,9 @@ use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::{one_of, tag, take_till0};
 use winnow::character::digit1;
-use winnow::combinator::{cut_err, fail, not, opt, peek, repeat};
+use winnow::combinator::{cut_err, fail, fold_repeat, not, opt, peek, repeat};
 use winnow::error::{ErrorKind, ParseError as _};
-use winnow::multi::{fold_many0, separated0, separated1};
+use winnow::multi::{separated0, separated1};
 use winnow::sequence::{preceded, terminated};
 
 use crate::{
@@ -302,7 +302,8 @@ impl<'a> Expr<'a> {
         }
 
         let mut exprs = vec![expr];
-        let (i, ()) = fold_many0(
+        let (i, ()) = fold_repeat(
+            0..,
             preceded(',', ws(|i| Self::parse(i, level))),
             || (),
             |(), expr| {

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -3,11 +3,11 @@ use std::str;
 
 use winnow::Parser;
 use winnow::ascii::digit1;
-use winnow::branch::alt;
-use winnow::combinator::{cut_err, fail, fold_repeat, not, opt, peek, repeat};
+use winnow::combinator::{
+    alt, cut_err, fail, fold_repeat, not, opt, peek, preceded, repeat, separated0, separated1,
+    terminated,
+};
 use winnow::error::{ErrorKind, ParserError as _};
-use winnow::multi::{separated0, separated1};
-use winnow::sequence::{preceded, terminated};
 use winnow::token::{one_of, tag, take_till0};
 
 use crate::{

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -2,9 +2,9 @@ use std::collections::HashSet;
 use std::str;
 
 use winnow::Parser;
+use winnow::ascii::digit1;
 use winnow::branch::alt;
 use winnow::bytes::{one_of, tag, take_till0};
-use winnow::character::digit1;
 use winnow::combinator::{cut_err, fail, fold_repeat, not, opt, peek, repeat};
 use winnow::error::{ErrorKind, ParserError as _};
 use winnow::multi::{separated0, separated1};

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -4,11 +4,11 @@ use std::str;
 use winnow::Parser;
 use winnow::ascii::digit1;
 use winnow::branch::alt;
-use winnow::bytes::{one_of, tag, take_till0};
 use winnow::combinator::{cut_err, fail, fold_repeat, not, opt, peek, repeat};
 use winnow::error::{ErrorKind, ParserError as _};
 use winnow::multi::{separated0, separated1};
 use winnow::sequence::{preceded, terminated};
+use winnow::token::{one_of, tag, take_till0};
 
 use crate::{
     CharLit, ErrorContext, Level, Num, ParseResult, PathOrIdentifier, StrLit, WithSpan, char_lit,

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -320,16 +320,11 @@ fn keyword(k: &str) -> impl Parser<&str, &str, ErrorContext<'_>> {
 }
 
 fn identifier(input: &str) -> ParseResult<'_> {
-    fn start(s: &str) -> ParseResult<'_> {
-        take_while(1.., |c: char| c.is_alpha() || c == '_' || c >= '\u{0080}').parse_next(s)
-    }
+    let start = take_while(1.., |c: char| c.is_alpha() || c == '_' || c >= '\u{0080}');
 
-    fn tail(s: &str) -> ParseResult<'_> {
-        take_while(1.., |c: char| {
-            c.is_alphanum() || c == '_' || c >= '\u{0080}'
-        })
-        .parse_next(s)
-    }
+    let tail = take_while(1.., |c: char| {
+        c.is_alphanum() || c == '_' || c >= '\u{0080}'
+    });
 
     (start, opt(tail)).recognize().parse_next(input)
 }

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -248,7 +248,7 @@ impl<'a> ErrorContext<'a> {
     }
 }
 
-impl<'a> winnow::error::ParseError<&'a str> for ErrorContext<'a> {
+impl<'a> winnow::error::ParserError<&'a str> for ErrorContext<'a> {
     fn from_error_kind(input: &'a str, _code: ErrorKind) -> Self {
         Self {
             input,

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -11,9 +11,9 @@ use std::sync::Arc;
 use std::{fmt, str};
 
 use winnow::Parser;
+use winnow::ascii::escaped;
 use winnow::branch::alt;
 use winnow::bytes::{any, one_of, tag, take_till0, take_till1, take_while};
-use winnow::character::escaped;
 use winnow::combinator::{cut_err, fail, not, opt, repeat};
 use winnow::error::{ErrorKind, FromExternalError};
 use winnow::sequence::{delimited, preceded};

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -380,7 +380,7 @@ fn num_lit<'a>(start: &'a str) -> ParseResult<'a, Num<'a>> {
     let float = |i: &'a str| -> ParseResult<'a, ()> {
         let (i, has_dot) = opt(('.', separated_digits(10, true))).parse_next(i)?;
         let (i, has_exp) = opt(|i| {
-            let (i, (kind, op)) = (one_of("eE"), opt(one_of("+-"))).parse_next(i)?;
+            let (i, (kind, op)) = (one_of(['e', 'E']), opt(one_of(['+', '-']))).parse_next(i)?;
             match opt(separated_digits(10, op.is_none())).parse_next(i)? {
                 (i, Some(_)) => Ok((i, ())),
                 (_, None) => Err(winnow::error::ErrMode::Cut(ErrorContext::new(

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -13,11 +13,11 @@ use std::{fmt, str};
 use winnow::Parser;
 use winnow::ascii::escaped;
 use winnow::branch::alt;
-use winnow::bytes::{any, one_of, tag, take_till0, take_till1, take_while};
 use winnow::combinator::{cut_err, fail, not, opt, repeat};
 use winnow::error::{ErrorKind, FromExternalError};
 use winnow::sequence::{delimited, preceded};
 use winnow::stream::AsChar;
+use winnow::token::{any, one_of, tag, take_till0, take_till1, take_while};
 
 pub mod expr;
 pub use expr::{Expr, Filter};

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -469,7 +469,8 @@ pub struct StrLit<'a> {
 }
 
 fn str_lit_without_prefix(i: &str) -> ParseResult<'_> {
-    let (i, s) = delimited('"', opt(escaped(take_till1("\\\""), '\\', any)), '"').parse_next(i)?;
+    let (i, s) =
+        delimited('"', opt(escaped(take_till1(['\\', '"']), '\\', any)), '"').parse_next(i)?;
     Ok((i, s.unwrap_or_default()))
 }
 
@@ -500,7 +501,11 @@ fn char_lit(i: &str) -> Result<(&str, CharLit<'_>), ParseErr<'_>> {
     let start = i;
     let (i, (b_prefix, s)) = (
         opt('b'),
-        delimited('\'', opt(escaped(take_till1("\\\'"), '\\', any)), '\''),
+        delimited(
+            '\'',
+            opt(escaped(take_till1(['\\', '\'']), '\\', any)),
+            '\'',
+        ),
     )
         .parse_next(i)?;
 

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -431,19 +431,19 @@ fn num_lit<'a>(start: &'a str) -> ParseResult<'a, Num<'a>> {
 
 /// Underscore separated digits of the given base, unless `start` is true this may start
 /// with an underscore.
-fn separated_digits(radix: u32, start: bool) -> impl Fn(&str) -> ParseResult<'_> {
-    move |i| {
-        (
-            |i| match start {
-                true => Ok((i, ())),
-                false => repeat(0.., '_').parse_next(i),
-            },
-            one_of(|ch: char| ch.is_digit(radix)),
-            repeat(0.., one_of(|ch: char| ch == '_' || ch.is_digit(radix))).map(|()| ()),
-        )
-            .recognize()
-            .parse_next(i)
-    }
+fn separated_digits<'a>(
+    radix: u32,
+    start: bool,
+) -> impl Parser<&'a str, &'a str, ErrorContext<'a>> {
+    (
+        move |i: &'a _| match start {
+            true => Ok((i, ())),
+            false => repeat(0.., '_').parse_next(i),
+        },
+        one_of(move |ch: char| ch.is_digit(radix)),
+        repeat(0.., one_of(move |ch: char| ch == '_' || ch.is_digit(radix))).map(|()| ()),
+    )
+        .recognize()
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -371,16 +371,9 @@ fn num_lit<'a>(start: &'a str) -> ParseResult<'a, Num<'a>> {
 
     // Equivalent to <https://github.com/rust-lang/rust/blob/e3f909b2bbd0b10db6f164d466db237c582d3045/compiler/rustc_lexer/src/lib.rs#L587-L620>.
     let int_with_base = (opt('-'), |i| {
-        let (i, (base, kind)) = preceded(
-            '0',
-            alt((
-                one_of('b').value(2),
-                one_of('o').value(8),
-                one_of('x').value(16),
-            )),
-        )
-        .with_recognized()
-        .parse_next(i)?;
+        let (i, (base, kind)) = preceded('0', alt(('b'.value(2), 'o'.value(8), 'x'.value(16))))
+            .with_recognized()
+            .parse_next(i)?;
         match opt(separated_digits(base, false)).parse_next(i)? {
             (i, Some(_)) => Ok((i, ())),
             (_, None) => Err(winnow::error::ErrMode::Cut(ErrorContext::new(
@@ -589,14 +582,14 @@ impl<'a> Char<'a> {
         (
             '\\',
             alt((
-                one_of('n').value(Self::Escaped),
-                one_of('r').value(Self::Escaped),
-                one_of('t').value(Self::Escaped),
-                one_of('\\').value(Self::Escaped),
-                one_of('0').value(Self::Escaped),
-                one_of('\'').value(Self::Escaped),
+                'n'.value(Self::Escaped),
+                'r'.value(Self::Escaped),
+                't'.value(Self::Escaped),
+                '\\'.value(Self::Escaped),
+                '0'.value(Self::Escaped),
+                '\''.value(Self::Escaped),
                 // Not useful but supported by rust.
-                one_of('"').value(Self::Escaped),
+                '"'.value(Self::Escaped),
                 ('x', take_while(2, |c: char| c.is_ascii_hexdigit()))
                     .map(|(_, s)| Self::AsciiEscape(s)),
                 (

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -569,7 +569,7 @@ enum Char<'a> {
 impl<'a> Char<'a> {
     fn parse(i: &'a str) -> ParseResult<'a, Self> {
         if i.chars().count() == 1 {
-            return Ok(("", Self::Literal));
+            return any.value(Self::Literal).parse_next(i);
         }
         (
             '\\',

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -12,10 +12,8 @@ use std::{fmt, str};
 
 use winnow::Parser;
 use winnow::ascii::escaped;
-use winnow::branch::alt;
-use winnow::combinator::{cut_err, fail, not, opt, repeat};
+use winnow::combinator::{alt, cut_err, delimited, fail, not, opt, preceded, repeat};
 use winnow::error::{ErrorKind, FromExternalError};
-use winnow::sequence::{delimited, preceded};
 use winnow::stream::AsChar;
 use winnow::token::{any, one_of, tag, take_till0, take_till1, take_while};
 

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -315,11 +315,8 @@ fn skip_till<'a, 'b, O>(
     }
 }
 
-fn keyword<'a>(k: &'a str) -> impl Parser<&'a str, &'a str, ErrorContext<'a>> {
-    move |i: &'a str| -> ParseResult<'a> {
-        let (j, v) = identifier.parse_next(i)?;
-        if k == v { Ok((j, v)) } else { fail(i) }
-    }
+fn keyword(k: &str) -> impl Parser<&str, &str, ErrorContext<'_>> {
+    identifier.verify(move |v: &str| v == k)
 }
 
 fn identifier(input: &str) -> ParseResult<'_> {

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -3,8 +3,8 @@ use std::str;
 use winnow::Parser;
 use winnow::branch::alt;
 use winnow::bytes::{any, tag, take_till0};
-use winnow::combinator::{cut_err, eof, fail, not, opt, peek};
-use winnow::multi::{many0, separated0, separated1};
+use winnow::combinator::{cut_err, eof, fail, not, opt, peek, repeat};
+use winnow::multi::{separated0, separated1};
 use winnow::sequence::{delimited, preceded};
 
 use crate::memchr_splitter::{Splitter1, Splitter2, Splitter3};
@@ -63,12 +63,15 @@ impl<'a> Node<'a> {
     }
 
     fn many(i: &'a str, s: &State<'_>) -> ParseResult<'a, Vec<Self>> {
-        many0(alt((
-            (|i| Lit::parse(i, s)).map(Self::Lit),
-            (|i| Comment::parse(i, s)).map(Self::Comment),
-            |i| Self::expr(i, s),
-            |i| Self::parse(i, s),
-        )))
+        repeat(
+            0..,
+            alt((
+                (|i| Lit::parse(i, s)).map(Self::Lit),
+                (|i| Comment::parse(i, s)).map(Self::Comment),
+                |i| Self::expr(i, s),
+                |i| Self::parse(i, s),
+            )),
+        )
         .map(|v: Vec<_>| v)
         .parse_next(i)
     }
@@ -301,7 +304,7 @@ impl<'a> When<'a> {
                 (
                     opt(Whitespace::parse),
                     |i| s.tag_block_end(i),
-                    many0(ws(|i| Comment::parse(i, s))).map(|()| ()),
+                    repeat(0.., ws(|i| Comment::parse(i, s))).map(|()| ()),
                 ),
             ),
         ))
@@ -679,7 +682,7 @@ impl<'a> FilterBlock<'a> {
                 (
                     ws(identifier),
                     opt(|i| Expr::arguments(i, s.level.get(), false)),
-                    many0(|i| {
+                    repeat(0.., |i| {
                         filter(i, &mut level).map(|(j, (name, params))| (j, (name, params, i)))
                     })
                     .map(|v: Vec<_>| v),
@@ -843,8 +846,8 @@ impl<'a> Match<'a> {
                     cut_node(
                         Some("match"),
                         (
-                            ws(many0(ws(|i| Comment::parse(i, s)))).map(|()| ()),
-                            many0(|i| When::when(i, s)).map(|v: Vec<_>| v),
+                            ws(repeat(0.., ws(|i| Comment::parse(i, s)))).map(|()| ()),
+                            repeat(0.., |i| When::when(i, s)).map(|v: Vec<_>| v),
                             cut_node(
                                 Some("match"),
                                 (
@@ -1124,7 +1127,7 @@ impl<'a> If<'a> {
                         Some("if"),
                         (
                             |i| Node::many(i, s),
-                            many0(|i| Cond::parse(i, s)).map(|v: Vec<_>| v),
+                            repeat(0.., |i| Cond::parse(i, s)).map(|v: Vec<_>| v),
                             cut_node(
                                 Some("if"),
                                 (

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -1,10 +1,9 @@
 use std::str;
 
 use winnow::Parser;
-use winnow::branch::alt;
-use winnow::combinator::{cut_err, eof, fail, not, opt, peek, repeat};
-use winnow::multi::{separated0, separated1};
-use winnow::sequence::{delimited, preceded};
+use winnow::combinator::{
+    alt, cut_err, delimited, eof, fail, not, opt, peek, preceded, repeat, separated0, separated1,
+};
 use winnow::token::{any, tag, take_till0};
 
 use crate::memchr_splitter::{Splitter1, Splitter2, Splitter3};

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -2,10 +2,10 @@ use std::str;
 
 use winnow::Parser;
 use winnow::branch::alt;
-use winnow::bytes::{any, tag, take_till0};
 use winnow::combinator::{cut_err, eof, fail, not, opt, peek, repeat};
 use winnow::multi::{separated0, separated1};
 use winnow::sequence::{delimited, preceded};
+use winnow::token::{any, tag, take_till0};
 
 use crate::memchr_splitter::{Splitter1, Splitter2, Splitter3};
 use crate::{

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -1,8 +1,5 @@
 use winnow::Parser;
-use winnow::branch::alt;
-use winnow::combinator::opt;
-use winnow::multi::separated1;
-use winnow::sequence::preceded;
+use winnow::combinator::{alt, opt, preceded, separated1};
 use winnow::token::one_of;
 
 use crate::{

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -132,7 +132,7 @@ impl<'a> Target<'a> {
     fn named(init_i: &'a str, s: &State<'_>) -> ParseResult<'a, (&'a str, Self)> {
         let (i, rest) = opt(Self::rest.with_recognized()).parse_next(init_i)?;
         if let Some(rest) = rest {
-            let (_, chr) = ws(opt(one_of(",:"))).parse_next(i)?;
+            let (_, chr) = ws(opt(one_of([',', ':']))).parse_next(i)?;
             if let Some(chr) = chr {
                 return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                     format!(

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -1,9 +1,9 @@
 use winnow::Parser;
 use winnow::branch::alt;
-use winnow::bytes::one_of;
 use winnow::combinator::opt;
 use winnow::multi::separated1;
 use winnow::sequence::preceded;
+use winnow::token::one_of;
 
 use crate::{
     CharLit, ErrorContext, Num, ParseErr, ParseResult, PathOrIdentifier, State, StrLit, WithSpan,

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -76,7 +76,7 @@ impl<'a> Target<'a> {
 
         let path = |i| {
             path_or_identifier
-                .map_res(|v| match v {
+                .try_map(|v| match v {
                     PathOrIdentifier::Path(v) => Ok(v),
                     PathOrIdentifier::Identifier(v) => Err(v),
                 })


### PR DESCRIPTION
This is a follow up to #209.

There is a performance regression compared to #209 but not compared to Nom.  We saw this with the [json benchmarks](https://epage.github.io/blog/2023/07/winnow-0-5-the-fastest-rust-parser-combinator-library/#numbers).  Addressing `one_of(str)` and `take_till*(str)` magically recovered all of the losses for json parsing but not for rinja.  Since this is still better than Nom, I'm moving forward with the upgrading and will look more into it if its still there by the time we are using Winnow 0.6.

<details>

<summary>Performance comparison with pre-#209</summary>

```
librustdoc/all          time:   [211.47 µs 211.95 µs 212.43 µs]
                        thrpt:  [66.472 MiB/s 66.625 MiB/s 66.774 MiB/s]
                 change:
                        time:   [-5.2816% -4.4478% -3.0084%] (p = 0.00 < 0.05)
                        thrpt:  [+3.1017% +4.6548% +5.5761%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
librustdoc/item_info    time:   [3.3956 µs 3.3981 µs 3.4006 µs]
                        thrpt:  [46.274 MiB/s 46.307 MiB/s 46.342 MiB/s]
                 change:
                        time:   [-10.928% -10.818% -10.712%] (p = 0.00 < 0.05)
                        thrpt:  [+11.997% +12.130% +12.269%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
librustdoc/item_union   time:   [20.326 µs 20.341 µs 20.355 µs]
                        thrpt:  [48.493 MiB/s 48.526 MiB/s 48.561 MiB/s]
                 change:
                        time:   [-11.560% -11.129% -10.736%] (p = 0.00 < 0.05)
                        thrpt:  [+12.027% +12.523% +13.071%]
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
librustdoc/page         time:   [93.632 µs 93.726 µs 93.813 µs]
                        thrpt:  [66.006 MiB/s 66.067 MiB/s 66.133 MiB/s]
                 change:
                        time:   [-11.178% -10.936% -10.726%] (p = 0.00 < 0.05)
                        thrpt:  [+12.015% +12.278% +12.585%]
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) low severe
  5 (5.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
librustdoc/print_item   time:   [11.563 µs 11.686 µs 11.797 µs]
                        thrpt:  [80.031 MiB/s 80.789 MiB/s 81.649 MiB/s]
                 change:
                        time:   [-6.6420% -6.2205% -5.8448%] (p = 0.00 < 0.05)
                        thrpt:  [+6.2076% +6.6331% +7.1145%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) low severe
  3 (3.00%) high mild
  3 (3.00%) high severe
librustdoc/short_item_info
                        time:   [11.228 µs 11.239 µs 11.248 µs]
                        thrpt:  [80.543 MiB/s 80.610 MiB/s 80.688 MiB/s]
                 change:
                        time:   [-16.343% -16.194% -16.050%] (p = 0.00 < 0.05)
                        thrpt:  [+19.118% +19.323% +19.536%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) low severe
  3 (3.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
librustdoc/sidebar      time:   [22.365 µs 22.389 µs 22.412 µs]
                        thrpt:  [55.063 MiB/s 55.118 MiB/s 55.179 MiB/s]
                 change:
                        time:   [-10.149% -9.8341% -9.5793%] (p = 0.00 < 0.05)
                        thrpt:  [+10.594% +10.907% +11.296%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) low severe
  5 (5.00%) low mild
  1 (1.00%) high severe
librustdoc/source       time:   [8.8052 µs 8.8176 µs 8.8312 µs]
                        thrpt:  [83.476 MiB/s 83.604 MiB/s 83.722 MiB/s]
                 change:
                        time:   [-5.1877% -5.0581% -4.9275%] (p = 0.00 < 0.05)
                        thrpt:  [+5.1829% +5.3275% +5.4715%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  5 (5.00%) high severe
librustdoc/type_layout_size
                        time:   [5.3613 µs 5.3694 µs 5.3798 µs]
                        thrpt:  [50.345 MiB/s 50.442 MiB/s 50.519 MiB/s]
                 change:
                        time:   [-4.5226% -4.3497% -4.1493%] (p = 0.00 < 0.05)
                        thrpt:  [+4.3289% +4.5475% +4.7368%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
librustdoc/type_layout  time:   [19.482 µs 19.614 µs 19.717 µs]
                        thrpt:  [136.54 MiB/s 137.26 MiB/s 138.19 MiB/s]
                 change:
                        time:   [-11.666% -11.069% -10.501%] (p = 0.00 < 0.05)
                        thrpt:  [+11.732% +12.447% +13.206%]
                        Performance has improved.
```

</details>