### PR TITLE
Move types into their tests

### DIFF
--- a/testing/tests/block_fragments.rs
+++ b/testing/tests/block_fragments.rs
@@ -1,29 +1,29 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(path = "fragment-simple.html", block = "body")]
-struct FragmentSimple<'a> {
-    name: &'a str,
-}
-
 /// Tests a simple base-inherited template with block fragment rendering.
 #[test]
 fn test_fragment_simple() {
+    #[derive(Template)]
+    #[template(path = "fragment-simple.html", block = "body")]
+    struct FragmentSimple<'a> {
+        name: &'a str,
+    }
+
     let simple = FragmentSimple { name: "world" };
 
     assert_eq!(simple.render().unwrap(), "\n<p>Hello world!</p>\n");
-}
-
-#[derive(Template)]
-#[template(path = "fragment-super.html", block = "body")]
-struct FragmentSuper<'a> {
-    name: &'a str,
 }
 
 /// Tests a case where a block fragment rendering calls the parent.
 /// Single inheritance only.
 #[test]
 fn test_fragment_super() {
+    #[derive(Template)]
+    #[template(path = "fragment-super.html", block = "body")]
+    struct FragmentSuper<'a> {
+        name: &'a str,
+    }
+
     let sup = FragmentSuper { name: "world" };
 
     assert_eq!(
@@ -32,13 +32,13 @@ fn test_fragment_super() {
     );
 }
 
-#[derive(Template)]
-#[template(path = "fragment-nested-block.html", block = "nested")]
-struct FragmentNestedBlock;
-
 /// Tests rendering a block fragment inside of a block.
 #[test]
 fn test_fragment_nested_block() {
+    #[derive(Template)]
+    #[template(path = "fragment-nested-block.html", block = "nested")]
+    struct FragmentNestedBlock;
+
     let nested_block = FragmentNestedBlock {};
 
     assert_eq!(
@@ -47,16 +47,16 @@ fn test_fragment_nested_block() {
     );
 }
 
-#[derive(Template)]
-#[template(path = "fragment-nested-super.html", block = "body")]
-struct FragmentNestedSuper<'a> {
-    name: &'a str,
-}
-
 /// Tests rendering a block fragment with multiple inheritance.
 /// The middle parent adds square brackets around the base.
 #[test]
 fn test_fragment_nested_super() {
+    #[derive(Template)]
+    #[template(path = "fragment-nested-super.html", block = "body")]
+    struct FragmentNestedSuper<'a> {
+        name: &'a str,
+    }
+
     let nested_sup = FragmentNestedSuper { name: "world" };
 
     assert_eq!(
@@ -65,16 +65,16 @@ fn test_fragment_nested_super() {
     );
 }
 
-#[derive(Template)]
-#[template(path = "fragment-unused-expr.html", block = "body")]
-struct FragmentUnusedExpr<'a> {
-    required: &'a str,
-}
-
 /// Tests a case where an expression is defined outside of a block fragment
 /// Ideally, the struct isn't required to define that field.
 #[test]
 fn test_fragment_unused_expression() {
+    #[derive(Template)]
+    #[template(path = "fragment-unused-expr.html", block = "body")]
+    struct FragmentUnusedExpr<'a> {
+        required: &'a str,
+    }
+
     let unused_expr = FragmentUnusedExpr {
         required: "Required",
     };
@@ -82,20 +82,20 @@ fn test_fragment_unused_expression() {
     assert_eq!(unused_expr.render().unwrap(), "\n<p>Required</p>\n");
 }
 
-#[derive(Template)]
-#[template(path = "blocks.txt", block = "index")]
-struct RenderInPlace<'a> {
-    s1: Section<'a>,
-}
-
-#[derive(Template)]
-#[template(path = "blocks.txt", block = "section")]
-struct Section<'a> {
-    values: &'a [&'a str],
-}
-
 #[test]
 fn test_specific_block() {
+    #[derive(Template)]
+    #[template(path = "blocks.txt", block = "index")]
+    struct RenderInPlace<'a> {
+        s1: Section<'a>,
+    }
+
+    #[derive(Template)]
+    #[template(path = "blocks.txt", block = "section")]
+    struct Section<'a> {
+        values: &'a [&'a str],
+    }
+
     let s1 = Section {
         values: &["a", "b", "c"],
     };
@@ -104,27 +104,29 @@ fn test_specific_block() {
     assert_eq!(t.render().unwrap(), "\nSection: [abc]\n");
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"{% block empty %}
+#[test]
+fn test_render_only_block() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% block empty %}
 {% endblock %}
 
 {% if let Some(var) = var %}
 {{ var }}
 {% endif %}"#,
-    block = "empty",
-    ext = "txt"
-)]
-struct Empty {}
+        block = "empty",
+        ext = "txt"
+    )]
+    struct Empty {}
 
-#[test]
-fn test_render_only_block() {
     assert_eq!(Empty {}.render().unwrap(), "\n");
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"{% extends "fragment-base.html" %}
+#[test]
+fn test_fragment_include() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% extends "fragment-base.html" %}
 
 {% block body %}
 {% include "included.html" %}
@@ -133,15 +135,13 @@ fn test_render_only_block() {
 {% block other_body %}
 <p>Don't render me.</p>
 {% endblock %}"#,
-    block = "body",
-    ext = "html"
-)]
-struct FragmentInclude<'a> {
-    s: &'a str,
-}
+        block = "body",
+        ext = "html"
+    )]
+    struct FragmentInclude<'a> {
+        s: &'a str,
+    }
 
-#[test]
-fn test_fragment_include() {
     let fragment_include = FragmentInclude { s: "world" };
     assert_eq!(fragment_include.render().unwrap(), "\nINCLUDED: world\n");
 }

--- a/testing/tests/calls.rs
+++ b/testing/tests/calls.rs
@@ -1,51 +1,51 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(source = "{{ b(value) }}", ext = "txt")]
-struct OneFunction {
-    value: u32,
-}
-
-impl OneFunction {
-    fn b(&self, x: &u32) -> u32 {
-        self.value + x
-    }
-}
-
 #[test]
 fn test_one_func() {
+    #[derive(Template)]
+    #[template(source = "{{ b(value) }}", ext = "txt")]
+    struct OneFunction {
+        value: u32,
+    }
+
+    impl OneFunction {
+        fn b(&self, x: &u32) -> u32 {
+            self.value + x
+        }
+    }
+
     let t = OneFunction { value: 10 };
     assert_eq!(t.render().unwrap(), "20");
 }
 
-#[derive(Template)]
-#[template(source = "{{ self.func(value) }}", ext = "txt")]
-struct OneFunctionSelf {
-    value: i32,
-}
-
-impl OneFunctionSelf {
-    fn func(&self, i: &i32) -> i32 {
-        2 * i
-    }
-}
-
 #[test]
 fn test_one_func_self() {
+    #[derive(Template)]
+    #[template(source = "{{ self.func(value) }}", ext = "txt")]
+    struct OneFunctionSelf {
+        value: i32,
+    }
+
+    impl OneFunctionSelf {
+        fn func(&self, i: &i32) -> i32 {
+            2 * i
+        }
+    }
+
     let t = OneFunctionSelf { value: 123 };
     assert_eq!(t.render().unwrap(), "246");
 }
 
-#[derive(Template)]
-#[template(source = "{{ func[index](value) }}", ext = "txt")]
-struct OneFunctionIndex<'a> {
-    func: &'a [fn(&i32) -> i32],
-    value: i32,
-    index: usize,
-}
-
 #[test]
 fn test_one_func_index() {
+    #[derive(Template)]
+    #[template(source = "{{ func[index](value) }}", ext = "txt")]
+    struct OneFunctionIndex<'a> {
+        func: &'a [fn(&i32) -> i32],
+        value: i32,
+        index: usize,
+    }
+
     let t = OneFunctionIndex {
         func: &[|_| panic!(), |&i| 2 * i, |_| panic!(), |_| panic!()],
         value: 123,
@@ -54,27 +54,27 @@ fn test_one_func_index() {
     assert_eq!(t.render().unwrap(), "246");
 }
 
-struct AddToGetAFunction;
-
-impl std::ops::Add<usize> for &AddToGetAFunction {
-    type Output = fn(&i32) -> i32;
-
-    fn add(self, rhs: usize) -> Self::Output {
-        assert_eq!(rhs, 1);
-        |&i| 2 * i
-    }
-}
-
-#[derive(Template)]
-#[template(source = "{{ (func + index)(value) }}", ext = "txt")]
-struct OneFunctionBinop<'a> {
-    func: &'a AddToGetAFunction,
-    value: i32,
-    index: usize,
-}
-
 #[test]
 fn test_one_func_binop() {
+    struct AddToGetAFunction;
+
+    impl std::ops::Add<usize> for &AddToGetAFunction {
+        type Output = fn(&i32) -> i32;
+
+        fn add(self, rhs: usize) -> Self::Output {
+            assert_eq!(rhs, 1);
+            |&i| 2 * i
+        }
+    }
+
+    #[derive(Template)]
+    #[template(source = "{{ (func + index)(value) }}", ext = "txt")]
+    struct OneFunctionBinop<'a> {
+        func: &'a AddToGetAFunction,
+        value: i32,
+        index: usize,
+    }
+
     let t = OneFunctionBinop {
         func: &AddToGetAFunction,
         value: 123,
@@ -83,29 +83,35 @@ fn test_one_func_binop() {
     assert_eq!(t.render().unwrap(), "246");
 }
 
-fn double_attr_arg_helper(x: u32) -> u32 {
-    x * x + x
-}
+mod test_double_attr_arg {
+    use rinja::Template;
 
-#[derive(rinja::Template)]
-#[template(
-    source = "{{ self::double_attr_arg_helper(self.x.0 + 2) }}",
-    ext = "txt"
-)]
-struct DoubleAttrArg {
-    x: (u32,),
-}
+    fn double_attr_arg_helper(x: u32) -> u32 {
+        x * x + x
+    }
 
-#[test]
-fn test_double_attr_arg() {
-    let t = DoubleAttrArg { x: (10,) };
-    assert_eq!(t.render().unwrap(), "156");
+    #[derive(rinja::Template)]
+    #[template(
+        source = "{{ self::double_attr_arg_helper(self.x.0 + 2) }}",
+        ext = "txt"
+    )]
+    struct DoubleAttrArg {
+        x: (u32,),
+    }
+
+    #[test]
+    fn test_double_attr_arg() {
+        let t = DoubleAttrArg { x: (10,) };
+        assert_eq!(t.render().unwrap(), "156");
+    }
 }
 
 // Ensures that fields are not moved when calling a jinja macro.
-#[derive(Template)]
-#[template(
-    source = "
+#[test]
+fn test_do_not_move_fields() {
+    #[derive(Template)]
+    #[template(
+        source = "
 {%- macro package_navigation(title, show) -%}
 {%- if show -%}
 {{title}}
@@ -116,29 +122,27 @@ no show
 
 {%- call package_navigation(title=title, show=true) -%}
 ",
-    ext = "html"
-)]
-struct DoNotMoveFields {
-    title: String,
-}
+        ext = "html"
+    )]
+    struct DoNotMoveFields {
+        title: String,
+    }
 
-#[test]
-fn test_do_not_move_fields() {
     let x = DoNotMoveFields {
         title: "a".to_string(),
     };
     assert_eq!(x.render().unwrap(), "a");
 }
 
-#[derive(Template)]
-#[template(source = "{{ (func)(value) }}", ext = "txt")]
-struct ClosureField {
-    func: fn(&i32) -> i32,
-    value: i32,
-}
-
 #[test]
 fn test_closure_field() {
+    #[derive(Template)]
+    #[template(source = "{{ (func)(value) }}", ext = "txt")]
+    struct ClosureField {
+        func: fn(&i32) -> i32,
+        value: i32,
+    }
+
     let t = ClosureField {
         func: |&i| 2 * i,
         value: 123,
@@ -146,70 +150,78 @@ fn test_closure_field() {
     assert_eq!(t.render().unwrap(), "246");
 }
 
-fn single() -> &'static str {
-    "a"
-}
+mod test_not_method {
+    use rinja::Template;
 
-mod sub_mod {
-    pub fn sub_fn(v: i32) -> i32 {
-        v * 2
+    fn single() -> &'static str {
+        "a"
+    }
+
+    mod sub_mod {
+        pub fn sub_fn(v: i32) -> i32 {
+            v * 2
+        }
+    }
+
+    #[derive(Template)]
+    #[template(
+        source = "
+    {{- self::single() -}}
+    {{- sub_mod::sub_fn(3) -}}
+    ",
+        ext = "txt"
+    )]
+    struct NotMethod;
+
+    #[test]
+    fn test_not_method() {
+        assert_eq!(NotMethod.render().unwrap(), "a6");
     }
 }
 
-#[derive(Template)]
-#[template(
-    source = "
-{{- self::single() -}}
-{{- sub_mod::sub_fn(3) -}}
-",
-    ext = "txt"
-)]
-struct NotMethod;
+mod test_deref_method_arg {
+    use rinja::Template;
 
-#[test]
-fn test_not_method() {
-    assert_eq!(NotMethod.render().unwrap(), "a6");
-}
-
-#[derive(Template)]
-#[template(
-    source = "
-{{- bar(x) -}}
-{{- bar(&*x) -}}
-{{- foo(*x) -}}
-{{- foo(*&*x) -}}
-{# #} {{+ extra_fn::bar(x) -}}
-{{- extra_fn::bar(&*x) -}}
-{{- extra_fn::foo(*x) -}}
-{{- extra_fn::foo(*&*x) -}}
-",
-    ext = "txt"
-)]
-struct DerefMethodArg {
-    x: u32,
-}
-
-mod extra_fn {
-    pub fn bar(x: &u32) -> u32 {
-        *x + 4
+    #[derive(Template)]
+    #[template(
+        source = "
+    {{- bar(x) -}}
+    {{- bar(&*x) -}}
+    {{- foo(*x) -}}
+    {{- foo(*&*x) -}}
+    {# #} {{+ extra_fn::bar(x) -}}
+    {{- extra_fn::bar(&*x) -}}
+    {{- extra_fn::foo(*x) -}}
+    {{- extra_fn::foo(*&*x) -}}
+    ",
+        ext = "txt"
+    )]
+    struct DerefMethodArg {
+        x: u32,
     }
-    pub fn foo(x: u32) -> u32 {
-        x + 5
-    }
-}
 
-impl DerefMethodArg {
-    fn bar(&self, x: &u32) -> u32 {
-        *x + 1
+    mod extra_fn {
+        pub fn bar(x: &u32) -> u32 {
+            *x + 4
+        }
+        pub fn foo(x: u32) -> u32 {
+            x + 5
+        }
     }
-    fn foo(&self, x: u32) -> u32 {
-        x
-    }
-}
 
-// This test ensures that the `*`/`&` operators are correctly placed on method/function arguments.
-#[test]
-fn test_deref_method_arg() {
-    let x = DerefMethodArg { x: 2 };
-    assert_eq!(x.render().unwrap(), "3322 6677");
+    impl DerefMethodArg {
+        fn bar(&self, x: &u32) -> u32 {
+            *x + 1
+        }
+        fn foo(&self, x: u32) -> u32 {
+            x
+        }
+    }
+
+    // This test ensures that the `*`/`&` operators are correctly placed on method/function arguments.
+    #[test]
+    fn test_deref_method_arg() {
+        let x = DerefMethodArg { x: 2 };
+        assert_eq!(x.render().unwrap(), "3322 6677");
+    }
 }

--- a/testing/tests/coerce.rs
+++ b/testing/tests/coerce.rs
@@ -1,14 +1,14 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(path = "if-coerce.html")]
-struct IfCoerceTemplate {
-    t: bool,
-    f: bool,
-}
-
 #[test]
 fn test_coerce() {
+    #[derive(Template)]
+    #[template(path = "if-coerce.html")]
+    struct IfCoerceTemplate {
+        t: bool,
+        f: bool,
+    }
+
     let t = IfCoerceTemplate { t: true, f: false };
     assert_eq!(t.render().unwrap(), "ftftfttftelseifelseif");
 }

--- a/testing/tests/ext.rs
+++ b/testing/tests/ext.rs
@@ -1,88 +1,88 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(path = "foo.html")]
-struct PathHtml;
-
 #[test]
 fn test_path_ext_html() {
+    #[derive(Template)]
+    #[template(path = "foo.html")]
+    struct PathHtml;
+
     let t = PathHtml;
     assert_eq!(t.render().unwrap(), "foo.html");
     assert_eq!(PathHtml::EXTENSION, Some("html"));
 }
 
-#[derive(Template)]
-#[template(path = "foo.jinja")]
-struct PathJinja;
-
 #[test]
 fn test_path_ext_jinja() {
+    #[derive(Template)]
+    #[template(path = "foo.jinja")]
+    struct PathJinja;
+
     let t = PathJinja;
     assert_eq!(t.render().unwrap(), "foo.jinja");
     assert_eq!(PathJinja::EXTENSION, Some("jinja"));
 }
 
-#[derive(Template)]
-#[template(path = "foo.html.jinja")]
-struct PathHtmlJinja;
-
 #[test]
 fn test_path_ext_html_jinja() {
+    #[derive(Template)]
+    #[template(path = "foo.html.jinja")]
+    struct PathHtmlJinja;
+
     let t = PathHtmlJinja;
     assert_eq!(t.render().unwrap(), "foo.html.jinja");
     assert_eq!(PathHtmlJinja::EXTENSION, Some("html"));
 }
 
-#[derive(Template)]
-#[template(path = "foo.html", ext = "txt")]
-struct PathHtmlAndExtTxt;
-
 #[test]
 fn test_path_ext_html_and_ext_txt() {
+    #[derive(Template)]
+    #[template(path = "foo.html", ext = "txt")]
+    struct PathHtmlAndExtTxt;
+
     let t = PathHtmlAndExtTxt;
     assert_eq!(t.render().unwrap(), "foo.html");
     assert_eq!(PathHtmlAndExtTxt::EXTENSION, Some("txt"));
 }
 
-#[derive(Template)]
-#[template(path = "foo.jinja", ext = "txt")]
-struct PathJinjaAndExtTxt;
-
 #[test]
 fn test_path_ext_jinja_and_ext_txt() {
+    #[derive(Template)]
+    #[template(path = "foo.jinja", ext = "txt")]
+    struct PathJinjaAndExtTxt;
+
     let t = PathJinjaAndExtTxt;
     assert_eq!(t.render().unwrap(), "foo.jinja");
     assert_eq!(PathJinjaAndExtTxt::EXTENSION, Some("txt"));
 }
 
-#[derive(Template)]
-#[template(path = "foo.html.jinja", ext = "txt")]
-struct PathHtmlJinjaAndExtTxt;
-
 #[test]
 fn test_path_ext_html_jinja_and_ext_txt() {
+    #[derive(Template)]
+    #[template(path = "foo.html.jinja", ext = "txt")]
+    struct PathHtmlJinjaAndExtTxt;
+
     let t = PathHtmlJinjaAndExtTxt;
     assert_eq!(t.render().unwrap(), "foo.html.jinja");
     assert_eq!(PathHtmlJinjaAndExtTxt::EXTENSION, Some("txt"));
 }
 
-#[derive(Template)]
-#[template(path = "foo.rinja")]
-struct PathRinja;
-
 #[test]
 fn test_path_ext_rinja() {
+    #[derive(Template)]
+    #[template(path = "foo.rinja")]
+    struct PathRinja;
+
     let t = PathRinja;
     assert_eq!(t.render().unwrap(), "foo.rinja");
     assert_eq!(PathRinja::EXTENSION, Some("rinja"));
 }
 
-#[derive(Template)]
-#[template(path = "foo.html.rinja")]
-struct PathHtmlRinja;
-
 #[test]
 fn test_path_ext_html_rinja() {
+    #[derive(Template)]
+    #[template(path = "foo.html.rinja")]
+    struct PathHtmlRinja;
+
     let t = PathHtmlRinja;
     assert_eq!(t.render().unwrap(), "foo.html.rinja");
     assert_eq!(PathHtmlRinja::EXTENSION, Some("html"));

--- a/testing/tests/extend.rs
+++ b/testing/tests/extend.rs
@@ -1,8 +1,10 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(
-    source = r#"{% extends "extend_and_import.html" %}
+#[test]
+fn test_macro_in_block_inheritance() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% extends "extend_and_import.html" %}
 {%- import "macro.html" as m2 -%}
 
 {%- macro another(param) -%}
@@ -17,11 +19,9 @@ use rinja::Template;
 {% call another(3) %}
 {%- endblock -%}
 "#,
-    ext = "txt"
-)]
-struct A;
+        ext = "txt"
+    )]
+    struct A;
 
-#[test]
-fn test_macro_in_block_inheritance() {
     assert_eq!(A.render().unwrap(), "\n\n1 1\n2 2\n--> 3");
 }

--- a/testing/tests/filter_block.rs
+++ b/testing/tests/filter_block.rs
@@ -1,35 +1,37 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(
-    source = r#"{% filter lower %}
+#[test]
+fn filter_block_basic() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% filter lower %}
     {{ t }} / HELLO / {{ u }}
 {% endfilter %}
 
 {{ u|lower }}
 "#,
