### PR TITLE
refactor(parser): Move off of deprecated re-export

### DIFF
--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -3,9 +3,8 @@ use std::str;
 
 use winnow::Parser;
 use winnow::combinator::{
-    alt, cut_err, delimited, eof, fail, not, opt, peek, preceded, repeat, separated1,
+    alt, cut_err, delimited, eof, fail, not, opt, peek, preceded, repeat, separated1, terminated,
 };
-use winnow::sequence::terminated;
 use winnow::token::{any, tag, take_till0};
 
 use crate::memchr_splitter::{Splitter1, Splitter2, Splitter3};


### PR DESCRIPTION
The `sequence` mod is deprdcated.  Unsure why the lint didn't fire.  I know it doesn't when applied to a re-export but I thought it did when applied to a mod and accessing something inside of it.