### PR TITLE
Fix crate version numbers in book

### DIFF
--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -4,7 +4,7 @@ First, add the following to your crate's `Cargo.toml`:
 
 ```toml
 # in section [dependencies]
-rinja = "0.12.1"
+rinja = "0.3.5"
 ```
 
 Now create a directory called `templates` in your crate root.
@@ -43,7 +43,7 @@ First, add this to your `Cargo.toml` instead:
 
 ```toml
 # in section [dependencies]
-rinja_axum = "0.4.0"
+rinja_axum = "0.3.5"
 ```
 
 Then, import from rinja_axum instead of rinja:


### PR DESCRIPTION
I was browsing over [the book](https://rinja.readthedocs.io/en/stable/getting_started.html), and noticed that the recommended version numbers were still left over from `askama`. This PR fixes them to be the latest values.

Note that this is a temporary fix, as the version will need to be bumped at the next minor release (0.4, then 0.5, etc.). While it is possible to automate updating these values, my best recommendation is to have a release checklist in `CONTRIBUTING.md` that notes that these values need to be changed.

Cheers :)