-    ext = "html"
-)]
-struct A<T, U = u8>
-where
-    T: std::fmt::Display,
-    U: std::fmt::Display,
-{
-    t: T,
-    u: U,
-}
+        ext = "html"
+    )]
+    struct A<T, U = u8>
+    where
+        T: std::fmt::Display,
+        U: std::fmt::Display,
+    {
+        t: T,
+        u: U,
+    }
 
-#[test]
-fn filter_block_basic() {
     let template = A { t: "a", u: "B" };
     assert_eq!(template.render().unwrap(), "\n    a / hello / b\n\n\nb\n");
 }
 
 // This test ensures that we don't have variable shadowing when we have more than one
 // filter block at the same location.
-#[derive(Template)]
-#[template(
-    source = r#"{% filter lower %}
+#[test]
+fn filter_block_shadowing() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% filter lower %}
     {{ t }} / HELLO / {{ u }}
 {% endfilter %}
 
@@ -42,19 +44,17 @@ fn filter_block_basic() {
 {% endfilter %}
 
 {{ u|upper }}"#,
-    ext = "html"
-)]
-struct B<T, U = u8>
-where
-    T: std::fmt::Display,
-    U: std::fmt::Display,
-{
-    t: T,
-    u: U,
-}
+        ext = "html"
+    )]
+    struct B<T, U = u8>
+    where
+        T: std::fmt::Display,
+        U: std::fmt::Display,
+    {
+        t: T,
+        u: U,
+    }
 
-#[test]
-fn filter_block_shadowing() {
     let template = B { t: "a", u: "B" };
     assert_eq!(
         template.render().unwrap(),
@@ -75,9 +75,11 @@ B"
 }
 
 // This test ensures that whitespace control is correctly handled.
-#[derive(Template)]
-#[template(
-    source = r#"{% filter lower -%}
+#[test]
+fn filter_block_whitespace_control() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% filter lower -%}
     {{ t }} / HELLO / {{ u }}
 {% endfilter %}
 
@@ -86,19 +88,17 @@ B"
 {%- endfilter -%}
 
 ++b"#,
-    ext = "html"
-)]
-struct C<T, U = u8>
-where
-    T: std::fmt::Display,
-    U: std::fmt::Display,
-{
-    t: T,
-    u: U,
-}
+        ext = "html"
+    )]
+    struct C<T, U = u8>
+    where
+        T: std::fmt::Display,
+        U: std::fmt::Display,
+    {
+        t: T,
+        u: U,
+    }
 
-#[test]
-fn filter_block_whitespace_control() {
     let template = C { t: "a", u: "B" };
     assert_eq!(
         template.render().unwrap(),
@@ -108,51 +108,53 @@ B + TADAM + A++b"
 }
 
 // This test ensures that HTML escape is correctly handled.
-#[derive(Template)]
-#[template(source = r#"{% filter lower %}<block>{% endfilter %}"#, ext = "html")]
-struct D;
-
 #[test]
 fn filter_block_html_escape() {
+    #[derive(Template)]
+    #[template(source = r#"{% filter lower %}<block>{% endfilter %}"#, ext = "html")]
+    struct D;
+
     let template = D;
     assert_eq!(template.render().unwrap(), r"&#60;block&#62;");
 }
 
 // This test ensures that it is not escaped if it is not HTML.
-#[derive(Template)]
-#[template(source = r#"{% filter lower %}<block>{% endfilter %}"#, ext = "txt")]
-struct E;
-
 #[test]
 fn filter_block_not_html_escape() {
+    #[derive(Template)]
+    #[template(source = r#"{% filter lower %}<block>{% endfilter %}"#, ext = "txt")]
+    struct E;
+
     let template = E;
     assert_eq!(template.render().unwrap(), r"<block>");
 }
 
 // This test checks that the filter chaining is working as expected.
-#[derive(Template)]
-#[template(
-    source = r#"{% filter lower|indent(2)|capitalize -%}
+#[test]
+fn filter_block_chaining() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% filter lower|indent(2)|capitalize -%}
 HELLO
 {{v}}
 {%- endfilter %}"#,
-    ext = "txt"
-)]
-struct F {
-    v: &'static str,
-}
+        ext = "txt"
+    )]
+    struct F {
+        v: &'static str,
+    }
 
-#[test]
-fn filter_block_chaining() {
     let template = F { v: "pIKA" };
     assert_eq!(template.render().unwrap(), "Hello\n  pika");
 }
 
 // This test checks that the filter chaining is working as expected when ending
 // followed by whitespace character(s).
-#[derive(Template)]
-#[template(
-    source = r#"{% filter lower|indent(2) -%}
+#[test]
+fn filter_block_chaining_paren_followed_by_whitespace() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% filter lower|indent(2) -%}
 HELLO
 {{v}}
 {%- endfilter %}
@@ -171,14 +173,12 @@ HELLO
 HELLO
 {{v}}
 {%- endfilter %}"#,
-    ext = "txt"
-)]
-struct G {
-    v: &'static str,
-}
+        ext = "txt"
+    )]
+    struct G {
+        v: &'static str,
+    }
 
-#[test]
-fn filter_block_chaining_paren_followed_by_whitespace() {
     let template = G { v: "pIKA" };
     assert_eq!(
         template.render().unwrap(),
@@ -198,9 +198,13 @@ hello
     );
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"{% extends "html-base.html" %}
+// This test ensures that `include` are correctly working inside filter blocks and that external
+// variables are used correctly.
+#[test]
+fn filter_block_include() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% extends "html-base.html" %}
 
 {%- block body -%}
     <h1>Metadata</h1>
@@ -212,14 +216,10 @@ hello
     {% endfilter %}
 {%- endblock body %}
 "#,
-    ext = "html"
-)]
-struct IncludeInFilter;
+        ext = "html"
+    )]
+    struct IncludeInFilter;
 
-// This test ensures that `include` are correctly working inside filter blocks and that external
-// variables are used correctly.
-#[test]
-fn filter_block_include() {
     assert_eq!(
         IncludeInFilter.render().unwrap(),
         r#"<!DOCTYPE html>
@@ -238,9 +238,13 @@ fn filter_block_include() {
     );
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"
+// This test ensures that `include` are correctly working inside filter blocks and that external
+// variables are used correctly.
+#[test]
+fn filter_block_conditions() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
 {%- filter title %}
     {{- x -}}
     {%- if x == 21 -%}
@@ -254,17 +258,13 @@ fn filter_block_include() {
     {% endif -%}
 {% endfilter -%}
 "#,
-    ext = "html"
-)]
-struct ConditionInFilter {
-    x: usize,
-    v: Option<String>,
-}
+        ext = "html"
+    )]
+    struct ConditionInFilter {
+        x: usize,
+        v: Option<String>,
+    }
 
-// This test ensures that `include` are correctly working inside filter blocks and that external
-// variables are used correctly.
-#[test]
-fn filter_block_conditions() {
     let s = ConditionInFilter {
         x: 21,
         v: Some("hoho".to_string()),
@@ -274,9 +274,11 @@ fn filter_block_conditions() {
 
 // The output of `|upper` is not marked as `|safe`, so the output of `|paragraphbreaks` gets
 // escaped. The '&' in the input is is not marked as `|safe`, so it should get escaped, twice.
-#[derive(Template)]
-#[template(
-    source = r#"
+#[test]
+fn filter_nested_filter_blocks() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
     {%- let count = 1 -%}
     {%- let canary = 2 -%}
     {%- filter upper -%}
@@ -289,14 +291,12 @@ fn filter_block_conditions() {
             {%- endfor -%}
         ]
     {%~ endfilter %}{{ canary }}"#,
-    ext = "html"
-)]
-struct NestedFilterBlocks2 {
-    v: &'static str,
-}
+        ext = "html"
+    )]
+    struct NestedFilterBlocks2 {
+        v: &'static str,
+    }
 
-#[test]
-fn filter_nested_filter_blocks() {
     let template = NestedFilterBlocks2 {
         v: "Hello &\n\ngoodbye!",
     };
@@ -311,20 +311,20 @@ fn filter_nested_filter_blocks() {
     );
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"
+#[test]
+fn filter_block_custom_errors() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
     {%- filter urlencode|urlencode|urlencode|urlencode -%}
         {{ msg.clone()? }}
     {%~ endfilter %}"#,
-    ext = "html"
-)]
-struct FilterBlockCustomErrors {
-    msg: Result<String, String>,
-}
+        ext = "html"
+    )]
+    struct FilterBlockCustomErrors {
+        msg: Result<String, String>,
+    }
 
-#[test]
-fn filter_block_custom_errors() {
     let template = FilterBlockCustomErrors {
         msg: Err("🐢".to_owned()),
     };

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -6,14 +6,14 @@ use rinja::Template;
 #[cfg(feature = "serde_json")]
 use serde_json::Value;
 
-#[derive(Template)]
-#[template(path = "filters.html")]
-struct TestTemplate {
-    strvar: String,
-}
-
 #[test]
 fn filter_escape() {
+    #[derive(Template)]
+    #[template(path = "filters.html")]
+    struct TestTemplate {
+        strvar: String,
+    }
+
     let s = TestTemplate {
         strvar: "// my <html> is \"unsafe\" & should be 'escaped'".to_string(),
     };
@@ -24,20 +24,20 @@ fn filter_escape() {
     );
 }
 
-#[derive(Template)]
-#[template(
-    source = "{{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape(\"none\") }}
+#[test]
+fn filter_opt_escaper_none() {
+    #[derive(Template)]
+    #[template(
+        source = "{{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape(\"none\") }}
 {{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape(\"html\") }}
 {{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape }}
 {{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\" }}
 ",
-    ext = "txt",
-    escape = "none"
-)]
-struct OptEscaperNoneTemplate;
+        ext = "txt",
+        escape = "none"
+    )]
+    struct OptEscaperNoneTemplate;
 
-#[test]
-fn filter_opt_escaper_none() {
     let t = OptEscaperNoneTemplate;
     assert_eq!(
         t.render().unwrap(),
@@ -49,20 +49,20 @@ fn filter_opt_escaper_none() {
     );
 }
 
-#[derive(Template)]
-#[template(
-    source = "{{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape(\"none\") }}
+#[test]
+fn filter_opt_escaper_html() {
+    #[derive(Template)]
+    #[template(
+        source = "{{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape(\"none\") }}
 {{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape(\"html\") }}
 {{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\"|escape }}
 {{ \"<h1 class=\\\"title\\\">Foo Bar</h1>\" }}
 ",
-    ext = "txt",
-    escape = "html"
-)]
-struct OptEscaperHtmlTemplate;
+        ext = "txt",
+        escape = "html"
+    )]
+    struct OptEscaperHtmlTemplate;
 
-#[test]
-fn filter_opt_escaper_html() {
     let t = OptEscaperHtmlTemplate;
     assert_eq!(
         t.render().unwrap(),
@@ -74,34 +74,28 @@ fn filter_opt_escaper_html() {
     );
 }
 
-#[derive(Template)]
-#[template(path = "format.html", escape = "none")]
-struct FormatTemplate<'a> {
-    var: &'a str,
-}
-
 #[test]
 fn filter_format() {
+    #[derive(Template)]
+    #[template(path = "format.html", escape = "none")]
+    struct FormatTemplate<'a> {
+        var: &'a str,
+    }
+
     let t = FormatTemplate { var: "formatted" };
     assert_eq!(t.render().unwrap(), "\"formatted\"");
 }
 
-#[derive(Template)]
-#[template(source = "{{ var|fmt(\"{:?}\") }}", ext = "html", escape = "none")]
-struct FmtTemplate<'a> {
-    var: &'a str,
-}
-
 #[test]
 fn filter_fmt() {
+    #[derive(Template)]
+    #[template(source = "{{ var|fmt(\"{:?}\") }}", ext = "html", escape = "none")]
+    struct FmtTemplate<'a> {
+        var: &'a str,
+    }
+
     let t = FmtTemplate { var: "formatted" };
     assert_eq!(t.render().unwrap(), "\"formatted\"");
-}
-
-#[derive(Template)]
-#[template(source = "{{ s|myfilter }}", ext = "txt")]
-struct MyFilterTemplate<'a> {
-    s: &'a str,
 }
 
 mod filters {
@@ -116,32 +110,38 @@ mod filters {
 
 #[test]
 fn test_my_filter() {
+    #[derive(Template)]
+    #[template(source = "{{ s|myfilter }}", ext = "txt")]
+    struct MyFilterTemplate<'a> {
+        s: &'a str,
+    }
+
     let t = MyFilterTemplate { s: "foo" };
     assert_eq!(t.render().unwrap(), "faa");
 }
 
-#[derive(Template)]
-#[template(path = "filters_join.html")]
-struct JoinTemplate<'a> {
-    s: &'a [&'a str],
-}
-
 #[test]
 fn test_join() {
+    #[derive(Template)]
+    #[template(path = "filters_join.html")]
+    struct JoinTemplate<'a> {
+        s: &'a [&'a str],
+    }
+
     let t = JoinTemplate {
         s: &["foo", "bar", "bazz"],
     };
     assert_eq!(t.render().unwrap(), "foo, bar, bazz");
 }
 
-#[derive(Template)]
-#[template(path = "filters_join.html")]
-struct VecJoinTemplate {
-    s: Vec<String>,
-}
-
 #[test]
 fn test_vec_join() {
+    #[derive(Template)]
+    #[template(path = "filters_join.html")]
+    struct VecJoinTemplate {
+        s: Vec<String>,
+    }
+
     let t = VecJoinTemplate {
         s: vec!["foo".into(), "bar".into(), "bazz".into()],
     };
@@ -149,22 +149,21 @@ fn test_vec_join() {
 }
 
 #[cfg(feature = "serde_json")]
-#[derive(Template)]
-#[template(
-    source = r#"{
+#[test]
+fn test_json() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{
   "foo": "{{ foo }}",
   "bar": {{ bar|json|safe }}
 }"#,
-    ext = "txt"
-)]
-struct JsonTemplate<'a> {
-    foo: &'a str,
-    bar: &'a Value,
-}
+        ext = "txt"
+    )]
+    struct JsonTemplate<'a> {
+        foo: &'a str,
+        bar: &'a Value,
+    }
 
-#[cfg(feature = "serde_json")]
-#[test]
-fn test_json() {
     let val = json!({"arr": [ "one", 2, true, null ]});
     let t = JsonTemplate {
         foo: "a",
@@ -180,22 +179,21 @@ fn test_json() {
 }
 
 #[cfg(feature = "serde_json")]
-#[derive(Template)]
-#[template(
-    source = r#"{
+#[test]
+fn test_pretty_json() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{
   "foo": "{{ foo }}",
   "bar": {{ bar|json(2)|safe }}
 }"#,
-    ext = "txt"
-)]
-struct PrettyJsonTemplate<'a> {
-    foo: &'a str,
-    bar: &'a Value,
-}
+        ext = "txt"
+    )]
+    struct PrettyJsonTemplate<'a> {
+        foo: &'a str,
+        bar: &'a Value,
+    }
 
-#[cfg(feature = "serde_json")]
-#[test]
-fn test_pretty_json() {
     let val = json!({"arr": [ "one", 2, true, null ]});
     let t = PrettyJsonTemplate {
         foo: "a",
@@ -219,16 +217,15 @@ fn test_pretty_json() {
 }
 
 #[cfg(feature = "serde_json")]
-#[derive(Template)]
-#[template(source = r#"{{ bar|json(indent)|safe }}"#, ext = "txt")]
-struct DynamicJsonTemplate<'a> {
-    bar: &'a Value,
-    indent: &'a str,
-}
-
-#[cfg(feature = "serde_json")]
 #[test]
 fn test_dynamic_json() {
+    #[derive(Template)]
+    #[template(source = r#"{{ bar|json(indent)|safe }}"#, ext = "txt")]
+    struct DynamicJsonTemplate<'a> {
+        bar: &'a Value,
+        indent: &'a str,
+    }
+
     let val = json!({"arr": ["one", 2]});
     let t = DynamicJsonTemplate {
         bar: &val,
@@ -245,40 +242,40 @@ fn test_dynamic_json() {
     );
 }
 
-#[derive(Template)]
-#[template(source = "{{ x|mytrim|safe }}", ext = "html")]
-struct NestedFilterTemplate {
-    x: String,
-}
-
 #[test]
 fn test_nested_filter_ref() {
+    #[derive(Template)]
+    #[template(source = "{{ x|mytrim|safe }}", ext = "html")]
+    struct NestedFilterTemplate {
+        x: String,
+    }
+
     let t = NestedFilterTemplate {
         x: " floo & bar".to_string(),
     };
     assert_eq!(t.render().unwrap(), "floo & bar");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% let p = baz.print(foo.as_ref()) %}{{ p|upper }}",
-    ext = "html"
-)]
-struct FilterLetFilterTemplate {
-    foo: String,
-    baz: Baz,
-}
-
-struct Baz {}
-
-impl Baz {
-    fn print(&self, s: &str) -> String {
-        s.trim().to_owned()
-    }
-}
-
 #[test]
 fn test_filter_let_filter() {
+    #[derive(Template)]
+    #[template(
+        source = "{% let p = baz.print(foo.as_ref()) %}{{ p|upper }}",
+        ext = "html"
+    )]
+    struct FilterLetFilterTemplate {
+        foo: String,
+        baz: Baz,
+    }
+
+    struct Baz {}
+
+    impl Baz {
+        fn print(&self, s: &str) -> String {
+            s.trim().to_owned()
+        }
+    }
+
     let t = FilterLetFilterTemplate {
         foo: " bar ".to_owned(),
         baz: Baz {},
@@ -286,14 +283,14 @@ fn test_filter_let_filter() {
     assert_eq!(t.render().unwrap(), "BAR");
 }
 
-#[derive(Template)]
-#[template(source = "{{ foo|truncate(10) }}{{ foo|truncate(5) }}", ext = "txt")]
-struct TruncateFilter {
-    foo: String,
-}
-
 #[test]
 fn test_filter_truncate() {
+    #[derive(Template)]
+    #[template(source = "{{ foo|truncate(10) }}{{ foo|truncate(5) }}", ext = "txt")]
+    struct TruncateFilter {
+        foo: String,
+    }
+
     let t = TruncateFilter {
         foo: "alpha bar".into(),
     };
@@ -301,15 +298,14 @@ fn test_filter_truncate() {
 }
 
 #[cfg(feature = "serde_json")]
-#[derive(Template)]
-#[template(source = r#"<li data-name="{{name|json}}"></li>"#, ext = "html")]
-struct JsonAttributeTemplate<'a> {
-    name: &'a str,
-}
-
-#[cfg(feature = "serde_json")]
 #[test]
 fn test_json_attribute() {
+    #[derive(Template)]
+    #[template(source = r#"<li data-name="{{name|json}}"></li>"#, ext = "html")]
+    struct JsonAttributeTemplate<'a> {
+        name: &'a str,
+    }
+
     let t = JsonAttributeTemplate {
         name: r#""><button>Hacked!</button>"#,
     };
@@ -320,15 +316,14 @@ fn test_json_attribute() {
 }
 
 #[cfg(feature = "serde_json")]
-#[derive(Template)]
-#[template(source = r#"<li data-name='{{name|json|safe}}'></li>"#, ext = "html")]
-struct JsonAttribute2Template<'a> {
-    name: &'a str,
-}
-
-#[cfg(feature = "serde_json")]
 #[test]
 fn test_json_attribute2() {
+    #[derive(Template)]
+    #[template(source = r#"<li data-name='{{name|json|safe}}'></li>"#, ext = "html")]
+    struct JsonAttribute2Template<'a> {
+        name: &'a str,
+    }
+
     let t = JsonAttribute2Template {
         name: r"'><button>Hacked!</button>",
     };
@@ -339,18 +334,17 @@ fn test_json_attribute2() {
 }
 
 #[cfg(feature = "serde_json")]
-#[derive(Template)]
-#[template(
-    source = r#"<script>var user = {{name|json|safe}}</script>"#,
-    ext = "html"
-)]
-struct JsonScriptTemplate<'a> {
-    name: &'a str,
-}
-
-#[cfg(feature = "serde_json")]
 #[test]
 fn test_json_script() {
+    #[derive(Template)]
+    #[template(
+        source = r#"<script>var user = {{name|json|safe}}</script>"#,
+        ext = "html"
+    )]
+    struct JsonScriptTemplate<'a> {
+        name: &'a str,
+    }
+
     let t = JsonScriptTemplate {
         name: r"</script><button>Hacked!</button>",
     };
@@ -360,19 +354,19 @@ fn test_json_script() {
     );
 }
 
-#[derive(rinja::Template)]
-#[template(
-    source = r#"{% let word = s|ref %}{{ word }}
-{%- let hello = String::from("hello") %}
-{%- if word|deref == hello %}1{% else %}2{% endif %}"#,
-    ext = "html"
-)]
-struct LetBorrow {
-    s: String,
-}
-
 #[test]
 fn test_let_borrow() {
+    #[derive(rinja::Template)]
+    #[template(
+        source = r#"{% let word = s|ref %}{{ word }}
+{%- let hello = String::from("hello") %}
+{%- if word|deref == hello %}1{% else %}2{% endif %}"#,
+        ext = "html"
+    )]
+    struct LetBorrow {
+        s: String,
+    }
+
     let template = LetBorrow {
         s: "hello".to_owned(),
     };

--- a/testing/tests/if.rs
+++ b/testing/tests/if.rs
@@ -1,8 +1,10 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(
-    source = r#"{%- if s == "" -%}
+#[test]
+fn test_if() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{%- if s == "" -%}
 empty
 {%- else if s == "b" -%}
 b
@@ -11,14 +13,12 @@ c
 {%- else -%}
 else
 {%- endif -%}"#,
-    ext = "txt"
-)]
-struct If<'a> {
-    s: &'a str,
-}
+        ext = "txt"
+    )]
+    struct If<'a> {
+        s: &'a str,
+    }
 
-#[test]
-fn test_if() {
     assert_eq!(If { s: "" }.render().unwrap(), "empty");
     assert_eq!(If { s: "b" }.render().unwrap(), "b");
     assert_eq!(If { s: "c" }.render().unwrap(), "c");

--- a/testing/tests/if_let.rs
+++ b/testing/tests/if_let.rs
@@ -1,13 +1,13 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(path = "if-let.html")]
-struct IfLetTemplate {
-    text: Option<&'static str>,
-}
-
 #[test]
 fn test_if_let() {
+    #[derive(Template)]
+    #[template(path = "if-let.html")]
+    struct IfLetTemplate {
+        text: Option<&'static str>,
+    }
+
     let s = IfLetTemplate {
         text: Some("hello"),
     };
@@ -17,14 +17,14 @@ fn test_if_let() {
     assert_eq!(t.render().unwrap(), "");
 }
 
-#[derive(Template)]
-#[template(path = "if-let-shadowing.html")]
-struct IfLetShadowingTemplate {
-    text: Option<&'static str>,
-}
-
 #[test]
 fn test_if_let_shadowing() {
+    #[derive(Template)]
+    #[template(path = "if-let-shadowing.html")]
+    struct IfLetShadowingTemplate {
+        text: Option<&'static str>,
+    }
+
     let s = IfLetShadowingTemplate {
         text: Some("hello"),
     };
@@ -40,14 +40,14 @@ struct Digits {
     three: i32,
 }
 
-#[derive(Template)]
-#[template(path = "if-let-struct.html")]
-struct IfLetStruct {
-    digits: Digits,
-}
-
 #[test]
 fn test_if_let_struct() {
+    #[derive(Template)]
+    #[template(path = "if-let-struct.html")]
+    struct IfLetStruct {
+        digits: Digits,
+    }
+
     let digits = Digits {
         one: 1,
         two: 2,
@@ -57,14 +57,14 @@ fn test_if_let_struct() {
     assert_eq!(s.render().unwrap(), "1 2 3");
 }
 
-#[derive(Template)]
-#[template(path = "if-let-struct.html")]
-struct IfLetStructRef<'a> {
-    digits: &'a Digits,
-}
-
 #[test]
 fn test_if_let_struct_ref() {
+    #[derive(Template)]
+    #[template(path = "if-let-struct.html")]
+    struct IfLetStructRef<'a> {
+        digits: &'a Digits,
+    }
+
     let digits = Digits {
         one: 1,
         two: 2,
@@ -74,15 +74,15 @@ fn test_if_let_struct_ref() {
     assert_eq!(s.render().unwrap(), "1 2 3");
 }
 
-#[derive(Template)]
-#[template(path = "if-let-else.html")]
-struct IfLetElse {
-    cond: bool,
-    value: Result<i32, &'static str>,
-}
-
 #[test]
 fn test_if_let_else() {
+    #[derive(Template)]
+    #[template(path = "if-let-else.html")]
+    struct IfLetElse {
+        cond: bool,
+        value: Result<i32, &'static str>,
+    }
+
     let s = IfLetElse {
         cond: false,
         value: Ok(4711),
@@ -108,23 +108,23 @@ fn test_if_let_else() {
     assert_eq!(s.render().unwrap(), "fail");
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"{%- if s.is_none() -%}
+#[test]
+fn test_elif() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{%- if s.is_none() -%}
 empty
 {%- elif let Some(a) = s -%}
 {{a}}
 {%- else -%}
 else
 {%- endif -%}"#,
-    ext = "txt"
-)]
-struct Elif<'a> {
-    s: Option<&'a str>,
-}
+        ext = "txt"
+    )]
+    struct Elif<'a> {
+        s: Option<&'a str>,
+    }
 
-#[test]
-fn test_elif() {
     assert_eq!(Elif { s: None }.render().unwrap(), "empty");
     assert_eq!(Elif { s: Some("tada") }.render().unwrap(), "tada");
 }

--- a/testing/tests/include.rs
+++ b/testing/tests/include.rs
@@ -1,26 +1,26 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(path = "include.html")]
-struct IncludeTemplate<'a> {
-    strs: &'a [&'a str],
-}
-
 #[test]
 fn test_include() {
+    #[derive(Template)]
+    #[template(path = "include.html")]
+    struct IncludeTemplate<'a> {
+        strs: &'a [&'a str],
+    }
+
     let strs = vec!["foo", "bar"];
     let s = IncludeTemplate { strs: &strs };
     assert_eq!(s.render().unwrap(), "\n  INCLUDED: foo\n  INCLUDED: bar");
 }
 
-#[derive(Template)]
-#[template(path = "include-extends.html")]
-struct IncludeExtendsTemplate<'a> {
-    name: &'a str,
-}
-
 #[test]
 fn test_include_extends() {
+    #[derive(Template)]
+    #[template(path = "include-extends.html")]
+    struct IncludeExtendsTemplate<'a> {
+        name: &'a str,
+    }
+
     let template = IncludeExtendsTemplate { name: "Alice" };
 
     assert_eq!(
@@ -37,15 +37,15 @@ fn test_include_extends() {
     );
 }
 
-#[derive(Template)]
-#[template(path = "include-macro.html")]
-struct IncludeMacroTemplate<'a> {
-    name: &'a str,
-    name2: &'a str,
-}
-
 #[test]
 fn test_include_macro() {
+    #[derive(Template)]
+    #[template(path = "include-macro.html")]
+    struct IncludeMacroTemplate<'a> {
+        name: &'a str,
+        name2: &'a str,
+    }
+
     let template = IncludeMacroTemplate {
         name: "Alice",
         name2: "Bob",

--- a/testing/tests/inheritance.rs
+++ b/testing/tests/inheritance.rs
@@ -8,20 +8,6 @@ struct BaseTemplate<'a> {
     title: &'a str,
 }
 
-#[derive(Template)]
-#[template(path = "child.html")]
-struct ChildTemplate<'a> {
-    _parent: &'a BaseTemplate<'a>,
-}
-
-impl<'a> Deref for ChildTemplate<'a> {
-    type Target = BaseTemplate<'a>;
-
-    fn deref(&self) -> &Self::Target {
-        self._parent
-    }
-}
-
 #[test]
 fn test_use_base_directly() {
     let t = BaseTemplate { title: "Foo" };
@@ -30,6 +16,20 @@ fn test_use_base_directly() {
 
 #[test]
 fn test_simple_extends() {
+    #[derive(Template)]
+    #[template(path = "child.html")]
+    struct ChildTemplate<'a> {
+        _parent: &'a BaseTemplate<'a>,
+    }
+
+    impl<'a> Deref for ChildTemplate<'a> {
+        type Target = BaseTemplate<'a>;
+
+        fn deref(&self) -> &Self::Target {
+            self._parent
+        }
+    }
+
     let t = ChildTemplate {
         _parent: &BaseTemplate { title: "Bar" },
     };
@@ -39,14 +39,14 @@ fn test_simple_extends() {
     );
 }
 
-#[derive(Template)]
-#[template(source = "{% extends \"base.html\" %}", ext = "html")]
-struct EmptyChild<'a> {
-    title: &'a str,
-}
-
 #[test]
 fn test_empty_child() {
+    #[derive(Template)]
+    #[template(source = "{% extends \"base.html\" %}", ext = "html")]
+    struct EmptyChild<'a> {
+        title: &'a str,
+    }
+
     let t = EmptyChild { title: "baz" };
     assert_eq!(t.render().unwrap(), "baz\n\nFoo\nCopyright 2017");
 }
@@ -92,62 +92,62 @@ fn test_different_module() {
     );
 }
 
-#[derive(Template)]
-#[template(path = "nested-base.html")]
-struct NestedBaseTemplate {}
-
-#[derive(Template)]
-#[template(path = "nested-child.html")]
-struct NestedChildTemplate {
-    _parent: NestedBaseTemplate,
-}
-
-impl Deref for NestedChildTemplate {
-    type Target = NestedBaseTemplate;
-
-    fn deref(&self) -> &Self::Target {
-        &self._parent
-    }
-}
-
 #[test]
 fn test_nested_blocks() {
+    #[derive(Template)]
+    #[template(path = "nested-base.html")]
+    struct NestedBaseTemplate {}
+
+    #[derive(Template)]
+    #[template(path = "nested-child.html")]
+    struct NestedChildTemplate {
+        _parent: NestedBaseTemplate,
+    }
+
+    impl Deref for NestedChildTemplate {
+        type Target = NestedBaseTemplate;
+
+        fn deref(&self) -> &Self::Target {
+            &self._parent
+        }
+    }
+
     let t = NestedChildTemplate {
         _parent: NestedBaseTemplate {},
     };
     assert_eq!(t.render().unwrap(), "\ndurpy\n");
 }
 
-#[derive(Template)]
-#[template(path = "deep-base.html")]
-struct DeepBaseTemplate {
-    year: u16,
-}
-
-#[derive(Template)]
-#[template(path = "deep-mid.html")]
-struct DeepMidTemplate {
-    _parent: DeepBaseTemplate,
-    title: String,
-}
-
-#[derive(Template)]
-#[template(path = "deep-kid.html")]
-struct DeepKidTemplate {
-    _parent: DeepMidTemplate,
-    item: String,
-}
-
-impl Deref for DeepKidTemplate {
-    type Target = DeepMidTemplate;
-
-    fn deref(&self) -> &Self::Target {
-        &self._parent
-    }
-}
-
 #[test]
 fn test_deep() {
+    #[derive(Template)]
+    #[template(path = "deep-base.html")]
+    struct DeepBaseTemplate {
+        year: u16,
+    }
+
+    #[derive(Template)]
+    #[template(path = "deep-mid.html")]
+    struct DeepMidTemplate {
+        _parent: DeepBaseTemplate,
+        title: String,
+    }
+
+    #[derive(Template)]
+    #[template(path = "deep-kid.html")]
+    struct DeepKidTemplate {
+        _parent: DeepMidTemplate,
+        item: String,
+    }
+
+    impl Deref for DeepKidTemplate {
+        type Target = DeepMidTemplate;
+
+        fn deref(&self) -> &Self::Target {
+            &self._parent
+        }
+    }
+
     let t = DeepKidTemplate {
         _parent: DeepMidTemplate {
             _parent: DeepBaseTemplate { year: 2018 },
@@ -228,26 +228,26 @@ fn test_deep() {
     );
 }
 
-#[derive(Template)]
-#[template(path = "deep-base.html")]
-struct FlatDeepBaseTemplate {
-    year: u16,
-}
-
-#[derive(Template)]
-#[template(path = "deep-mid.html")]
-struct FlatDeepMidTemplate {
-    title: String,
-}
-
-#[derive(Template)]
-#[template(path = "deep-kid.html")]
-struct FlatDeepKidTemplate {
-    item: String,
-}
-
 #[test]
 fn test_flat_deep() {
+    #[derive(Template)]
+    #[template(path = "deep-base.html")]
+    struct FlatDeepBaseTemplate {
+        year: u16,
+    }
+
+    #[derive(Template)]
+    #[template(path = "deep-mid.html")]
+    struct FlatDeepMidTemplate {
+        title: String,
+    }
+
+    #[derive(Template)]
+    #[template(path = "deep-kid.html")]
+    struct FlatDeepKidTemplate {
+        item: String,
+    }
+
     let t = FlatDeepKidTemplate { item: "Foo".into() };
 
     assert_eq!(
@@ -328,29 +328,29 @@ fn test_flat_deep() {
     );
 }
 
-#[derive(Template)]
-#[template(path = "let-base.html")]
-#[allow(dead_code)]
-struct LetBase {}
-
-#[derive(Template)]
-#[template(path = "let-child.html")]
-struct LetChild {}
-
 #[test]
 fn test_let_block() {
+    #[derive(Template)]
+    #[template(path = "let-base.html")]
+    #[allow(dead_code)]
+    struct LetBase {}
+
+    #[derive(Template)]
+    #[template(path = "let-child.html")]
+    struct LetChild {}
+
     let t = LetChild {};
     assert_eq!(t.render().unwrap(), "1");
 }
 
-#[derive(Template)]
-#[template(path = "named-end.html")]
-struct NamedBlocks<'a> {
-    title: &'a str,
-}
-
 #[test]
 fn test_named_end() {
+    #[derive(Template)]
+    #[template(path = "named-end.html")]
+    struct NamedBlocks<'a> {
+        title: &'a str,
+    }
+
     let n = NamedBlocks { title: "title" };
     assert_eq!(n.render().unwrap(), "title\n\ntadam\nCopyright 2017");
 }

--- a/testing/tests/is_defined.rs
+++ b/testing/tests/is_defined.rs
@@ -1,24 +1,24 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(
-    source = r#"<script>
+// This test ensures that `include` are correctly working inside filter blocks and that external
+// variables are used correctly.
+#[test]
+fn is_defined_in_expr() {
+    #[derive(Template)]
+    #[template(
+        source = r#"<script>
 const x = {{ x is defined }};
 const y = {{ y is not defined }};
 const z = {{ y is defined }};
 const w = {{ x is not defined }};
 const v = {{ y }};
 </script>"#,
-    ext = "html"
-)]
-struct IsDefined {
-    y: u32,
-}
+        ext = "html"
+    )]
+    struct IsDefined {
+        y: u32,
+    }
 
-// This test ensures that `include` are correctly working inside filter blocks and that external
-// variables are used correctly.
-#[test]
-fn is_defined_in_expr() {
     let s = IsDefined { y: 0 };
     assert_eq!(
         s.render().unwrap(),
@@ -32,15 +32,15 @@ const v = 0;
     );
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"{% if x is defined && x == 12 %}bli{% else %}bla{% endif %}"#,
-    ext = "html"
-)]
-struct IsDefinedChaining;
-
 // This test ensures that if the variable is not defined, it will not generate following code.
 #[test]
 fn is_defined_chaining() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% if x is defined && x == 12 %}bli{% else %}bla{% endif %}"#,
+        ext = "html"
+    )]
+    struct IsDefinedChaining;
+
     assert_eq!(IsDefinedChaining.render().unwrap(), r"bla");
 }

--- a/testing/tests/let.rs
+++ b/testing/tests/let.rs
@@ -1,23 +1,23 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(
-    source = r#"{%- let x -%}
+// This test ensures that rust macro calls in `let`/`set` statements are not prepended with `&`.
+#[test]
+fn let_macro() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{%- let x -%}
 {%- if y -%}
     {%- let x = String::new() %}
 {%- else -%}
     {%- let x = format!("blob") %}
 {%- endif -%}
 {{ x }}"#,
-    ext = "html"
-)]
-struct A {
-    y: bool,
-}
+        ext = "html"
+    )]
+    struct A {
+        y: bool,
+    }
 
-// This test ensures that rust macro calls in `let`/`set` statements are not prepended with `&`.
-#[test]
-fn let_macro() {
     let template = A { y: false };
     assert_eq!(template.render().unwrap(), "blob")
 }

--- a/testing/tests/let_destructoring.rs
+++ b/testing/tests/let_destructoring.rs
@@ -1,47 +1,47 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(source = "{% let (a, b, c) = v %}{{a}}{{b}}{{c}}", ext = "txt")]
-struct LetDestructoringTuple {
-    v: (i32, i32, i32),
-}
-
 #[test]
 fn test_let_destruct_tuple() {
+    #[derive(Template)]
+    #[template(source = "{% let (a, b, c) = v %}{{a}}{{b}}{{c}}", ext = "txt")]
+    struct LetDestructoringTuple {
+        v: (i32, i32, i32),
+    }
+
     let t = LetDestructoringTuple { v: (1, 2, 3) };
     assert_eq!(t.render().unwrap(), "123");
 }
 
 struct UnnamedStruct(i32, i32, i32);
 
-#[derive(Template)]
-#[template(
-    source = "{% let UnnamedStruct(a, b, c) = v %}{{a}}{{b}}{{c}}",
-    ext = "txt"
-)]
-struct LetDestructoringUnnamedStruct {
-    v: UnnamedStruct,
-}
-
 #[test]
 fn test_let_destruct_unnamed_struct() {
+    #[derive(Template)]
+    #[template(
+        source = "{% let UnnamedStruct(a, b, c) = v %}{{a}}{{b}}{{c}}",
+        ext = "txt"
+    )]
+    struct LetDestructoringUnnamedStruct {
+        v: UnnamedStruct,
+    }
+
     let t = LetDestructoringUnnamedStruct {
         v: UnnamedStruct(1, 2, 3),
     };
     assert_eq!(t.render().unwrap(), "123");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% let UnnamedStruct(a, b, c) = v %}{{a}}{{b}}{{c}}",
-    ext = "txt"
-)]
-struct LetDestructoringUnnamedStructRef<'a> {
-    v: &'a UnnamedStruct,
-}
-
 #[test]
 fn test_let_destruct_unnamed_struct_ref() {
+    #[derive(Template)]
+    #[template(
+        source = "{% let UnnamedStruct(a, b, c) = v %}{{a}}{{b}}{{c}}",
+        ext = "txt"
+    )]
+    struct LetDestructoringUnnamedStructRef<'a> {
+        v: &'a UnnamedStruct,
+    }
+
     let v = UnnamedStruct(1, 2, 3);
     let t = LetDestructoringUnnamedStructRef { v: &v };
     assert_eq!(t.render().unwrap(), "123");
@@ -53,34 +53,34 @@ struct NamedStruct {
     c: i32,
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% let NamedStruct { a, b: d, c } = v %}{{a}}{{d}}{{c}}",
-    ext = "txt"
-)]
-struct LetDestructoringNamedStruct {
-    v: NamedStruct,
-}
-
 #[test]
 fn test_let_destruct_named_struct() {
+    #[derive(Template)]
+    #[template(
+        source = "{% let NamedStruct { a, b: d, c } = v %}{{a}}{{d}}{{c}}",
+        ext = "txt"
+    )]
+    struct LetDestructoringNamedStruct {
+        v: NamedStruct,
+    }
+
     let t = LetDestructoringNamedStruct {
         v: NamedStruct { a: 1, b: 2, c: 3 },
     };
     assert_eq!(t.render().unwrap(), "123");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% let NamedStruct { a, b: d, c } = v %}{{a}}{{d}}{{c}}",
-    ext = "txt"
-)]
-struct LetDestructoringNamedStructRef<'a> {
-    v: &'a NamedStruct,
-}
-
 #[test]
 fn test_let_destruct_named_struct_ref() {
+    #[derive(Template)]
+    #[template(
+        source = "{% let NamedStruct { a, b: d, c } = v %}{{a}}{{d}}{{c}}",
+        ext = "txt"
+    )]
+    struct LetDestructoringNamedStructRef<'a> {
+        v: &'a NamedStruct,
+    }
+
     let v = NamedStruct { a: 1, b: 2, c: 3 };
     let t = LetDestructoringNamedStructRef { v: &v };
     assert_eq!(t.render().unwrap(), "123");
@@ -92,54 +92,54 @@ mod some {
     }
 }
 
-#[derive(Template)]
-#[template(source = "{% let some::path::Struct(v) = v %}{{v}}", ext = "txt")]
-struct LetDestructoringWithPath<'a> {
-    v: some::path::Struct<'a>,
-}
-
 #[test]
 fn test_let_destruct_with_path() {
+    #[derive(Template)]
+    #[template(source = "{% let some::path::Struct(v) = v %}{{v}}", ext = "txt")]
+    struct LetDestructoringWithPath<'a> {
+        v: some::path::Struct<'a>,
+    }
+
     let t = LetDestructoringWithPath {
         v: some::path::Struct("hello"),
     };
     assert_eq!(t.render().unwrap(), "hello");
 }
 
-#[derive(Template)]
-#[template(source = "{% let some::path::Struct with (v) = v %}{{v}}", ext = "txt")]
-struct LetDestructoringWithPathAndWithKeyword<'a> {
-    v: some::path::Struct<'a>,
-}
-
 #[test]
 fn test_let_destruct_with_path_and_with_keyword() {
+    #[derive(Template)]
+    #[template(source = "{% let some::path::Struct with (v) = v %}{{v}}", ext = "txt")]
+    struct LetDestructoringWithPathAndWithKeyword<'a> {
+        v: some::path::Struct<'a>,
+    }
+
     let t = LetDestructoringWithPathAndWithKeyword {
         v: some::path::Struct("hello"),
     };
     assert_eq!(t.render().unwrap(), "hello");
 }
 
-#[derive(Template)]
-#[template(
-    source = "
+#[test]
+fn test_has_rest_pattern() {
+    #[derive(Template)]
+    #[template(
+        source = "
 {%- if let RestPattern2 { a, b } = x -%}hello {{ a }}{%- endif -%}
 {%- if let RestPattern2 { a, b, } = x -%}hello {{ b }}{%- endif -%}
 {%- if let RestPattern2 { a, .. } = x -%}hello {{ a }}{%- endif -%}
 ",
-    ext = "html"
-)]
-struct RestPattern {
-    x: RestPattern2,
-}
+        ext = "html"
+    )]
+    struct RestPattern {
+        x: RestPattern2,
+    }
 
-struct RestPattern2 {
-    a: u32,
-    b: u32,
-}
+    struct RestPattern2 {
+        a: u32,
+        b: u32,
+    }
 
-#[test]
-fn test_has_rest_pattern() {
     let t = RestPattern {
         x: RestPattern2 { a: 0, b: 1 },
     };
@@ -152,38 +152,38 @@ struct X {
     b: u32,
 }
 
-#[derive(Template)]
-#[template(
-    source = "
-{%- if let X { a, .. } = x -%}hello {{ a }}{%- endif -%}
-",
-    ext = "html"
-)]
-struct T1 {
-    x: X,
-}
-
 #[test]
 fn test_t1() {
+    #[derive(Template)]
+    #[template(
+        source = "
+{%- if let X { a, .. } = x -%}hello {{ a }}{%- endif -%}
+",
+        ext = "html"
+    )]
+    struct T1 {
+        x: X,
+    }
+
     let t = T1 {
         x: X { a: 1, b: 2 },
     };
     assert_eq!(t.render().unwrap(), "hello 1");
 }
 
-#[derive(Template)]
-#[template(
-    source = "
-{%- if let X { .. } = x -%}hello{%- endif -%}
-",
-    ext = "html"
-)]
-struct T2 {
-    x: X,
-}
-
 #[test]
 fn test_t2() {
+    #[derive(Template)]
+    #[template(
+        source = "
+{%- if let X { .. } = x -%}hello{%- endif -%}
+",
+        ext = "html"
+    )]
+    struct T2 {
+        x: X,
+    }
+
     let t = T2 {
         x: X { a: 1, b: 2 },
     };

--- a/testing/tests/literal.rs
+++ b/testing/tests/literal.rs
@@ -1,61 +1,61 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(source = "{% if x == b'a' %}bc{% endif %}", ext = "txt")]
-struct Expr {
-    x: u8,
-}
-
 #[test]
 fn test_prefix_char_literal_in_expr() {
+    #[derive(Template)]
+    #[template(source = "{% if x == b'a' %}bc{% endif %}", ext = "txt")]
+    struct Expr {
+        x: u8,
+    }
+
     let t = Expr { x: b'a' };
     assert_eq!(t.render().unwrap(), "bc");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% if let Some(b'a') = Some(b'a') %}bc{% endif %}
-{%- if data == [b'h', b'i'] %} hoy{% endif %}",
-    ext = "txt"
-)]
-struct Target {
-    data: &'static [u8],
-}
-
 #[test]
 fn test_prefix_char_literal_in_target() {
+    #[derive(Template)]
+    #[template(
+        source = "{% if let Some(b'a') = Some(b'a') %}bc{% endif %}
+{%- if data == [b'h', b'i'] %} hoy{% endif %}",
+        ext = "txt"
+    )]
+    struct Target {
+        data: &'static [u8],
+    }
+
     let t = Target { data: b"hi" };
     assert_eq!(t.render().unwrap(), "bc hoy");
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"{% if x == b"hi".as_slice() %}bc{% endif %}
-{%- if c"a".to_bytes_with_nul() == b"a\0" %} hoy{% endif %}"#,
-    ext = "txt"
-)]
-struct ExprStr {
-    x: &'static [u8],
-}
-
 #[test]
 fn test_prefix_str_literal_in_expr() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% if x == b"hi".as_slice() %}bc{% endif %}
+{%- if c"a".to_bytes_with_nul() == b"a\0" %} hoy{% endif %}"#,
+        ext = "txt"
+    )]
+    struct ExprStr {
+        x: &'static [u8],
+    }
+
     let t = ExprStr { x: b"hi" };
     assert_eq!(t.render().unwrap(), "bc hoy");
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"{% if let Some(b"hi") = Some(data) %}bc{% endif %}
-{%- if let x = c"hi" %} hoy{% endif %}"#,
-    ext = "txt"
-)]
-struct TargetStr {
-    data: [u8; 2],
-}
-
 #[test]
 fn test_prefix_str_literal_in_target() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% if let Some(b"hi") = Some(data) %}bc{% endif %}
+{%- if let x = c"hi" %} hoy{% endif %}"#,
+        ext = "txt"
+    )]
+    struct TargetStr {
+        data: [u8; 2],
+    }
+
     let t = TargetStr { data: *b"hi" };
     assert_eq!(t.render().unwrap(), "bc hoy");
 }

--- a/testing/tests/loop_else.rs
+++ b/testing/tests/loop_else.rs
@@ -1,16 +1,16 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(
-    source = "{% for v in values %}{{ v }}{% else %}empty{% endfor %}",
-    ext = "txt"
-)]
-struct ForElse<'a> {
-    values: &'a [i32],
-}
-
 #[test]
 fn test_for_else() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for v in values %}{{ v }}{% else %}empty{% endfor %}",
+        ext = "txt"
+    )]
+    struct ForElse<'a> {
+        values: &'a [i32],
+    }
+
     let t = ForElse { values: &[1, 2, 3] };
     assert_eq!(t.render().unwrap(), "123");
 
@@ -18,1088 +18,1151 @@ fn test_for_else() {
     assert_eq!(t.render().unwrap(), "empty");
 }
 
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{% else %}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim00<'a> {
-    values: &'a [i32],
-}
-
 #[test]
 fn test_loop_else_trim00() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{% else %}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim00<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim00 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1\t b");
 
     let t = LoopElseTrim00 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nX\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{% else %}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim01<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim01() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{% else %}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim01<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim01 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1\t b");
 
     let t = LoopElseTrim01 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nX\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{% else %}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim02<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim02() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{% else %}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim02<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim02 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1\t b");
 
     let t = LoopElseTrim02 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nX\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{% else %}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim03<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim03() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{% else %}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim03<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim03 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1\t b");
 
     let t = LoopElseTrim03 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nX\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{%-else %}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim04<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim04() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{%-else %}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim04<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim04 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1 b");
 
     let t = LoopElseTrim04 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nX\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{%-else %}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim05<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim05() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{%-else %}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim05<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim05 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1 b");
 
     let t = LoopElseTrim05 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nX\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{%-else %}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim06<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim06() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{%-else %}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim06<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim06 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1 b");
 
     let t = LoopElseTrim06 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nX\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{%-else %}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim07<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim07() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{%-else %}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim07<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim07 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1 b");
 
     let t = LoopElseTrim07 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nX\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{% else-%}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim08<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim08() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{% else-%}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim08<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim08 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1\t b");
 
     let t = LoopElseTrim08 { values: &[] };
     assert_eq!(t.render().unwrap(), "a X\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{% else-%}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim09<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim09() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{% else-%}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim09<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim09 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1\t b");
 
     let t = LoopElseTrim09 { values: &[] };
     assert_eq!(t.render().unwrap(), "aX\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{% else-%}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim10<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim10() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{% else-%}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim10<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim10 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1\t b");
 
     let t = LoopElseTrim10 { values: &[] };
     assert_eq!(t.render().unwrap(), "a X\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{% else-%}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim11<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim11() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{% else-%}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim11<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim11 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1\t b");
 
     let t = LoopElseTrim11 { values: &[] };
     assert_eq!(t.render().unwrap(), "aX\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{%-else-%}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim12<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim12() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{%-else-%}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim12<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim12 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1 b");
 
     let t = LoopElseTrim12 { values: &[] };
     assert_eq!(t.render().unwrap(), "a X\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{%-else-%}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim13<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim13() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{%-else-%}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim13<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim13 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1 b");
 
     let t = LoopElseTrim13 { values: &[] };
     assert_eq!(t.render().unwrap(), "aX\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{%-else-%}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim14<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim14() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{%-else-%}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim14<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim14 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1 b");
 
     let t = LoopElseTrim14 { values: &[] };
     assert_eq!(t.render().unwrap(), "a X\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{%-else-%}\nX\n{% endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim15<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim15() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{%-else-%}\nX\n{% endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim15<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim15 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1 b");
 
     let t = LoopElseTrim15 { values: &[] };
     assert_eq!(t.render().unwrap(), "aX\n b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{% else %}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim16<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim16() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{% else %}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim16<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim16 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1\t b");
 
     let t = LoopElseTrim16 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nX b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{% else %}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim17<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim17() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{% else %}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim17<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim17 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1\t b");
 
     let t = LoopElseTrim17 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nX b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{% else %}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim18<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim18() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{% else %}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim18<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim18 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1\t b");
 
     let t = LoopElseTrim18 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nX b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{% else %}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim19<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim19() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{% else %}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim19<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim19 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1\t b");
 
     let t = LoopElseTrim19 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nX b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{%-else %}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim20<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim20() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{%-else %}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim20<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim20 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1 b");
 
     let t = LoopElseTrim20 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nX b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{%-else %}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim21<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim21() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{%-else %}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim21<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim21 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1 b");
 
     let t = LoopElseTrim21 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nX b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{%-else %}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim22<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim22() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{%-else %}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim22<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim22 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1 b");
 
     let t = LoopElseTrim22 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nX b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{%-else %}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim23<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim23() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{%-else %}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim23<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim23 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1 b");
 
     let t = LoopElseTrim23 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nX b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{% else-%}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim24<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim24() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{% else-%}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim24<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim24 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1\t b");
 
     let t = LoopElseTrim24 { values: &[] };
     assert_eq!(t.render().unwrap(), "a X b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{% else-%}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim25<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim25() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{% else-%}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim25<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim25 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1\t b");
 
     let t = LoopElseTrim25 { values: &[] };
     assert_eq!(t.render().unwrap(), "aX b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{% else-%}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim26<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim26() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{% else-%}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim26<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim26 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1\t b");
 
     let t = LoopElseTrim26 { values: &[] };
     assert_eq!(t.render().unwrap(), "a X b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{% else-%}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim27<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim27() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{% else-%}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim27<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim27 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1\t b");
 
     let t = LoopElseTrim27 { values: &[] };
     assert_eq!(t.render().unwrap(), "aX b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{%-else-%}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim28<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim28() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{%-else-%}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim28<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim28 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1 b");
 
     let t = LoopElseTrim28 { values: &[] };
     assert_eq!(t.render().unwrap(), "a X b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{%-else-%}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim29<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim29() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{%-else-%}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim29<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim29 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1 b");
 
     let t = LoopElseTrim29 { values: &[] };
     assert_eq!(t.render().unwrap(), "aX b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{%-else-%}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim30<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim30() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{%-else-%}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim30<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim30 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1 b");
 
     let t = LoopElseTrim30 { values: &[] };
     assert_eq!(t.render().unwrap(), "a X b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{%-else-%}\nX\n{%-endfor %} b",
-    ext = "txt"
-)]
-struct LoopElseTrim31<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim31() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{%-else-%}\nX\n{%-endfor %} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim31<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim31 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1 b");
 
     let t = LoopElseTrim31 { values: &[] };
     assert_eq!(t.render().unwrap(), "aX b");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{% else %}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim32<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim32() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{% else %}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim32<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim32 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1\tb");
 
     let t = LoopElseTrim32 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nX\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{% else %}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim33<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim33() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{% else %}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim33<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim33 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1\tb");
 
     let t = LoopElseTrim33 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nX\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{% else %}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim34<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim34() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{% else %}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim34<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim34 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1\tb");
 
     let t = LoopElseTrim34 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nX\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{% else %}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim35<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim35() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{% else %}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim35<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim35 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1\tb");
 
     let t = LoopElseTrim35 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nX\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{%-else %}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim36<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim36() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{%-else %}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim36<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim36 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1b");
 
     let t = LoopElseTrim36 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nX\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{%-else %}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim37<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim37() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{%-else %}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim37<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim37 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1b");
 
     let t = LoopElseTrim37 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nX\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{%-else %}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim38<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim38() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{%-else %}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim38<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim38 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1b");
 
     let t = LoopElseTrim38 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nX\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{%-else %}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim39<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim39() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{%-else %}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim39<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim39 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1b");
 
     let t = LoopElseTrim39 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nX\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{% else-%}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim40<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim40() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{% else-%}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim40<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim40 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1\tb");
 
     let t = LoopElseTrim40 { values: &[] };
     assert_eq!(t.render().unwrap(), "a X\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{% else-%}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim41<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim41() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{% else-%}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim41<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim41 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1\tb");
 
     let t = LoopElseTrim41 { values: &[] };
     assert_eq!(t.render().unwrap(), "aX\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{% else-%}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim42<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim42() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{% else-%}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim42<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim42 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1\tb");
 
     let t = LoopElseTrim42 { values: &[] };
     assert_eq!(t.render().unwrap(), "a X\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{% else-%}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim43<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim43() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{% else-%}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim43<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim43 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1\tb");
 
     let t = LoopElseTrim43 { values: &[] };
     assert_eq!(t.render().unwrap(), "aX\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{%-else-%}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim44<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim44() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{%-else-%}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim44<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim44 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1b");
 
     let t = LoopElseTrim44 { values: &[] };
     assert_eq!(t.render().unwrap(), "a X\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{%-else-%}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim45<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim45() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{%-else-%}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim45<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim45 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1b");
 
     let t = LoopElseTrim45 { values: &[] };
     assert_eq!(t.render().unwrap(), "aX\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{%-else-%}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim46<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim46() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{%-else-%}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim46<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim46 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1b");
 
     let t = LoopElseTrim46 { values: &[] };
     assert_eq!(t.render().unwrap(), "a X\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{%-else-%}\nX\n{% endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim47<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim47() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{%-else-%}\nX\n{% endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim47<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim47 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1b");
 
     let t = LoopElseTrim47 { values: &[] };
     assert_eq!(t.render().unwrap(), "aX\nb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{% else %}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim48<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim48() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{% else %}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim48<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim48 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1\tb");
 
     let t = LoopElseTrim48 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nXb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{% else %}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim49<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim49() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{% else %}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim49<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim49 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1\tb");
 
     let t = LoopElseTrim49 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nXb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{% else %}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim50<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim50() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{% else %}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim50<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim50 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1\tb");
 
     let t = LoopElseTrim50 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nXb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{% else %}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim51<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim51() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{% else %}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim51<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim51 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1\tb");
 
     let t = LoopElseTrim51 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nXb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{%-else %}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim52<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim52() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{%-else %}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim52<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim52 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1b");
 
     let t = LoopElseTrim52 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nXb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{%-else %}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim53<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim53() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{%-else %}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim53<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim53 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1b");
 
     let t = LoopElseTrim53 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nXb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{%-else %}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim54<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim54() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{%-else %}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim54<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim54 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1b");
 
     let t = LoopElseTrim54 { values: &[] };
     assert_eq!(t.render().unwrap(), "a \nXb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{%-else %}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim55<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim55() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{%-else %}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim55<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim55 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1b");
 
     let t = LoopElseTrim55 { values: &[] };
     assert_eq!(t.render().unwrap(), "a\nXb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{% else-%}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim56<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim56() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{% else-%}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim56<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim56 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1\tb");
 
     let t = LoopElseTrim56 { values: &[] };
     assert_eq!(t.render().unwrap(), "a Xb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{% else-%}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim57<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim57() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{% else-%}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim57<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim57 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1\tb");
 
     let t = LoopElseTrim57 { values: &[] };
     assert_eq!(t.render().unwrap(), "aXb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{% else-%}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim58<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim58() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{% else-%}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim58<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim58 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1\tb");
 
     let t = LoopElseTrim58 { values: &[] };
     assert_eq!(t.render().unwrap(), "a Xb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{% else-%}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim59<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim59() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{% else-%}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim59<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim59 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1\tb");
 
     let t = LoopElseTrim59 { values: &[] };
     assert_eq!(t.render().unwrap(), "aXb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values %}\t{{v}}\t{%-else-%}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim60<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim60() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values %}\t{{v}}\t{%-else-%}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim60<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim60 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a \t1b");
 
     let t = LoopElseTrim60 { values: &[] };
     assert_eq!(t.render().unwrap(), "a Xb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values %}\t{{v}}\t{%-else-%}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim61<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim61() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values %}\t{{v}}\t{%-else-%}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim61<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim61 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a\t1b");
 
     let t = LoopElseTrim61 { values: &[] };
     assert_eq!(t.render().unwrap(), "aXb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {% for v in values-%}\t{{v}}\t{%-else-%}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim62<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim62() {
+    #[derive(Template)]
+    #[template(
+        source = "a {% for v in values-%}\t{{v}}\t{%-else-%}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim62<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim62 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a 1b");
 
     let t = LoopElseTrim62 { values: &[] };
     assert_eq!(t.render().unwrap(), "a Xb");
 }
-#[derive(Template)]
-#[template(
-    source = "a {%-for v in values-%}\t{{v}}\t{%-else-%}\nX\n{%-endfor-%} b",
-    ext = "txt"
-)]
-struct LoopElseTrim63<'a> {
-    values: &'a [i32],
-}
 
 #[test]
 fn test_loop_else_trim63() {
+    #[derive(Template)]
+    #[template(
+        source = "a {%-for v in values-%}\t{{v}}\t{%-else-%}\nX\n{%-endfor-%} b",
+        ext = "txt"
+    )]
+    struct LoopElseTrim63<'a> {
+        values: &'a [i32],
+    }
+
     let t = LoopElseTrim63 { values: &[1] };
     assert_eq!(t.render().unwrap(), "a1b");
 

--- a/testing/tests/loops.rs
+++ b/testing/tests/loops.rs
@@ -5,15 +5,15 @@ use std::ops::Range;
 
 use rinja::Template;
 
-#[derive(Template)]
-#[template(path = "for.html")]
-struct ForTemplate<'a> {
-    strings: Vec<&'a str>,
-    tuple_strings: Vec<(&'a str, &'a str)>,
-}
-
 #[test]
 fn test_for() {
+    #[derive(Template)]
+    #[template(path = "for.html")]
+    struct ForTemplate<'a> {
+        strings: Vec<&'a str>,
+        tuple_strings: Vec<(&'a str, &'a str)>,
+    }
+
     let s = ForTemplate {
         strings: vec!["A", "alfa", "1"],
         tuple_strings: vec![("B", "beta")],
@@ -24,14 +24,14 @@ fn test_for() {
     );
 }
 
-#[derive(Template)]
-#[template(path = "nested-for.html")]
-struct NestedForTemplate<'a> {
-    seqs: Vec<&'a [&'a str]>,
-}
-
 #[test]
 fn test_nested_for() {
+    #[derive(Template)]
+    #[template(path = "nested-for.html")]
+    struct NestedForTemplate<'a> {
+        seqs: Vec<&'a [&'a str]>,
+    }
+
     let alpha = vec!["a", "b", "c"];
     let numbers = vec!["one", "two"];
     let s = NestedForTemplate {
@@ -40,14 +40,14 @@ fn test_nested_for() {
     assert_eq!(s.render().unwrap(), "1\n  0a1b2c2\n  0one1two");
 }
 
-#[derive(Template)]
-#[template(path = "precedence-for.html")]
-struct PrecedenceTemplate<'a> {
-    strings: Vec<&'a str>,
-}
-
 #[test]
 fn test_precedence_for() {
+    #[derive(Template)]
+    #[template(path = "precedence-for.html")]
+    struct PrecedenceTemplate<'a> {
+        strings: Vec<&'a str>,
+    }
+
     let s = PrecedenceTemplate {
         strings: vec!["A", "alfa", "1"],
     };
@@ -57,15 +57,15 @@ fn test_precedence_for() {
     );
 }
 
-#[derive(Template)]
-#[template(path = "for-range.html")]
-struct ForRangeTemplate {
-    init: i32,
-    end: i32,
-}
-
 #[test]
 fn test_for_range() {
+    #[derive(Template)]
+    #[template(path = "for-range.html")]
+    struct ForRangeTemplate {
+        init: i32,
+        end: i32,
+    }
+
     let s = ForRangeTemplate { init: -1, end: 1 };
     assert_eq!(
         s.render().unwrap(),
@@ -73,63 +73,63 @@ fn test_for_range() {
     );
 }
 
-#[derive(Template)]
-#[template(source = "{% for i in [1, 2, 3] %}{{ i }}{% endfor %}", ext = "txt")]
-struct ForArrayTemplate;
-
 #[test]
 fn test_for_array() {
+    #[derive(Template)]
+    #[template(source = "{% for i in [1, 2, 3] %}{{ i }}{% endfor %}", ext = "txt")]
+    struct ForArrayTemplate;
+
     let t = ForArrayTemplate;
     assert_eq!(t.render().unwrap(), "123");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% for i in [1, 2, 3].iter() %}{{ i }}{% endfor %}",
-    ext = "txt"
-)]
-struct ForMethodCallTemplate;
-
 #[test]
 fn test_for_method_call() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for i in [1, 2, 3].iter() %}{{ i }}{% endfor %}",
+        ext = "txt"
+    )]
+    struct ForMethodCallTemplate;
+
     let t = ForMethodCallTemplate;
     assert_eq!(t.render().unwrap(), "123");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% for i in ::std::iter::repeat(\"a\").take(5) %}{{ i }}{% endfor %}",
-    ext = "txt"
-)]
-struct ForPathCallTemplate;
-
 #[test]
 fn test_for_path_call() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for i in ::std::iter::repeat(\"a\").take(5) %}{{ i }}{% endfor %}",
+        ext = "txt"
+    )]
+    struct ForPathCallTemplate;
+
     assert_eq!(ForPathCallTemplate.render().unwrap(), "aaaaa");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% for i in [1, 2, 3, 4, 5][3..] %}{{ i }}{% endfor %}",
-    ext = "txt"
-)]
-struct ForIndexTemplate;
-
 #[test]
 fn test_for_index() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for i in [1, 2, 3, 4, 5][3..] %}{{ i }}{% endfor %}",
+        ext = "txt"
+    )]
+    struct ForIndexTemplate;
+
     let t = ForIndexTemplate;
     assert_eq!(t.render().unwrap(), "45");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% for (i, j) in (0..10).zip(10..20).zip(30..40) %}{{ i.0 }} {{ i.1 }} {{ j }} {% endfor %}",
-    ext = "txt"
-)]
-struct ForZipRangesTemplate;
-
 #[test]
 fn test_for_zip_ranges() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for (i, j) in (0..10).zip(10..20).zip(30..40) %}{{ i.0 }} {{ i.1 }} {{ j }} {% endfor %}",
+        ext = "txt"
+    )]
+    struct ForZipRangesTemplate;
+
     let t = ForZipRangesTemplate;
     assert_eq!(
         t.render().unwrap(),
@@ -137,21 +137,21 @@ fn test_for_zip_ranges() {
     );
 }
 
-struct ForVecAttrVec {
-    iterable: Vec<i32>,
-}
-
-#[derive(Template)]
-#[template(
-    source = "{% for x in v %}{% for y in x.iterable %}{{ y }} {% endfor %}{% endfor %}",
-    ext = "txt"
-)]
-struct ForVecAttrVecTemplate {
-    v: Vec<ForVecAttrVec>,
-}
-
 #[test]
 fn test_for_vec_attr_vec() {
+    struct ForVecAttrVec {
+        iterable: Vec<i32>,
+    }
+
+    #[derive(Template)]
+    #[template(
+        source = "{% for x in v %}{% for y in x.iterable %}{{ y }} {% endfor %}{% endfor %}",
+        ext = "txt"
+    )]
+    struct ForVecAttrVecTemplate {
+        v: Vec<ForVecAttrVec>,
+    }
+
     let t = ForVecAttrVecTemplate {
         v: vec![
             ForVecAttrVec {
@@ -172,17 +172,17 @@ struct ForVecAttrSlice {
     iterable: &'static [i32],
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% for x in v %}{% for y in x.iterable %}{{ y }} {% endfor %}{% endfor %}",
-    ext = "txt"
-)]
-struct ForVecAttrSliceTemplate {
-    v: Vec<ForVecAttrSlice>,
-}
-
 #[test]
 fn test_for_vec_attr_slice() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for x in v %}{% for y in x.iterable %}{{ y }} {% endfor %}{% endfor %}",
+        ext = "txt"
+    )]
+    struct ForVecAttrSliceTemplate {
+        v: Vec<ForVecAttrSlice>,
+    }
+
     let t = ForVecAttrSliceTemplate {
         v: vec![
             ForVecAttrSlice { iterable: &[1, 2] },
@@ -193,21 +193,21 @@ fn test_for_vec_attr_slice() {
     assert_eq!(t.render().unwrap(), "1 2 3 4 5 6 ");
 }
 
-struct ForVecAttrRange {
-    iterable: Range<usize>,
-}
-
-#[derive(Template)]
-#[template(
-    source = "{% for x in v %}{% for y in x.iterable.clone() %}{{ y }} {% endfor %}{% endfor %}",
-    ext = "txt"
-)]
-struct ForVecAttrRangeTemplate {
-    v: Vec<ForVecAttrRange>,
-}
-
 #[test]
 fn test_for_vec_attr_range() {
+    struct ForVecAttrRange {
+        iterable: Range<usize>,
+    }
+
+    #[derive(Template)]
+    #[template(
+        source = "{% for x in v %}{% for y in x.iterable.clone() %}{{ y }} {% endfor %}{% endfor %}",
+        ext = "txt"
+    )]
+    struct ForVecAttrRangeTemplate {
+        v: Vec<ForVecAttrRange>,
+    }
+
     let t = ForVecAttrRangeTemplate {
         v: vec![
             ForVecAttrRange { iterable: 1..3 },
@@ -218,17 +218,17 @@ fn test_for_vec_attr_range() {
     assert_eq!(t.render().unwrap(), "1 2 3 4 5 6 ");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% for v in v %}{% let v = v %}{% for v in v.iterable %}{% let v = v %}{{ v }} {% endfor %}{% endfor %}",
-    ext = "txt"
-)]
-struct ForVecAttrSliceShadowingTemplate {
-    v: Vec<ForVecAttrSlice>,
-}
-
 #[test]
 fn test_for_vec_attr_slice_shadowing() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for v in v %}{% let v = v %}{% for v in v.iterable %}{% let v = v %}{{ v }} {% endfor %}{% endfor %}",
+        ext = "txt"
+    )]
+    struct ForVecAttrSliceShadowingTemplate {
+        v: Vec<ForVecAttrSlice>,
+    }
+
     let t = ForVecAttrSliceShadowingTemplate {
         v: vec![
             ForVecAttrSlice { iterable: &[1, 2] },
@@ -247,17 +247,17 @@ impl<T: fmt::Display> fmt::Display for NotCloneable<T> {
     }
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% for (((a,), b), c) in v %}{{a}}{{b}}{{c}}-{% endfor %}",
-    ext = "txt"
-)]
-struct ForDestructoringRefTupleTemplate<'a> {
-    v: &'a [(((char,), NotCloneable<char>), &'a char)],
-}
-
 #[test]
 fn test_for_destructoring_ref_tuple() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for (((a,), b), c) in v %}{{a}}{{b}}{{c}}-{% endfor %}",
+        ext = "txt"
+    )]
+    struct ForDestructoringRefTupleTemplate<'a> {
+        v: &'a [(((char,), NotCloneable<char>), &'a char)],
+    }
+
     let v = [
         ((('a',), NotCloneable('b')), &'c'),
         ((('d',), NotCloneable('e')), &'f'),
@@ -267,17 +267,17 @@ fn test_for_destructoring_ref_tuple() {
     assert_eq!(t.render().unwrap(), "abc-def-ghi-");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% for (((a,), b), c) in v %}{{a}}{{b}}{{c}}-{% endfor %}",
-    ext = "txt"
-)]
-struct ForDestructoringTupleTemplate<'a, const N: usize> {
-    v: [(((char,), NotCloneable<char>), &'a char); N],
-}
-
 #[test]
 fn test_for_destructoring_tuple() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for (((a,), b), c) in v %}{{a}}{{b}}{{c}}-{% endfor %}",
+        ext = "txt"
+    )]
+    struct ForDestructoringTupleTemplate<'a, const N: usize> {
+        v: [(((char,), NotCloneable<char>), &'a char); N],
+    }
+
     let t = ForDestructoringTupleTemplate {
         v: [
             ((('a',), NotCloneable('b')), &'c'),
@@ -288,34 +288,34 @@ fn test_for_destructoring_tuple() {
     assert_eq!(t.render().unwrap(), "abc-def-ghi-");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% for (i, msg) in messages.iter().enumerate() %}{{i}}={{msg}}-{% endfor %}",
-    ext = "txt"
-)]
-struct ForEnumerateTemplate<'a> {
-    messages: &'a [&'a str],
-}
-
 #[test]
 fn test_for_enumerate() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for (i, msg) in messages.iter().enumerate() %}{{i}}={{msg}}-{% endfor %}",
+        ext = "txt"
+    )]
+    struct ForEnumerateTemplate<'a> {
+        messages: &'a [&'a str],
+    }
+
     let t = ForEnumerateTemplate {
         messages: &["hello", "world", "!"],
     };
     assert_eq!(t.render().unwrap(), "0=hello-1=world-2=!-");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% for v in values.iter() %}x{{v}}{% if matches!(v, x if *x==3) %}{% break %}{% endif %}y{% endfor %}",
-    ext = "txt"
-)]
-struct Break<'a> {
-    values: &'a [i32],
-}
-
 #[test]
 fn test_loop_break() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for v in values.iter() %}x{{v}}{% if matches!(v, x if *x==3) %}{% break %}{% endif %}y{% endfor %}",
+        ext = "txt"
+    )]
+    struct Break<'a> {
+        values: &'a [i32],
+    }
+
     let t = Break {
         values: &[1, 2, 3, 4, 5],
     };
@@ -327,17 +327,17 @@ fn test_loop_break() {
     assert_eq!(t.render().unwrap(), "x1yx2yx4yx5y");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% for v in values %}x{{v}}{% if matches!(v, x if *x==3) %}{% continue %}{% endif %}y{% endfor %}",
-    ext = "txt"
-)]
-struct Continue<'a> {
-    values: &'a [i32],
-}
-
 #[test]
 fn test_loop_continue() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for v in values %}x{{v}}{% if matches!(v, x if *x==3) %}{% continue %}{% endif %}y{% endfor %}",
+        ext = "txt"
+    )]
+    struct Continue<'a> {
+        values: &'a [i32],
+    }
+
     let t = Continue {
         values: &[1, 2, 3, 4, 5],
     };
@@ -349,14 +349,14 @@ fn test_loop_continue() {
     assert_eq!(t.render().unwrap(), "x1yx2yx4yx5y");
 }
 
-#[derive(Template)]
-#[template(path = "for-break-continue.html")]
-struct BreakContinue<'a> {
-    values: &'a [i32],
-}
-
 #[test]
 fn test_loop_break_continue() {
+    #[derive(Template)]
+    #[template(path = "for-break-continue.html")]
+    struct BreakContinue<'a> {
+        values: &'a [i32],
+    }
+
     let t = BreakContinue {
         values: &[1, 2, 3, 4, 5],
     };
@@ -373,62 +373,66 @@ fn test_loop_break_continue() {
     assert_eq!(t.render().unwrap(), "x1yx2yx3yx11x4yx5y");
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"{% for v in values %}{{loop.cycle(["r", "g", "b"])}}{{v}},{% endfor %}"#,
-    ext = "txt"
-)]
-struct ForCycle<'a> {
-    values: &'a [u8],
-}
-
 #[test]
 fn test_for_cycle() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% for v in values %}{{loop.cycle(["r", "g", "b"])}}{{v}},{% endfor %}"#,
+        ext = "txt"
+    )]
+    struct ForCycle<'a> {
+        values: &'a [u8],
+    }
+
     let t = ForCycle {
         values: &[1, 2, 3, 4, 5, 6, 7, 8, 9],
     };
     assert_eq!(t.render().unwrap(), "r1,g2,b3,r4,g5,b6,r7,g8,b9,");
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"{% for v in values %}{{loop.cycle(cycle)}}{{v}},{% endfor %}"#,
-    ext = "txt"
-)]
-struct ForCycleDynamic<'a> {
-    values: &'a [u8],
-    cycle: &'a [char],
-}
+mod test_for_cycle {
+    use rinja::Template;
 
-#[test]
-fn test_for_cycle_dynamic() {
-    let t = ForCycleDynamic {
-        values: &[1, 2, 3, 4, 5, 6, 7, 8, 9],
-        cycle: &['a', 'b', 'c', 'd'],
-    };
-    assert_eq!(t.render().unwrap(), "a1,b2,c3,d4,a5,b6,c7,d8,a9,");
-}
+    #[derive(Template)]
+    #[template(
+        source = r#"{% for v in values %}{{loop.cycle(cycle)}}{{v}},{% endfor %}"#,
+        ext = "txt"
+    )]
+    struct ForCycleDynamic<'a> {
+        values: &'a [u8],
+        cycle: &'a [char],
+    }
 
-#[test]
-fn test_for_cycle_empty() {
-    let t = ForCycleDynamic {
-        values: &[1, 2, 3, 4, 5, 6, 7, 8, 9],
-        cycle: &[],
-    };
-    assert!(t.render().is_err());
-}
+    #[test]
+    fn test_for_cycle_dynamic() {
+        let t = ForCycleDynamic {
+            values: &[1, 2, 3, 4, 5, 6, 7, 8, 9],
+            cycle: &['a', 'b', 'c', 'd'],
+        };
+        assert_eq!(t.render().unwrap(), "a1,b2,c3,d4,a5,b6,c7,d8,a9,");
+    }
 
-#[derive(Template)]
-#[template(
-    source = "{% for i in 0..limit if i % 2 == 1 %}{{i}}.{% else %}:({% endfor %}",
-    ext = "txt"
-)]
-struct ForInIf {
-    limit: usize,
+    #[test]
+    fn test_for_cycle_empty() {
+        let t = ForCycleDynamic {
+            values: &[1, 2, 3, 4, 5, 6, 7, 8, 9],
+            cycle: &[],
+        };
+        assert!(t.render().is_err());
+    }
 }
 
 #[test]
 fn test_for_in_if() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for i in 0..limit if i % 2 == 1 %}{{i}}.{% else %}:({% endfor %}",
+        ext = "txt"
+    )]
+    struct ForInIf {
+        limit: usize,
+    }
+
     let t = ForInIf { limit: 10 };
     assert_eq!(t.render().unwrap(), "1.3.5.7.9.");
 
@@ -439,9 +443,11 @@ fn test_for_in_if() {
 // This is a regression test for <https://github.com/rinja-rs/rinja/issues/150>.
 // The loop didn't drop its locals context, creating a bug where a field could
 // not be retrieved although it existed.
-#[derive(Template)]
-#[template(
-    source = r#"
+#[test]
+fn test_loop_locals() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
 {%- macro mac(bla) -%}
 {% for x in &[1] -%}
 {% endfor -%}
@@ -449,14 +455,12 @@ fn test_for_in_if() {
 
 {% call mac(bla=bla) %}
 {{- bla }}"#,
-    ext = "txt"
-)]
-struct LoopLocalsContext {
-    bla: u8,
-}
+        ext = "txt"
+    )]
+    struct LoopLocalsContext {
+        bla: u8,
+    }
 
-#[test]
-fn test_loop_locals() {
     let t = LoopLocalsContext { bla: 10 };
     assert_eq!(t.render().unwrap(), "10");
 }

--- a/testing/tests/macro.rs
+++ b/testing/tests/macro.rs
@@ -1,104 +1,108 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(path = "macro.html")]
-struct MacroTemplate<'a> {
-    s: &'a str,
-}
-
 #[test]
 fn test_macro() {
+    #[derive(Template)]
+    #[template(path = "macro.html")]
+    struct MacroTemplate<'a> {
+        s: &'a str,
+    }
+
     let t = MacroTemplate { s: "foo" };
     assert_eq!(t.render().unwrap(), "12foo foo foo34foo foo5");
 }
 
-#[derive(Template)]
-#[template(path = "macro-no-args.html")]
-struct MacroNoArgsTemplate;
-
 #[test]
 fn test_macro_no_args() {
+    #[derive(Template)]
+    #[template(path = "macro-no-args.html")]
+    struct MacroNoArgsTemplate;
+
     let t = MacroNoArgsTemplate;
     assert_eq!(t.render().unwrap(), "11the best thing111we've ever done11");
 }
 
-#[derive(Template)]
-#[template(path = "import.html")]
-struct ImportTemplate<'a> {
-    s: &'a str,
-}
-
 #[test]
 fn test_import() {
+    #[derive(Template)]
+    #[template(path = "import.html")]
+    struct ImportTemplate<'a> {
+        s: &'a str,
+    }
+
     let t = ImportTemplate { s: "foo" };
     assert_eq!(t.render().unwrap(), "foo foo foo");
 }
 
-#[derive(Template)]
-#[template(path = "deep-nested-macro.html")]
-struct NestedTemplate;
-
 #[test]
 fn test_nested() {
+    #[derive(Template)]
+    #[template(path = "deep-nested-macro.html")]
+    struct NestedTemplate;
+
     let t = NestedTemplate;
     assert_eq!(t.render().unwrap(), "foo");
 }
 
-#[derive(Template)]
-#[template(path = "deep-import-parent.html")]
-struct DeepImportTemplate;
-
 #[test]
 fn test_deep_import() {
+    #[derive(Template)]
+    #[template(path = "deep-import-parent.html")]
+    struct DeepImportTemplate;
+
     let t = DeepImportTemplate;
     assert_eq!(t.render().unwrap(), "foo");
 }
 
-#[derive(Template)]
-#[template(path = "macro-short-circuit.html")]
-struct ShortCircuitTemplate {}
-
 #[test]
 fn test_short_circuit() {
+    #[derive(Template)]
+    #[template(path = "macro-short-circuit.html")]
+    struct ShortCircuitTemplate {}
+
     let t = ShortCircuitTemplate {};
     assert_eq!(t.render().unwrap(), "truetruetruefalsetruetrue");
 }
 
-#[derive(Template)]
-#[template(path = "nested-macro-args.html")]
-struct NestedMacroArgsTemplate {}
-
 #[test]
 fn test_nested_macro_with_args() {
+    #[derive(Template)]
+    #[template(path = "nested-macro-args.html")]
+    struct NestedMacroArgsTemplate {}
+
     let t = NestedMacroArgsTemplate {};
     assert_eq!(t.render().unwrap(), "first second");
 }
 
-#[derive(Template)]
-#[template(path = "macro-import-str-cmp.html")]
-struct StrCmpTemplate;
-
 #[test]
 fn str_cmp() {
+    #[derive(Template)]
+    #[template(path = "macro-import-str-cmp.html")]
+    struct StrCmpTemplate;
+
     let t = StrCmpTemplate;
     assert_eq!(t.render().unwrap(), "AfooBotherCneitherD");
 }
 
-#[derive(Template)]
-#[template(path = "macro-self-arg.html")]
-struct MacroSelfArgTemplate<'a> {
-    s: &'a str,
-}
-
 #[test]
 fn test_macro_self_arg() {
+    #[derive(Template)]
+    #[template(path = "macro-self-arg.html")]
+    struct MacroSelfArgTemplate<'a> {
+        s: &'a str,
+    }
+
     let t = MacroSelfArgTemplate { s: "foo" };
     assert_eq!(t.render().unwrap(), "foo");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{%- macro thrice(param1, param2) -%}
+#[test]
+// We check that it's always the correct values passed to the
+// expected argument.
+fn test_named_argument() {
+    #[derive(Template)]
+    #[template(
+        source = "{%- macro thrice(param1, param2) -%}
 {{ param1 }} {{ param2 }}
 {% endmacro -%}
 
@@ -106,14 +110,10 @@ fn test_macro_self_arg() {
 {%- call thrice(param2=3, param1=2) -%}
 {%- call thrice(3, param2=2) -%}
 ",
-    ext = "html"
-)]
-struct MacroNamedArg;
+        ext = "html"
+    )]
+    struct MacroNamedArg;
 
-#[test]
-// We check that it's always the correct values passed to the
-// expected argument.
-fn test_named_argument() {
     assert_eq!(
         MacroNamedArg.render().unwrap(),
         "\
@@ -124,27 +124,29 @@ fn test_named_argument() {
     );
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"{% macro button(label) %}
+#[test]
+fn test_only_named_argument() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% macro button(label) %}
 {{- label -}}
 {% endmacro %}
 
 {%- call button(label="hi") -%}
 "#,
-    ext = "html"
-)]
-struct OnlyNamedArgument;
+        ext = "html"
+    )]
+    struct OnlyNamedArgument;
 
-#[test]
-fn test_only_named_argument() {
     assert_eq!(OnlyNamedArgument.render().unwrap(), "hi");
 }
 
 // Check for trailing commas.
-#[derive(Template)]
-#[template(
-    source = r#"{% macro button(label , ) %}
+#[test]
+fn test_trailing_comma() {
+    #[derive(Template)]
+    #[template(
+        source = r#"{% macro button(label , ) %}
 {{- label -}}
 {% endmacro %}
 {%- macro button2(label ,) %}
@@ -162,18 +164,18 @@ fn test_only_named_argument() {
 {%- call button(label="hi", ) -%}
 {%- call button(label="hi" ) -%}
 "#,
-    ext = "html"
-)]
-struct TrailingComma;
+        ext = "html"
+    )]
+    struct TrailingComma;
 
-#[test]
-fn test_trailing_comma() {
     assert_eq!(TrailingComma.render().unwrap(), "hihihihihi");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{%- macro thrice(param1=0, param2=1) -%}
+#[test]
+fn test_default_value() {
+    #[derive(Template)]
+    #[template(
+        source = "{%- macro thrice(param1=0, param2=1) -%}
 {{ param1 }} {{ param2 }}
 {% endmacro -%}
 
@@ -183,12 +185,10 @@ fn test_trailing_comma() {
 {%- call thrice(param2=4, param1=5) -%}
 {%- call thrice(4) -%}
 ",
-    ext = "html"
-)]
-struct MacroDefaultValue;
+        ext = "html"
+    )]
+    struct MacroDefaultValue;
 
-#[test]
-fn test_default_value() {
     assert_eq!(
         MacroDefaultValue.render().unwrap(),
         "0 1\n4 1\n0 4\n5 4\n4 1\n"
@@ -197,27 +197,29 @@ fn test_default_value() {
 
 // This test ensures that the mix of named argument and default value generates
 // the expected result.
-#[derive(Template)]
-#[template(
-    source = "{%- macro thrice(param1=0, param2=1, param3=2) -%}
+#[test]
+fn test_default_value2() {
+    #[derive(Template)]
+    #[template(
+        source = "{%- macro thrice(param1=0, param2=1, param3=2) -%}
 {{ param1 }} {{ param2 }} {{ param3 }}
 {% endmacro -%}
 
 {%- call thrice(4, param3=5) -%}
 ",
-    ext = "html"
-)]
-struct MacroDefaultValue2;
+        ext = "html"
+    )]
+    struct MacroDefaultValue2;
 
-#[test]
-fn test_default_value2() {
     assert_eq!(MacroDefaultValue2.render().unwrap(), "4 1 5\n");
 }
 
 // This test ensures that we can use the macro arguments as default value.
-#[derive(Template)]
-#[template(
-    source = "{%- macro thrice(a=1, b=a + 1, c=a + b + 2) -%}
+#[test]
+fn test_default_value3() {
+    #[derive(Template)]
+    #[template(
+        source = "{%- macro thrice(a=1, b=a + 1, c=a + b + 2) -%}
 {{ a }} {{ b }} {{ c }}
 {% endmacro -%}
 
@@ -226,12 +228,10 @@ fn test_default_value2() {
 {%- call thrice(c=3) -%}
 {%- call thrice(a=3) -%}
 ",
-    ext = "html"
-)]
-struct MacroDefaultValue3;
+        ext = "html"
+    )]
+    struct MacroDefaultValue3;
 
-#[test]
-fn test_default_value3() {
     assert_eq!(
         MacroDefaultValue3.render().unwrap(),
         "1 2 5\n1 6 9\n1 2 3\n3 4 9\n"
@@ -240,9 +240,11 @@ fn test_default_value3() {
 
 // This test ensures that we can use declared variables as default value for
 // macro arguments.
-#[derive(Template)]
-#[template(
-    source = "{% let x = 12 %}
+#[test]
+fn test_default_value4() {
+    #[derive(Template)]
+    #[template(
+        source = "{% let x = 12 %}
 {%- macro thrice(a=x, b=y) -%}
 {{ a }} {{ b }}
 {% endmacro -%}
@@ -252,20 +254,20 @@ fn test_default_value3() {
 {%- call thrice(1) -%}
 {%- call thrice(b=1) -%}
 ",
-    ext = "html"
-)]
-struct MacroDefaultValue4;
+        ext = "html"
+    )]
+    struct MacroDefaultValue4;
 
-#[test]
-fn test_default_value4() {
     assert_eq!(MacroDefaultValue4.render().unwrap(), "12 4\n1 4\n12 1\n");
 }
 
 // This test ensures that we can macro arguments take precedence over declared
 // variables when a macro argument default value is using a variable.
-#[derive(Template)]
-#[template(
-    source = "{% let a = 12 %}
+#[test]
+fn test_default_value5() {
+    #[derive(Template)]
+    #[template(
+        source = "{% let a = 12 %}
 {%- macro thrice(a=3, b=a) -%}
 {{ a }} {{ b }}
 {% endmacro -%}
@@ -274,11 +276,9 @@ fn test_default_value4() {
 {%- call thrice(1) -%}
 {%- call thrice(1, 2) -%}
 ",
-    ext = "html"
-)]
-struct MacroDefaultValue5;
+        ext = "html"
+    )]
+    struct MacroDefaultValue5;
 
-#[test]
-fn test_default_value5() {
     assert_eq!(MacroDefaultValue5.render().unwrap(), "3 3\n1 1\n1 2\n");
 }

--- a/testing/tests/matches.rs
+++ b/testing/tests/matches.rs
@@ -1,19 +1,13 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(path = "match-opt.html")]
-struct MatchOptTemplate<'a> {
-    item: Option<&'a str>,
-}
-
-#[derive(Template)]
-#[template(path = "match-opt.html")]
-struct MatchOptRefTemplate<'a> {
-    item: &'a Option<&'a str>,
-}
-
 #[test]
 fn test_match_option() {
+    #[derive(Template)]
+    #[template(path = "match-opt.html")]
+    struct MatchOptTemplate<'a> {
+        item: Option<&'a str>,
+    }
+
     let s = MatchOptTemplate { item: Some("foo") };
     assert_eq!(s.render().unwrap(), "\nFound literal foo\n");
 
@@ -24,14 +18,14 @@ fn test_match_option() {
     assert_eq!(s.render().unwrap(), "\nNot Found\n");
 }
 
-#[derive(Template)]
-#[template(path = "match-opt-bool.html")]
-struct MatchOptBoolTemplate {
-    item: Option<bool>,
-}
-
 #[test]
 fn test_match_option_bool() {
+    #[derive(Template)]
+    #[template(path = "match-opt-bool.html")]
+    struct MatchOptBoolTemplate {
+        item: Option<bool>,
+    }
+
     let s = MatchOptBoolTemplate { item: Some(true) };
     assert_eq!(s.render().unwrap(), "\nFound Some(true)\n");
 
@@ -44,18 +38,24 @@ fn test_match_option_bool() {
 
 #[test]
 fn test_match_ref_deref() {
+    #[derive(Template)]
+    #[template(path = "match-opt.html")]
+    struct MatchOptRefTemplate<'a> {
+        item: &'a Option<&'a str>,
+    }
+
     let s = MatchOptRefTemplate { item: &Some("foo") };
     assert_eq!(s.render().unwrap(), "\nFound literal foo\n");
 }
 
-#[derive(Template)]
-#[template(path = "match-literal.html")]
-struct MatchLitTemplate<'a> {
-    item: &'a str,
-}
-
 #[test]
 fn test_match_literal() {
+    #[derive(Template)]
+    #[template(path = "match-literal.html")]
+    struct MatchLitTemplate<'a> {
+        item: &'a str,
+    }
+
     let s = MatchLitTemplate { item: "bar" };
     assert_eq!(s.render().unwrap(), "\nFound literal bar\n");
 
@@ -63,14 +63,14 @@ fn test_match_literal() {
     assert_eq!(s.render().unwrap(), "\nElse found qux\n");
 }
 
-#[derive(Template)]
-#[template(path = "match-literal-char.html")]
-struct MatchLitCharTemplate {
-    item: char,
-}
-
 #[test]
 fn test_match_literal_char() {
+    #[derive(Template)]
+    #[template(path = "match-literal-char.html")]
+    struct MatchLitCharTemplate {
+        item: char,
+    }
+
     let s = MatchLitCharTemplate { item: 'b' };
     assert_eq!(s.render().unwrap(), "\nFound literal b\n");
 
@@ -78,14 +78,14 @@ fn test_match_literal_char() {
     assert_eq!(s.render().unwrap(), "\nElse found c\n");
 }
 
-#[derive(Template)]
-#[template(path = "match-literal-num.html")]
-struct MatchLitNumTemplate {
-    item: u32,
-}
-
 #[test]
 fn test_match_literal_num() {
+    #[derive(Template)]
+    #[template(path = "match-literal-num.html")]
+    struct MatchLitNumTemplate {
+        item: u32,
+    }
+
     let s = MatchLitNumTemplate { item: 42 };
     assert_eq!(s.render().unwrap(), "\nFound answer to everything\n");
 
@@ -93,21 +93,21 @@ fn test_match_literal_num() {
     assert_eq!(s.render().unwrap(), "\nElse found 23\n");
 }
 
-#[allow(dead_code)]
-enum Color {
-    Rgb { r: u32, g: u32, b: u32 },
-    GrayScale(u32),
-    Cmyk(u32, u32, u32, u32),
-}
-
-#[derive(Template)]
-#[template(path = "match-custom-enum.html")]
-struct MatchCustomEnumTemplate {
-    color: Color,
-}
-
 #[test]
 fn test_match_custom_enum() {
+    #[allow(dead_code)]
+    enum Color {
+        Rgb { r: u32, g: u32, b: u32 },
+        GrayScale(u32),
+        Cmyk(u32, u32, u32, u32),
+    }
+
+    #[derive(Template)]
+    #[template(path = "match-custom-enum.html")]
+    struct MatchCustomEnumTemplate {
+        color: Color,
+    }
+
     let s = MatchCustomEnumTemplate {
         color: Color::Rgb {
             r: 160,
@@ -118,43 +118,43 @@ fn test_match_custom_enum() {
     assert_eq!(s.render().unwrap(), "\nColorful: #A000FF\n");
 }
 
-#[derive(Template)]
-#[template(path = "match-no-ws.html")]
-struct MatchNoWhitespace {
-    foo: Option<usize>,
-}
-
 #[test]
 fn test_match_no_whitespace() {
+    #[derive(Template)]
+    #[template(path = "match-no-ws.html")]
+    struct MatchNoWhitespace {
+        foo: Option<usize>,
+    }
+
     let s = MatchNoWhitespace { foo: Some(1) };
     assert_eq!(s.render().unwrap(), "1");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% match foo %}{% when Some(bar) %}{{ bar }}{% when None %}{% endmatch %}",
-    ext = "txt"
-)]
-struct MatchWithoutWithKeyword {
-    foo: Option<usize>,
-}
-
 #[test]
 fn test_match_without_with_keyword() {
+    #[derive(Template)]
+    #[template(
+        source = "{% match foo %}{% when Some(bar) %}{{ bar }}{% when None %}{% endmatch %}",
+        ext = "txt"
+    )]
+    struct MatchWithoutWithKeyword {
+        foo: Option<usize>,
+    }
+
     let s = MatchWithoutWithKeyword { foo: Some(1) };
     assert_eq!(s.render().unwrap(), "1");
     let s = MatchWithoutWithKeyword { foo: None };
     assert_eq!(s.render().unwrap(), "");
 }
 
-#[derive(Template)]
-#[template(path = "match-option-result-option.html")]
-struct MatchOptionResultOption {
-    foo: Option<Result<Option<usize>, &'static str>>,
-}
-
 #[test]
 fn test_match_option_result_option() {
+    #[derive(Template)]
+    #[template(path = "match-option-result-option.html")]
+    struct MatchOptionResultOption {
+        foo: Option<Result<Option<usize>, &'static str>>,
+    }
+
     let s = MatchOptionResultOption { foo: None };
     assert_eq!(s.render().unwrap(), "nothing");
     let s = MatchOptionResultOption {
@@ -171,10 +171,12 @@ fn test_match_option_result_option() {
     assert_eq!(s.render().unwrap(), "num=4711");
 }
 
-#[derive(Template)]
-#[template(
-    ext = "txt",
-    source = r#"
+#[test]
+fn test_match_with_comment() {
+    #[derive(Template)]
+    #[template(
+        ext = "txt",
+        source = r#"
 {%- match good -%}
     {#- when good, then good -#}
     {%- when true -%}
@@ -182,13 +184,11 @@ fn test_match_option_result_option() {
     {%- when _ -%}
         bad
 {%- endmatch -%}"#
-)]
-struct MatchWithComment {
-    good: bool,
-}
+    )]
+    struct MatchWithComment {
+        good: bool,
+    }
 
-#[test]
-fn test_match_with_comment() {
     let s = MatchWithComment { good: true };
     assert_eq!(s.render().unwrap(), "good");
 
@@ -196,21 +196,21 @@ fn test_match_with_comment() {
     assert_eq!(s.render().unwrap(), "bad");
 }
 
-enum Suit {
-    Clubs,
-    Diamonds,
-    Hearts,
-    Spades,
-}
-
-#[derive(Template)]
-#[template(path = "match-enum-or.html")]
-struct MatchEnumOrTemplate {
-    suit: Suit,
-}
-
 #[test]
 fn test_match_enum_or() {
+    enum Suit {
+        Clubs,
+        Diamonds,
+        Hearts,
+        Spades,
+    }
+
+    #[derive(Template)]
+    #[template(path = "match-enum-or.html")]
+    struct MatchEnumOrTemplate {
+        suit: Suit,
+    }
+
     let template = MatchEnumOrTemplate { suit: Suit::Clubs };
     assert_eq!(template.render().unwrap(), "The card is black\n");
     let template = MatchEnumOrTemplate { suit: Suit::Spades };
@@ -225,22 +225,24 @@ fn test_match_enum_or() {
     assert_eq!(template.render().unwrap(), "The card is red\n");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% match true %}{% else %}otherwise{% endmatch %}",
-    ext = "html"
-)]
-struct EmptyMatch;
-
 #[test]
 fn test_empty_match() {
+    #[derive(Template)]
+    #[template(
+        source = "{% match true %}{% else %}otherwise{% endmatch %}",
+        ext = "html"
+    )]
+    struct EmptyMatch;
+
     assert_eq!(EmptyMatch.to_string(), "otherwise");
 }
 
-#[derive(Template)]
-#[template(
-    ext = "txt",
-    source = r#"
+#[test]
+fn test_match_with_patterns() {
+    #[derive(Template)]
+    #[template(
+        ext = "txt",
+        source = r#"
 {%- match n -%}
     {%- when 1 | 2 | 3 | 4 -%}
         a listed one!
@@ -249,13 +251,11 @@ fn test_empty_match() {
     {%- when n -%}
         {{ n }}
 {%- endmatch -%}"#
-)]
-struct MatchPatterns {
-    n: u8,
-}
+    )]
+    struct MatchPatterns {
+        n: u8,
+    }
 
-#[test]
-fn test_match_with_patterns() {
     let s = MatchPatterns { n: 1 };
     assert_eq!(s.render().unwrap(), "a listed one!");
 
@@ -266,27 +266,27 @@ fn test_match_with_patterns() {
     assert_eq!(s.render().unwrap(), "12");
 }
 
-#[derive(Template)]
-#[template(in_doc = true, ext = "html")]
-/// ```rinja
-/// {% match result %}
-///     {% when Some(Ok(s)) -%}
-///         good: {{s}}
-///     {%- endwhen +%}
-///     {# This is not good: #}
-///     {%+ when Some(Err(s)) -%}
-///         bad: {{s}}
-///     {%- endwhen +%}
-///     {%+ else -%}
-///         unprocessed
-/// {% endmatch %}
-/// ```
-struct EndWhen<'a> {
-    result: Option<Result<&'a str, &'a str>>,
-}
-
 #[test]
 fn test_end_when() {
+    #[derive(Template)]
+    #[template(in_doc = true, ext = "html")]
+    /// ```rinja
+    /// {% match result %}
+    ///     {% when Some(Ok(s)) -%}
+    ///         good: {{s}}
+    ///     {%- endwhen +%}
+    ///     {# This is not good: #}
+    ///     {%+ when Some(Err(s)) -%}
+    ///         bad: {{s}}
+    ///     {%- endwhen +%}
+    ///     {%+ else -%}
+    ///         unprocessed
+    /// {% endmatch %}
+    /// ```
+    struct EndWhen<'a> {
+        result: Option<Result<&'a str, &'a str>>,
+    }
+
     let tmpl = EndWhen {
         result: Some(Ok("msg")),
     };

--- a/testing/tests/methods.rs
+++ b/testing/tests/methods.rs
@@ -18,36 +18,36 @@ fn test_self_method() {
     assert_eq!(t.render().unwrap(), "foo");
 }
 
-#[derive(Template)]
-#[template(source = "{{ self.type() }}", ext = "txt")]
-struct SelfRawIdentifierMethodTemplate {}
-
-impl SelfRawIdentifierMethodTemplate {
-    fn r#type(&self) -> &str {
-        "foo"
-    }
-}
-
 #[test]
 fn test_self_raw_identifier_method() {
+    #[derive(Template)]
+    #[template(source = "{{ self.type() }}", ext = "txt")]
+    struct SelfRawIdentifierMethodTemplate {}
+
+    impl SelfRawIdentifierMethodTemplate {
+        fn r#type(&self) -> &str {
+            "foo"
+        }
+    }
+
     let t = SelfRawIdentifierMethodTemplate {};
     assert_eq!(t.render().unwrap(), "foo");
 }
 
-#[derive(Template)]
-#[template(source = "{{ self.get_s() }} {{ t.get_s() }}", ext = "txt")]
-struct NestedSelfMethodTemplate<'a> {
-    t: SelfMethodTemplate<'a>,
-}
-
-impl<'a> NestedSelfMethodTemplate<'a> {
-    fn get_s(&self) -> &str {
-        "bar"
-    }
-}
-
 #[test]
 fn test_nested() {
+    #[derive(Template)]
+    #[template(source = "{{ self.get_s() }} {{ t.get_s() }}", ext = "txt")]
+    struct NestedSelfMethodTemplate<'a> {
+        t: SelfMethodTemplate<'a>,
+    }
+
+    impl<'a> NestedSelfMethodTemplate<'a> {
+        fn get_s(&self) -> &str {
+            "bar"
+        }
+    }
+
     let t = NestedSelfMethodTemplate {
         t: SelfMethodTemplate { s: "foo" },
     };

--- a/testing/tests/operators.rs
+++ b/testing/tests/operators.rs
@@ -1,63 +1,63 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(path = "compare.html")]
-struct CompareTemplate {
-    a: usize,
-    b: usize,
-    c: usize,
-}
-
 #[test]
 fn test_compare() {
+    #[derive(Template)]
+    #[template(path = "compare.html")]
+    struct CompareTemplate {
+        a: usize,
+        b: usize,
+        c: usize,
+    }
+
     let t = CompareTemplate { a: 1, b: 1, c: 2 };
     assert_eq!(t.render().unwrap(), "tf\ntf\ntf\ntf\ntf\ntf");
 }
 
-#[derive(Template)]
-#[template(path = "operators.html")]
-struct OperatorsTemplate {
-    a: usize,
-    b: usize,
-    c: usize,
-}
-
 #[test]
 fn test_operators() {
+    #[derive(Template)]
+    #[template(path = "operators.html")]
+    struct OperatorsTemplate {
+        a: usize,
+        b: usize,
+        c: usize,
+    }
+
     let t = OperatorsTemplate { a: 1, b: 1, c: 2 };
     assert_eq!(t.render().unwrap(), "muldivmodaddrshlshbandbxorborandor");
 }
 
-#[derive(Template)]
-#[template(path = "precedence.html")]
-struct PrecedenceTemplate {}
-
 #[test]
 fn test_precedence() {
+    #[derive(Template)]
+    #[template(path = "precedence.html")]
+    struct PrecedenceTemplate {}
+
     let t = PrecedenceTemplate {};
     assert_eq!(t.render().unwrap(), "6".repeat(7));
 }
 
-#[derive(Template)]
-#[template(path = "ranges.txt")]
-struct RangesTemplate<'a> {
-    foo: Vec<&'a str>,
-}
-
 #[test]
 fn test_ranges() {
+    #[derive(Template)]
+    #[template(path = "ranges.txt")]
+    struct RangesTemplate<'a> {
+        foo: Vec<&'a str>,
+    }
+
     let t = RangesTemplate {
         foo: vec!["a", "b", "c", "d"],
     };
     assert_eq!(t.render().unwrap(), "abcd\nbcd\n\na\nab");
 }
 
-#[derive(Template)]
-#[template(source = "{{ true && true }}{{ false || true }}", ext = "txt")]
-struct ShortCircuitTemplate {}
-
 #[test]
 fn test_short_circuit() {
+    #[derive(Template)]
+    #[template(source = "{{ true && true }}{{ false || true }}", ext = "txt")]
+    struct ShortCircuitTemplate {}
+
     let t = ShortCircuitTemplate {};
     assert_eq!(t.render().unwrap(), "truetrue");
 }

--- a/testing/tests/ref_deref.rs
+++ b/testing/tests/ref_deref.rs
@@ -1,8 +1,10 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(
-    source = r#"
+#[test]
+fn test_ref_deref() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
 {%- if *title == "something" -%}
 something1
 {%- elif title == &"another" -%}
@@ -13,14 +15,12 @@ yep3
 {{title}}
 {%- endif -%}
 "#,
-    ext = "html"
-)]
-struct RefDeref {
-    title: &'static &'static str,
-}
+        ext = "html"
+    )]
+    struct RefDeref {
+        title: &'static &'static str,
+    }
 
-#[test]
-fn test_ref_deref() {
     let x = RefDeref {
         title: &"something",
     };
@@ -36,9 +36,11 @@ fn test_ref_deref() {
     assert_eq!(x.render().unwrap(), "bla");
 }
 
-#[derive(Template)]
-#[template(
-    source = r#"
+#[test]
+fn test_ref_deref_assign() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
 {%- let x = **title -%}
 {%- if x == "another" -%}
 another2
@@ -46,14 +48,12 @@ another2
 {{x}}
 {%- endif -%}
 "#,
-    ext = "html"
-)]
-struct RefDerefAssignment {
-    title: &'static &'static str,
-}
+        ext = "html"
+    )]
+    struct RefDerefAssignment {
+        title: &'static &'static str,
+    }
 
-#[test]
-fn test_ref_deref_assign() {
     let x = RefDerefAssignment { title: &"another" };
     assert_eq!(x.render().unwrap(), "another2");
 

--- a/testing/tests/render_in_place.rs
+++ b/testing/tests/render_in_place.rs
@@ -1,28 +1,29 @@
 use rinja::Template;
-#[derive(Template)]
-#[template(path = "render_in_place.html")]
-struct RenderInPlace<'a> {
-    s1: SectionOne<'a>,
-    s2: SectionTwo<'a>,
-    s3: &'a Vec<SectionOne<'a>>,
-}
-
-#[derive(Template)]
-#[template(source = "A={{ a }}\nB={{ b }}", ext = "html")]
-struct SectionOne<'a> {
-    a: &'a str,
-    b: &'a str,
-}
-
-#[derive(Template)]
-#[template(source = "C={{ c }}\nD={{ d }}", ext = "html")]
-struct SectionTwo<'a> {
-    c: &'a str,
-    d: &'a str,
-}
 
 #[test]
 fn test_render_in_place() {
+    #[derive(Template)]
+    #[template(path = "render_in_place.html")]
+    struct RenderInPlace<'a> {
+        s1: SectionOne<'a>,
+        s2: SectionTwo<'a>,
+        s3: &'a Vec<SectionOne<'a>>,
+    }
+
+    #[derive(Template)]
+    #[template(source = "A={{ a }}\nB={{ b }}", ext = "html")]
+    struct SectionOne<'a> {
+        a: &'a str,
+        b: &'a str,
+    }
+
+    #[derive(Template)]
+    #[template(source = "C={{ c }}\nD={{ d }}", ext = "html")]
+    struct SectionTwo<'a> {
+        c: &'a str,
+        d: &'a str,
+    }
+
     let t = RenderInPlace {
         s1: SectionOne { a: "A", b: "B" },
         s2: SectionTwo { c: "C", d: "D" },

--- a/testing/tests/rest_pattern.rs
+++ b/testing/tests/rest_pattern.rs
@@ -1,8 +1,10 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(
-    source = r#"
+#[test]
+fn test_rest() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
 {%- if let [1, 2, who @ .., 4] = [1, 2, 3, 4] -%}
 111> {{"{:?}"|format(who)}}
 {%- endif -%}
@@ -13,12 +15,10 @@ use rinja::Template;
 333> {{"{:?}"|format(who)}}
 {%- endif -%}
 "#,
-    ext = "txt"
-)]
-struct Rest;
+        ext = "txt"
+    )]
+    struct Rest;
 
-#[test]
-fn test_rest() {
     assert_eq!(
         Rest.render().unwrap(),
         "111> [3]222> [1, 2, 3]333> [2, 3, 4]"

--- a/testing/tests/rust_macro.rs
+++ b/testing/tests/rust_macro.rs
@@ -6,12 +6,12 @@ macro_rules! hello {
     };
 }
 
-#[derive(Template)]
-#[template(path = "rust-macros.html")]
-struct RustMacrosTemplate {}
-
 #[test]
 fn macro_basic() {
+    #[derive(Template)]
+    #[template(path = "rust-macros.html")]
+    struct RustMacrosTemplate {}
+
     let template = RustMacrosTemplate {};
     assert_eq!("Hello, world!", template.render().unwrap());
 }
@@ -26,12 +26,12 @@ mod foo {
     pub(crate) use hello2;
 }
 
-#[derive(Template)]
-#[template(path = "rust-macros-full-path.html")]
-struct RustMacrosFullPathTemplate {}
-
 #[test]
 fn macro_full_path() {
+    #[derive(Template)]
+    #[template(path = "rust-macros-full-path.html")]
+    struct RustMacrosFullPathTemplate {}
+
     let template = RustMacrosFullPathTemplate {};
     assert_eq!("Hello, world!", template.render().unwrap());
 }
@@ -50,24 +50,28 @@ macro_rules! call_a_or_b_on_tail {
     };
 }
 
-fn year(y: u16, _: &str, _: u8) -> u16 {
-    y
-}
+mod macro_with_args {
+    use rinja::Template;
 
-fn month(_: u16, m: &str, _: u8) -> &str {
-    m
-}
+    fn year(y: u16, _: &str, _: u8) -> u16 {
+        y
+    }
 
-fn day(_: u16, _: &str, d: u8) -> u8 {
-    d
-}
+    fn month(_: u16, m: &str, _: u8) -> &str {
+        m
+    }
 
-#[derive(Template)]
-#[template(path = "rust-macro-args.html")]
-struct RustMacrosArgTemplate {}
+    fn day(_: u16, _: &str, d: u8) -> u8 {
+        d
+    }
 
-#[test]
-fn macro_with_args() {
-    let template = RustMacrosArgTemplate {};
-    assert_eq!("2021\nJuly\n2", template.render().unwrap());
+    #[derive(Template)]
+    #[template(path = "rust-macro-args.html")]
+    struct RustMacrosArgTemplate {}
+
+    #[test]
+    fn macro_with_args() {
+        let template = RustMacrosArgTemplate {};
+        assert_eq!("2021\nJuly\n2", template.render().unwrap());
+    }
 }

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -9,16 +9,16 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use rinja::Template;
 use rinja::filters::HtmlSafe;
 
-#[derive(Template)]
-#[template(path = "simple.html")]
-struct VariablesTemplate<'a> {
-    strvar: &'a str,
-    num: i64,
-    i18n: String,
-}
-
 #[test]
 fn test_variables() {
+    #[derive(Template)]
+    #[template(path = "simple.html")]
+    struct VariablesTemplate<'a> {
+        strvar: &'a str,
+        num: i64,
+        i18n: String,
+    }
+
     let s = VariablesTemplate {
         strvar: "foo",
         num: 42,
@@ -34,29 +34,29 @@ fn test_variables() {
     assert_eq!(VariablesTemplate::EXTENSION, Some("html"));
 }
 
-#[derive(Template)]
-#[template(path = "hello.html")]
-struct EscapeTemplate<'a> {
-    name: &'a str,
-}
-
 #[test]
 fn test_escape() {
+    #[derive(Template)]
+    #[template(path = "hello.html")]
+    struct EscapeTemplate<'a> {
+        name: &'a str,
+    }
+
     let s = EscapeTemplate { name: "<>&\"'" };
 
     assert_eq!(s.render().unwrap(), "Hello, &#60;&#62;&#38;&#34;&#39;!");
 }
 
-#[derive(Template)]
-#[template(path = "simple-no-escape.txt")]
-struct VariablesTemplateNoEscape<'a> {
-    strvar: &'a str,
-    num: i64,
-    i18n: String,
-}
-
 #[test]
 fn test_variables_no_escape() {
+    #[derive(Template)]
+    #[template(path = "simple-no-escape.txt")]
+    struct VariablesTemplateNoEscape<'a> {
+        strvar: &'a str,
+        num: i64,
+        i18n: String,
+    }
+
     let s = VariablesTemplateNoEscape {
         strvar: "foo",
         num: 42,
@@ -71,69 +71,73 @@ fn test_variables_no_escape() {
     );
 }
 
-#[derive(Template)]
-#[template(
-    source = "{{ foo }} {{ foo_bar }} {{ FOO }} {{ FOO_BAR }} {{ self::FOO }} {{ self::FOO_BAR }} {{ Self::BAR }} {{ Self::BAR_BAZ }}",
-    ext = "txt"
-)]
-struct ConstTemplate {
-    foo: &'static str,
-    foo_bar: &'static str,
-}
+mod test_constants {
+    use rinja::Template;
 
-impl ConstTemplate {
-    const BAR: &'static str = "BAR";
-    const BAR_BAZ: &'static str = "BAR BAZ";
-}
+    const FOO: &str = "FOO";
+    const FOO_BAR: &str = "FOO BAR";
 
-#[test]
-fn test_constants() {
-    let t = ConstTemplate {
-        foo: "foo",
-        foo_bar: "foo bar",
-    };
-    assert_eq!(
-        t.render().unwrap(),
-        "foo foo bar FOO FOO BAR FOO FOO BAR BAR BAR BAZ"
-    );
-}
+    #[derive(Template)]
+    #[template(
+        source = "{{ foo }} {{ foo_bar }} {{ FOO }} {{ FOO_BAR }} {{ self::FOO }} {{ self::FOO_BAR }} {{ Self::BAR }} {{ Self::BAR_BAZ }}",
+        ext = "txt"
+    )]
+    struct ConstTemplate {
+        foo: &'static str,
+        foo_bar: &'static str,
+    }
 
-const FOO: &str = "FOO";
-const FOO_BAR: &str = "FOO BAR";
+    impl ConstTemplate {
+        const BAR: &'static str = "BAR";
+        const BAR_BAZ: &'static str = "BAR BAZ";
+    }
 
-#[derive(Template)]
-#[template(path = "if.html")]
-struct IfTemplate {
-    cond: bool,
+    #[test]
+    fn test_constants() {
+        let t = ConstTemplate {
+            foo: "foo",
+            foo_bar: "foo bar",
+        };
+        assert_eq!(
+            t.render().unwrap(),
+            "foo foo bar FOO FOO BAR FOO FOO BAR BAR BAR BAZ"
+        );
+    }
 }
 
 #[test]
 fn test_if() {
+    #[derive(Template)]
+    #[template(path = "if.html")]
+    struct IfTemplate {
+        cond: bool,
+    }
+
     let s = IfTemplate { cond: true };
     assert_eq!(s.render().unwrap(), "true");
 }
 
-#[derive(Template)]
-#[template(path = "else.html")]
-struct ElseTemplate {
-    cond: bool,
-}
-
 #[test]
 fn test_else() {
+    #[derive(Template)]
+    #[template(path = "else.html")]
+    struct ElseTemplate {
+        cond: bool,
+    }
+
     let s = ElseTemplate { cond: false };
     assert_eq!(s.render().unwrap(), "false");
 }
 
-#[derive(Template)]
-#[template(path = "else-if.html")]
-struct ElseIfTemplate {
-    cond: bool,
-    check: bool,
-}
-
 #[test]
 fn test_else_if() {
+    #[derive(Template)]
+    #[template(path = "else-if.html")]
+    struct ElseIfTemplate {
+        cond: bool,
+        check: bool,
+    }
+
     let s = ElseIfTemplate {
         cond: false,
         check: true,
@@ -141,22 +145,22 @@ fn test_else_if() {
     assert_eq!(s.render().unwrap(), "checked");
 }
 
-#[derive(Template)]
-#[template(path = "literals.html")]
-struct LiteralsTemplate {}
-
 #[test]
 fn test_literals() {
+    #[derive(Template)]
+    #[template(path = "literals.html")]
+    struct LiteralsTemplate {}
+
     let s = LiteralsTemplate {};
     assert_eq!(s.render().unwrap(), "a\na\ntrue\nfalse");
 }
 
-#[derive(Template)]
-#[template(path = "literals-escape.html")]
-struct LiteralsEscapeTemplate {}
-
 #[test]
 fn test_literals_escape() {
+    #[derive(Template)]
+    #[template(path = "literals-escape.html")]
+    struct LiteralsEscapeTemplate {}
+
     let s = LiteralsEscapeTemplate {};
     assert_eq!(
         s.render().unwrap(),
@@ -164,50 +168,54 @@ fn test_literals_escape() {
     );
 }
 
-struct Holder {
-    a: usize,
-}
-
-#[derive(Template)]
-#[template(path = "attr.html")]
-struct AttrTemplate {
-    inner: Holder,
-}
-
 #[test]
 fn test_attr() {
+    struct Holder {
+        a: usize,
+    }
+
+    #[derive(Template)]
+    #[template(path = "attr.html")]
+    struct AttrTemplate {
+        inner: Holder,
+    }
+
     let t = AttrTemplate {
         inner: Holder { a: 5 },
     };
     assert_eq!(t.render().unwrap(), "5");
 }
 
-#[derive(Template)]
-#[template(path = "tuple-attr.html")]
-struct TupleAttrTemplate<'a> {
-    tuple: (&'a str, &'a str),
-}
-
 #[test]
 fn test_tuple_attr() {
+    #[derive(Template)]
+    #[template(path = "tuple-attr.html")]
+    struct TupleAttrTemplate<'a> {
+        tuple: (&'a str, &'a str),
+    }
+
     let t = TupleAttrTemplate {
         tuple: ("foo", "bar"),
     };
     assert_eq!(t.render().unwrap(), "foobar");
 }
 
-struct NestedHolder {
-    holder: Holder,
-}
-
-#[derive(Template)]
-#[template(path = "nested-attr.html")]
-struct NestedAttrTemplate {
-    inner: NestedHolder,
-}
-
 #[test]
 fn test_nested_attr() {
+    struct Holder {
+        a: usize,
+    }
+
+    struct NestedHolder {
+        holder: Holder,
+    }
+
+    #[derive(Template)]
+    #[template(path = "nested-attr.html")]
+    struct NestedAttrTemplate {
+        inner: NestedHolder,
+    }
+
     let t = NestedAttrTemplate {
         inner: NestedHolder {
             holder: Holder { a: 5 },
@@ -216,227 +224,237 @@ fn test_nested_attr() {
     assert_eq!(t.render().unwrap(), "5");
 }
 
-#[derive(Template)]
-#[template(path = "option.html")]
-struct OptionTemplate<'a> {
-    var: Option<&'a str>,
-}
-
 #[test]
 fn test_option() {
+    #[derive(Template)]
+    #[template(path = "option.html")]
+    struct OptionTemplate<'a> {
+        var: Option<&'a str>,
+    }
+
     let some = OptionTemplate { var: Some("foo") };
     assert_eq!(some.render().unwrap(), "some: foo");
     let none = OptionTemplate { var: None };
     assert_eq!(none.render().unwrap(), "none");
 }
 
-#[derive(Template)]
-#[template(source = "{{ Self::foo(None) }} {{ Self::foo(Some(1)) }}", ext = "txt")]
-struct OptionNoneSomeTemplate;
-
-impl OptionNoneSomeTemplate {
-    fn foo(x: Option<i32>) -> i32 {
-        x.unwrap_or_default()
-    }
-}
-
 #[test]
 fn test_option_none_some() {
+    #[derive(Template)]
+    #[template(source = "{{ Self::foo(None) }} {{ Self::foo(Some(1)) }}", ext = "txt")]
+    struct OptionNoneSomeTemplate;
+
+    impl OptionNoneSomeTemplate {
+        fn foo(x: Option<i32>) -> i32 {
+            x.unwrap_or_default()
+        }
+    }
+
     let t = OptionNoneSomeTemplate;
     assert_eq!(t.render().unwrap(), "0 1");
 }
 
-#[derive(Template)]
-#[template(path = "generics.html")]
-struct GenericsTemplate<T, U = u8>
-where
-    T: std::fmt::Display,
-    U: std::fmt::Display,
-{
-    t: T,
-    u: U,
-}
-
 #[test]
 fn test_generics() {
+    #[derive(Template)]
+    #[template(path = "generics.html")]
+    struct GenericsTemplate<T, U = u8>
+    where
+        T: std::fmt::Display,
+        U: std::fmt::Display,
+    {
+        t: T,
+        u: U,
+    }
+
     let t = GenericsTemplate { t: "a", u: 42 };
     assert_eq!(t.render().unwrap(), "a42");
 }
 
-#[derive(Template)]
-#[template(path = "composition.html")]
-struct CompositionTemplate {
-    foo: IfTemplate,
-}
-
 #[test]
 fn test_composition() {
+    #[derive(Template)]
+    #[template(path = "if.html")]
+    struct IfTemplate {
+        cond: bool,
+    }
+
+    #[derive(Template)]
+    #[template(path = "composition.html")]
+    struct CompositionTemplate {
+        foo: IfTemplate,
+    }
+
     let t = CompositionTemplate {
         foo: IfTemplate { cond: true },
     };
     assert_eq!(t.render().unwrap(), "composed: true");
 }
 
-#[derive(PartialEq, Eq)]
-enum Alphabet {
-    Alpha,
-}
-
-#[derive(Template)]
-#[template(source = "{% if x == Alphabet::Alpha %}true{% endif %}", ext = "txt")]
-struct PathCompareTemplate {
-    x: Alphabet,
-}
-
 #[test]
 fn test_path_compare() {
+    #[derive(PartialEq, Eq)]
+    enum Alphabet {
+        Alpha,
+    }
+
+    #[derive(Template)]
+    #[template(source = "{% if x == Alphabet::Alpha %}true{% endif %}", ext = "txt")]
+    struct PathCompareTemplate {
+        x: Alphabet,
+    }
+
     let t = PathCompareTemplate { x: Alphabet::Alpha };
     assert_eq!(t.render().unwrap(), "true");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% for i in [\"a\", \"\"] %}{{ i }}{% endfor %}",
-    ext = "txt"
-)]
-struct ArrayTemplate {}
-
 #[test]
 fn test_slice_literal() {
+    #[derive(Template)]
+    #[template(
+        source = "{% for i in [\"a\", \"\"] %}{{ i }}{% endfor %}",
+        ext = "txt"
+    )]
+    struct ArrayTemplate {}
+
     let t = ArrayTemplate {};
     assert_eq!(t.render().unwrap(), "a");
 }
 
-#[derive(Template)]
-#[template(source = "Hello, {{ world(\"123\", 4) }}!", ext = "txt")]
-struct FunctionRefTemplate;
-
-impl FunctionRefTemplate {
-    fn world(&self, s: &str, v: u8) -> String {
-        format!("world({s}, {v})")
-    }
-}
-
 #[test]
 fn test_func_ref_call() {
+    #[derive(Template)]
+    #[template(source = "Hello, {{ world(\"123\", 4) }}!", ext = "txt")]
+    struct FunctionRefTemplate;
+
+    impl FunctionRefTemplate {
+        fn world(&self, s: &str, v: u8) -> String {
+            format!("world({s}, {v})")
+        }
+    }
+
     let t = FunctionRefTemplate;
     assert_eq!(t.render().unwrap(), "Hello, world(123, 4)!");
 }
 
-#[allow(clippy::trivially_copy_pass_by_ref)]
-fn world2(s: &str, v: u8) -> String {
-    format!("world{v}{s}")
-}
+mod test_path_func_call {
+    use rinja::Template;
 
-#[derive(Template)]
-#[template(source = "Hello, {{ self::world2(\"123\", 4) }}!", ext = "txt")]
-struct PathFunctionTemplate;
-
-#[test]
-fn test_path_func_call() {
-    assert_eq!(PathFunctionTemplate.render().unwrap(), "Hello, world4123!");
-}
-
-#[derive(Template)]
-#[template(source = "{{ ::std::string::String::from(\"123\") }}", ext = "txt")]
-struct RootPathFunctionTemplate;
-
-#[test]
-fn test_root_path_func_call() {
-    assert_eq!(RootPathFunctionTemplate.render().unwrap(), "123");
-}
-
-#[derive(Template)]
-#[template(source = "Hello, {{ Self::world3(self, \"123\", 4) }}!", ext = "txt")]
-struct FunctionTemplate;
-
-impl FunctionTemplate {
     #[allow(clippy::trivially_copy_pass_by_ref)]
-    #[allow(dead_code)]
-    fn world3(&self, s: &str, v: u8) -> String {
-        format!("world{s}{v}")
+    fn world2(s: &str, v: u8) -> String {
+        format!("world{v}{s}")
+    }
+
+    #[derive(Template)]
+    #[template(source = "Hello, {{ self::world2(\"123\", 4) }}!", ext = "txt")]
+    struct PathFunctionTemplate;
+
+    #[test]
+    fn test_path_func_call() {
+        assert_eq!(PathFunctionTemplate.render().unwrap(), "Hello, world4123!");
     }
 }
 
 #[test]
+fn test_root_path_func_call() {
+    #[derive(Template)]
+    #[template(source = "{{ ::std::string::String::from(\"123\") }}", ext = "txt")]
+    struct RootPathFunctionTemplate;
+
+    assert_eq!(RootPathFunctionTemplate.render().unwrap(), "123");
+}
+
+#[test]
 fn test_fn() {
+    #[derive(Template)]
+    #[template(source = "Hello, {{ Self::world3(self, \"123\", 4) }}!", ext = "txt")]
+    struct FunctionTemplate;
+
+    impl FunctionTemplate {
+        #[allow(clippy::trivially_copy_pass_by_ref)]
+        #[allow(dead_code)]
+        fn world3(&self, s: &str, v: u8) -> String {
+            format!("world{s}{v}")
+        }
+    }
+
     let t = FunctionTemplate;
     assert_eq!(t.render().unwrap(), "Hello, world1234!");
 }
 
-#[derive(Template)]
-#[template(source = "  {# foo -#} ", ext = "txt")]
-struct CommentTemplate {}
-
 #[test]
 fn test_comment() {
+    #[derive(Template)]
+    #[template(source = "  {# foo -#} ", ext = "txt")]
+    struct CommentTemplate {}
+
     let t = CommentTemplate {};
     assert_eq!(t.render().unwrap(), "  ");
 }
 
-#[derive(Template)]
-#[template(source = "{% if !foo %}Hello{% endif %}", ext = "txt")]
-struct NegationTemplate {
-    foo: bool,
-}
-
 #[test]
 fn test_negation() {
+    #[derive(Template)]
+    #[template(source = "{% if !foo %}Hello{% endif %}", ext = "txt")]
+    struct NegationTemplate {
+        foo: bool,
+    }
+
     let t = NegationTemplate { foo: false };
     assert_eq!(t.render().unwrap(), "Hello");
 }
 
-#[derive(Template)]
-#[template(source = "{% if foo > -2 %}Hello{% endif %}", ext = "txt")]
-struct MinusTemplate {
-    foo: i8,
-}
-
 #[test]
 fn test_minus() {
+    #[derive(Template)]
+    #[template(source = "{% if foo > -2 %}Hello{% endif %}", ext = "txt")]
+    struct MinusTemplate {
+        foo: i8,
+    }
+
     let t = MinusTemplate { foo: 1 };
     assert_eq!(t.render().unwrap(), "Hello");
 }
 
-#[derive(Template)]
-#[template(source = "{{ foo[\"bar\"] }}", ext = "txt")]
-struct IndexTemplate {
-    foo: HashMap<String, String>,
-}
-
 #[test]
 fn test_index() {
+    #[derive(Template)]
+    #[template(source = "{{ foo[\"bar\"] }}", ext = "txt")]
+    struct IndexTemplate {
+        foo: HashMap<String, String>,
+    }
+
     let mut foo = HashMap::new();
     foo.insert("bar".into(), "baz".into());
     let t = IndexTemplate { foo };
     assert_eq!(t.render().unwrap(), "baz");
 }
 
-#[derive(Template)]
-#[template(source = "foo", ext = "txt")]
-struct Empty;
-
 #[test]
 fn test_empty() {
+    #[derive(Template)]
+    #[template(source = "foo", ext = "txt")]
+    struct Empty;
+
     assert_eq!(Empty.render().unwrap(), "foo");
 }
 
-#[derive(Template)]
-#[template(path = "raw-simple.html")]
-struct RawTemplate;
-
 #[test]
 fn test_raw_simple() {
+    #[derive(Template)]
+    #[template(path = "raw-simple.html")]
+    struct RawTemplate;
+
     let template = RawTemplate;
     assert_eq!(template.render().unwrap(), "\n<span>{{ name }}</span>\n");
 }
 
-#[derive(Template)]
-#[template(path = "raw-complex.html")]
-struct RawTemplateComplex;
-
 #[test]
 fn test_raw_complex() {
+    #[derive(Template)]
+    #[template(path = "raw-complex.html")]
+    struct RawTemplateComplex;
+
     let template = RawTemplateComplex;
     assert_eq!(
         template.render().unwrap(),
@@ -444,12 +462,12 @@ fn test_raw_complex() {
     );
 }
 
-#[derive(Template)]
-#[template(path = "raw-ws.html")]
-struct RawTemplateWs;
-
 #[test]
 fn test_raw_ws() {
+    #[derive(Template)]
+    #[template(path = "raw-ws.html")]
+    struct RawTemplateWs;
+
     let template = RawTemplateWs;
     assert_eq!(template.render().unwrap(), "<{{hello}}>\n<{{bye}}>");
 }
@@ -466,44 +484,37 @@ mod without_import_on_derive {
     }
 }
 
-#[derive(rinja::Template)]
-#[template(source = "{% let s = String::new() %}{{ s }}", ext = "txt")]
-struct DefineStringVar;
-
 #[test]
 fn test_define_string_var() {
+    #[derive(rinja::Template)]
+    #[template(source = "{% let s = String::new() %}{{ s }}", ext = "txt")]
+    struct DefineStringVar;
+
     let template = DefineStringVar;
     assert_eq!(template.render().unwrap(), "");
 }
 
-#[derive(rinja::Template)]
-#[template(source = "{% let x = 4.5 %}{{ x }}", ext = "html")]
-struct SimpleFloat;
-
 #[test]
 fn test_simple_float() {
+    #[derive(rinja::Template)]
+    #[template(source = "{% let x = 4.5 %}{{ x }}", ext = "html")]
+    struct SimpleFloat;
+
     let template = SimpleFloat;
     assert_eq!(template.render().unwrap(), "4.5");
 }
 
-#[derive(rinja::Template)]
-#[template(path = "num-literals.html")]
-struct NumLiterals;
-
 #[test]
 fn test_num_literals() {
+    #[derive(rinja::Template)]
+    #[template(path = "num-literals.html")]
+    struct NumLiterals;
+
     let template = NumLiterals;
     assert_eq!(
         template.render().unwrap(),
         "[90, -90, 90, 2, 56, 240, 10.5, 10.5, 100000000000, 105000000000]\n1\n12",
     );
-}
-
-#[allow(non_snake_case)]
-#[derive(rinja::Template)]
-#[template(source = "{{ xY }}", ext = "txt")]
-struct MixedCase {
-    xY: &'static str,
 }
 
 /// Test that we can use mixed case in variable names
@@ -515,20 +526,27 @@ struct MixedCase {
 /// <https://github.com/rinja-rs/rinja/issues/924>
 #[test]
 fn test_mixed_case() {
+    #[allow(non_snake_case)]
+    #[derive(rinja::Template)]
+    #[template(source = "{{ xY }}", ext = "txt")]
+    struct MixedCase {
+        xY: &'static str,
+    }
+
     let template = MixedCase { xY: "foo" };
     assert_eq!(template.render().unwrap(), "foo");
-}
-
-#[allow(non_snake_case)]
-#[derive(rinja::Template)]
-#[template(source = "Hello, {{ user }}!", ext = "txt")]
-struct Referenced {
-    user: &'static str,
 }
 
 #[test]
 #[allow(clippy::needless_borrows_for_generic_args)]
 fn test_referenced() {
+    #[allow(non_snake_case)]
+    #[derive(rinja::Template)]
+    #[template(source = "Hello, {{ user }}!", ext = "txt")]
+    struct Referenced {
+        user: &'static str,
+    }
+
     fn template_to_string(template: impl Template) -> String {
         template.to_string()
     }
@@ -539,30 +557,30 @@ fn test_referenced() {
     assert_eq!(template_to_string(template), "Hello, person!");
 }
 
-#[derive(rinja::Template)]
-#[template(
-    source = "{{ input as u8 }} {{ &input as u8 }} {{ &&input as u8 }}",
-    ext = "txt"
-)]
-struct TestI16ToU8 {
-    input: i16,
-}
-
 #[test]
 fn test_i16_to_u8() {
+    #[derive(rinja::Template)]
+    #[template(
+        source = "{{ input as u8 }} {{ &input as u8 }} {{ &&input as u8 }}",
+        ext = "txt"
+    )]
+    struct TestI16ToU8 {
+        input: i16,
+    }
+
     assert_eq!(TestI16ToU8 { input: 0 }.to_string(), "0 0 0");
     assert_eq!(TestI16ToU8 { input: 0x7f00 }.to_string(), "0 0 0");
     assert_eq!(TestI16ToU8 { input: 255 }.to_string(), "255 255 255");
     assert_eq!(TestI16ToU8 { input: -12345 }.to_string(), "199 199 199");
 }
 
-#[derive(Template)]
-#[template(source = "🙂")]
-#[template(ext = "txt")]
-struct SplitTemplateDeclaration;
-
 #[test]
 fn test_split_template_declaration() {
+    #[derive(Template)]
+    #[template(source = "🙂")]
+    #[template(ext = "txt")]
+    struct SplitTemplateDeclaration;
+
     assert_eq!(SplitTemplateDeclaration.to_string(), "🙂");
 }
 

--- a/testing/tests/try.rs
+++ b/testing/tests/try.rs
@@ -1,19 +1,19 @@
 use rinja::Template;
 
-#[derive(Template)]
-#[template(source = "{% let v = self.parse()? %}{{s}}={{v}}", ext = "txt")]
-struct IntParserTemplate<'a> {
-    s: &'a str,
-}
-
-impl IntParserTemplate<'_> {
-    fn parse(&self) -> Result<i32, std::num::ParseIntError> {
-        self.s.parse()
-    }
-}
-
 #[test]
 fn test_int_parser() {
+    #[derive(Template)]
+    #[template(source = "{% let v = self.parse()? %}{{s}}={{v}}", ext = "txt")]
+    struct IntParserTemplate<'a> {
+        s: &'a str,
+    }
+
+    impl IntParserTemplate<'_> {
+        fn parse(&self) -> Result<i32, std::num::ParseIntError> {
+            self.s.parse()
+        }
+    }
+
     let template = IntParserTemplate { s: "💯" };
     assert!(matches!(template.render(), Err(rinja::Error::Custom(_))));
     assert_eq!(
@@ -25,24 +25,24 @@ fn test_int_parser() {
     assert_eq!(template.render().unwrap(), "100=100");
 }
 
-#[derive(Template)]
-#[template(source = "{{ value()? }}", ext = "txt")]
-struct FailFmt {
-    inner: Option<&'static str>,
-}
-
-impl FailFmt {
-    fn value(&self) -> Result<&'static str, std::fmt::Error> {
-        if let Some(inner) = self.inner {
-            Ok(inner)
-        } else {
-            Err(std::fmt::Error)
-        }
-    }
-}
-
 #[test]
 fn fail_fmt() {
+    #[derive(Template)]
+    #[template(source = "{{ value()? }}", ext = "txt")]
+    struct FailFmt {
+        inner: Option<&'static str>,
+    }
+
+    impl FailFmt {
+        fn value(&self) -> Result<&'static str, std::fmt::Error> {
+            if let Some(inner) = self.inner {
+                Ok(inner)
+            } else {
+                Err(std::fmt::Error)
+            }
+        }
+    }
+
     let template = FailFmt { inner: None };
     assert!(matches!(template.render(), Err(rinja::Error::Custom(_))));
     assert_eq!(
@@ -56,24 +56,24 @@ fn fail_fmt() {
     assert_eq!(template.render().unwrap(), "hello world");
 }
 
-#[derive(Template)]
-#[template(source = "{{ value()? }}", ext = "txt")]
-struct FailStr {
-    value: bool,
-}
-
-impl FailStr {
-    fn value(&self) -> Result<&'static str, &'static str> {
-        if !self.value {
-            Err("FAIL")
-        } else {
-            Ok("hello world")
-        }
-    }
-}
-
 #[test]
 fn fail_str() {
+    #[derive(Template)]
+    #[template(source = "{{ value()? }}", ext = "txt")]
+    struct FailStr {
+        value: bool,
+    }
+
+    impl FailStr {
+        fn value(&self) -> Result<&'static str, &'static str> {
+            if !self.value {
+                Err("FAIL")
+            } else {
+                Ok("hello world")
+            }
+        }
+    }
+
     let template = FailStr { value: false };
     assert!(matches!(template.render(), Err(rinja::Error::Custom(_))));
     assert_eq!(format!("{}", &template.render().unwrap_err()), "FAIL");

--- a/testing/tests/tuple.rs
+++ b/testing/tests/tuple.rs
@@ -1,27 +1,29 @@
 use rinja::Template;
 
-struct Post {
-    id: u32,
-}
-
-struct Client<'a> {
-    can_post_ids: &'a [u32],
-    can_update_ids: &'a [u32],
-}
-
-impl Client<'_> {
-    fn can_post(&self, post: &Post) -> bool {
-        self.can_post_ids.contains(&post.id)
+#[test]
+fn test_tuple() {
+    struct Post {
+        id: u32,
     }
 
-    fn can_update(&self, post: &Post) -> bool {
-        self.can_update_ids.contains(&post.id)
+    struct Client<'a> {
+        can_post_ids: &'a [u32],
+        can_update_ids: &'a [u32],
     }
-}
 
-#[derive(Template)]
-#[template(
-    source = r#"
+    impl Client<'_> {
+        fn can_post(&self, post: &Post) -> bool {
+            self.can_post_ids.contains(&post.id)
+        }
+
+        fn can_update(&self, post: &Post) -> bool {
+            self.can_update_ids.contains(&post.id)
+        }
+    }
+
+    #[derive(Template)]
+    #[template(
+        source = r#"
 {%- match (client.can_post(post), client.can_update(post)) -%}
     {%- when (false, false) -%}
         No!
@@ -32,15 +34,13 @@ impl Client<'_> {
         </ul>
 {%- endmatch -%}
 "#,
-    ext = "txt"
-)]
-struct TupleTemplate<'a> {
-    client: &'a Client<'a>,
-    post: &'a Post,
-}
+        ext = "txt"
+    )]
+    struct TupleTemplate<'a> {
+        client: &'a Client<'a>,
+        post: &'a Post,
+    }
 
-#[test]
-fn test_tuple() {
     let template = TupleTemplate {
         client: &Client {
             can_post_ids: &[1, 2],

--- a/testing/tests/vars.rs
+++ b/testing/tests/vars.rs
@@ -2,27 +2,27 @@
 
 use rinja::Template;
 
-#[derive(Template)]
-#[template(source = "{% let v = s %}{{ v }}", ext = "txt")]
-struct LetTemplate<'a> {
-    s: &'a str,
-}
-
 #[test]
 fn test_let() {
+    #[derive(Template)]
+    #[template(source = "{% let v = s %}{{ v }}", ext = "txt")]
+    struct LetTemplate<'a> {
+        s: &'a str,
+    }
+
     let t = LetTemplate { s: "foo" };
     assert_eq!(t.render().unwrap(), "foo");
 }
 
-#[derive(Template)]
-#[template(path = "let.html")]
-struct LetTupleTemplate<'a> {
-    s: &'a str,
-    t: (&'a str, &'a str),
-}
-
 #[test]
 fn test_let_tuple() {
+    #[derive(Template)]
+    #[template(path = "let.html")]
+    struct LetTupleTemplate<'a> {
+        s: &'a str,
+        t: (&'a str, &'a str),
+    }
+
     let t = LetTupleTemplate {
         s: "foo",
         t: ("bar", "bazz"),
@@ -30,15 +30,15 @@ fn test_let_tuple() {
     assert_eq!(t.render().unwrap(), "foo\nbarbazz");
 }
 
-#[derive(Template)]
-#[template(path = "let-decl.html")]
-struct LetDeclTemplate<'a> {
-    cond: bool,
-    s: &'a str,
-}
-
 #[test]
 fn test_let_decl() {
+    #[derive(Template)]
+    #[template(path = "let-decl.html")]
+    struct LetDeclTemplate<'a> {
+        cond: bool,
+        s: &'a str,
+    }
+
     let t = LetDeclTemplate {
         cond: false,
         s: "bar",
@@ -46,20 +46,20 @@ fn test_let_decl() {
     assert_eq!(t.render().unwrap(), "bar");
 }
 
-#[derive(Template)]
-#[template(path = "let-shadow.html")]
-struct LetShadowTemplate {
-    cond: bool,
-}
-
-impl LetShadowTemplate {
-    fn tuple() -> (i32, i32) {
-        (4, 5)
-    }
-}
-
 #[test]
 fn test_let_shadow() {
+    #[derive(Template)]
+    #[template(path = "let-shadow.html")]
+    struct LetShadowTemplate {
+        cond: bool,
+    }
+
+    impl LetShadowTemplate {
+        fn tuple() -> (i32, i32) {
+            (4, 5)
+        }
+    }
+
     let t = LetShadowTemplate { cond: true };
     assert_eq!(t.render().unwrap(), "22-1-33-11-22");
 
@@ -67,85 +67,85 @@ fn test_let_shadow() {
     assert_eq!(t.render().unwrap(), "222-1-333-4-5-11-222");
 }
 
-#[derive(Template)]
-#[template(source = "{% for v in self.0 %}{{ v }}{% endfor %}", ext = "txt")]
-struct SelfIterTemplate(Vec<usize>);
-
 #[test]
 fn test_self_iter() {
+    #[derive(Template)]
+    #[template(source = "{% for v in self.0 %}{{ v }}{% endfor %}", ext = "txt")]
+    struct SelfIterTemplate(Vec<usize>);
+
     let t = SelfIterTemplate(vec![1, 2, 3]);
     assert_eq!(t.render().unwrap(), "123");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% if true %}{% let t = a.unwrap() %}{{ t }}{% endif %}",
-    ext = "txt"
-)]
-struct IfLet {
-    a: Option<&'static str>,
-}
-
 #[test]
 fn test_if_let() {
+    #[derive(Template)]
+    #[template(
+        source = "{% if true %}{% let t = a.unwrap() %}{{ t }}{% endif %}",
+        ext = "txt"
+    )]
+    struct IfLet {
+        a: Option<&'static str>,
+    }
+
     let t = IfLet { a: Some("foo") };
     assert_eq!(t.render().unwrap(), "foo");
 }
 
-#[derive(Template)]
-#[template(path = "let-destruct-tuple.html")]
-struct LetDestructTupleTemplate {
-    abcd: (char, ((char, char), char)),
-}
-
 #[test]
 fn test_destruct_tuple() {
+    #[derive(Template)]
+    #[template(path = "let-destruct-tuple.html")]
+    struct LetDestructTupleTemplate {
+        abcd: (char, ((char, char), char)),
+    }
+
     let t = LetDestructTupleTemplate {
         abcd: ('w', (('x', 'y'), 'z')),
     };
     assert_eq!(t.render().unwrap(), "wxyz\nwz\nw");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% let x = 1 %}{% for x in x..=x %}{{ x }}{% endfor %}",
-    ext = "txt"
-)]
-struct DeclRange;
-
 #[test]
 fn test_decl_range() {
+    #[derive(Template)]
+    #[template(
+        source = "{% let x = 1 %}{% for x in x..=x %}{{ x }}{% endfor %}",
+        ext = "txt"
+    )]
+    struct DeclRange;
+
     let t = DeclRange;
     assert_eq!(t.render().unwrap(), "1");
 }
 
-#[derive(Template)]
-#[template(
-    source = "{% let x %}{% let x = 1 %}{% for x in x..=x %}{{ x }}{% endfor %}",
-    ext = "txt"
-)]
-struct DeclAssignRange;
-
 #[test]
 fn test_decl_assign_range() {
+    #[derive(Template)]
+    #[template(
+        source = "{% let x %}{% let x = 1 %}{% for x in x..=x %}{{ x }}{% endfor %}",
+        ext = "txt"
+    )]
+    struct DeclAssignRange;
+
     let t = DeclAssignRange;
     assert_eq!(t.render().unwrap(), "1");
 }
 
-#[derive(Template)]
-#[template(
-    source = "
+#[test]
+fn test_not_moving_fields_in_var() {
+    #[derive(Template)]
+    #[template(
+        source = "
 {%- set t = title -%}
 {{t}}/{{title -}}
 ",
-    ext = "txt"
-)]
-struct DoNotMoveFields {
-    title: String,
-}
+        ext = "txt"
+    )]
+    struct DoNotMoveFields {
+        title: String,
+    }
 
-#[test]
-fn test_not_moving_fields_in_var() {
     let x = DoNotMoveFields {
         title: "a".to_string(),
     };

--- a/testing/tests/whitespace.rs
+++ b/testing/tests/whitespace.rs
@@ -2,40 +2,40 @@
 
 use rinja::Template;
 
-#[derive(rinja::Template, Default)]
-#[template(path = "allow-whitespaces.html")]
-struct AllowWhitespaces {
-    tuple: (u64, u64, u64, u64),
-    string: &'static str,
-    option: Option<bool>,
-    nested_1: AllowWhitespacesNested1,
-}
-
-#[derive(Default)]
-struct AllowWhitespacesNested1 {
-    nested_2: AllowWhitespacesNested2,
-}
-
-#[derive(Default)]
-struct AllowWhitespacesNested2 {
-    array: &'static [&'static str],
-    hash: std::collections::HashMap<&'static str, &'static str>,
-}
-
-impl AllowWhitespaces {
-    fn f0(&self) -> &str {
-        ""
-    }
-    fn f1(&self, _a: &str) -> &str {
-        ""
-    }
-    fn f2(&self, _a: &str, _b: &str) -> &str {
-        ""
-    }
-}
-
 #[test]
 fn test_extra_whitespace() {
+    #[derive(rinja::Template, Default)]
+    #[template(path = "allow-whitespaces.html")]
+    struct AllowWhitespaces {
+        tuple: (u64, u64, u64, u64),
+        string: &'static str,
+        option: Option<bool>,
+        nested_1: AllowWhitespacesNested1,
+    }
+
+    #[derive(Default)]
+    struct AllowWhitespacesNested1 {
+        nested_2: AllowWhitespacesNested2,
+    }
+
+    #[derive(Default)]
+    struct AllowWhitespacesNested2 {
+        array: &'static [&'static str],
+        hash: std::collections::HashMap<&'static str, &'static str>,
+    }
+
+    impl AllowWhitespaces {
+        fn f0(&self) -> &str {
+            ""
+        }
+        fn f1(&self, _a: &str) -> &str {
+            ""
+        }
+        fn f2(&self, _a: &str, _b: &str) -> &str {
+            ""
+        }
+    }
+
     let mut template = AllowWhitespaces::default();
     template.nested_1.nested_2.array = &["a0", "a1", "a2", "a3"];
     template.nested_1.nested_2.hash.insert("key", "value");


### PR DESCRIPTION
It's frequent to copy-paste an existing test and its associated (template) type to create a new test. But it's also very possible to use the wrong (template) type from there. Moving the (template) type directly into its test function greatly limit this possibility and it's something that we both started to do recently so with this PR, everything else is moved to this way of writing tests. :)