### PR TITLE
Add concat operator `~`

### DIFF
--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -736,6 +736,11 @@ restrictions:
 - If the source is a reference to a primitive type, e.g. `&&&bool`, then rinja automatically
   dereferences the value until it gets the underlying `bool`.
 
+### String concatenation
+
+As a short-hand for `{{ a }}{{ b }}{{ c }}` you can use the concat operator `~`: `{{ a ~ b ~ c }}`.
+The tilde `~` has to be surrounded by spaces to avoid confusion with the whitespace control operator.
+
 ## Templates in templates
 
 Using expressions, it is possible to delegate rendering part of a template to another template.

--- a/rinja/src/helpers.rs
+++ b/rinja/src/helpers.rs
@@ -236,3 +236,21 @@ impl FastWritable for Empty {
 pub fn as_bool<T: PrimitiveType<Value = bool>>(value: T) -> bool {
     value.get()
 }
+
+pub struct Concat<L, R>(pub L, pub R);
+
+impl<L: fmt::Display, R: fmt::Display> fmt::Display for Concat<L, R> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)?;
+        self.1.fmt(f)
+    }
+}
+
+impl<L: FastWritable, R: FastWritable> FastWritable for Concat<L, R> {
+    #[inline]
+    fn write_into<W: fmt::Write + ?Sized>(&self, dest: &mut W) -> crate::Result<()> {
+        self.0.write_into(dest)?;
+        self.1.write_into(dest)
+    }
+}

--- a/testing/tests/simple.rs
+++ b/testing/tests/simple.rs
@@ -611,3 +611,25 @@ fn test_ref_custom_type() {
     };
     assert_eq!(tmpl.render().unwrap(), TEXT);
 }
+
+#[test]
+fn test_concat_outer() {
+    #[derive(Template)]
+    #[template(ext = "html", source = r#"{{ "<" ~ a ~ '>' }}"#)]
+    struct ConcatOuter {
+        a: &'static str,
+    }
+
+    assert_eq!(ConcatOuter { a: "'" }.to_string(), "&#60;&#39;&#62;");
+}
+
+#[test]
+fn test_concat_inner() {
+    #[derive(Template)]
+    #[template(ext = "html", source = r#"{{ ("<" ~ a ~ '>')|urlencode }}"#)]
+    struct ConcatInner {
+        a: &'static str,
+    }
+
+    assert_eq!(ConcatInner { a: "'" }.to_string(), "%3C%27%3E");
+}

--- a/testing/tests/ui/concat.rs
+++ b/testing/tests/ui/concat.rs
@@ -1,0 +1,70 @@
+use rinja::Template;
+
+#[derive(Template)]
+#[template(source = r#"{{ a~b }}"#, ext = "txt")]
+struct NoSpaces {
+    a: u32,
+    b: u32,
+}
+
+#[derive(Template)]
+#[template(source = r#"{{ a ~b }}"#, ext = "txt")]
+struct OnlyFront {
+    a: u32,
+    b: u32,
+}
+
+#[derive(Template)]
+#[template(source = r#"{{ a~ b }}"#, ext = "txt")]
+struct OnlyBack {
+    a: u32,
+    b: u32,
+}
+
+#[derive(Template)]
+#[template(source = r#"{{~a~b~}}"#, ext = "txt")]
+struct NoSpaces2 {
+    a: u32,
+    b: u32,
+}
+
+#[derive(Template)]
+#[template(source = r#"{{~a ~b~}}"#, ext = "txt")]
+struct OnlyFront2 {
+    a: u32,
+    b: u32,
+}
+
+#[derive(Template)]
+#[template(source = r#"{{~a~ b~}}"#, ext = "txt")]
+struct OnlyBack2 {
+    a: u32,
+    b: u32,
+}
+
+#[derive(Template)]
+#[template(source = r#"{{ a ~ }}"#, ext = "txt")]
+struct MissingLhs {
+    a: u32,
+}
+
+#[derive(Template)]
+#[template(source = r#"{{ ~ b }}"#, ext = "txt")]
+struct MissingRhs {
+    b: u32,
+}
+
+#[derive(Template)]
+#[template(source = r#"{{~a ~~}}"#, ext = "txt")]
+struct MissingLhs2 {
+    a: u32,
+}
+
+#[derive(Template)]
+#[template(source = r#"{{~~ b~}}"#, ext = "txt")]
+struct MissingRhs2 {
+    b: u32,
+}
+
+fn main() {
+}

--- a/testing/tests/ui/concat.stderr
+++ b/testing/tests/ui/concat.stderr
@@ -1,0 +1,79 @@
+error: the concat operator `~` must be surrounded by spaces
+ --> <source attribute>:1:4
+       "~b }}"
+ --> tests/ui/concat.rs:4:21
+  |
+4 | #[template(source = r#"{{ a~b }}"#, ext = "txt")]
+  |                     ^^^^^^^^^^^^^^
+
+error: the concat operator `~` must be surrounded by spaces
+ --> <source attribute>:1:4
+       " ~b }}"
+  --> tests/ui/concat.rs:11:21
+   |
+11 | #[template(source = r#"{{ a ~b }}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^
+
+error: the concat operator `~` must be surrounded by spaces
+ --> <source attribute>:1:4
+       "~ b }}"
+  --> tests/ui/concat.rs:18:21
+   |
+18 | #[template(source = r#"{{ a~ b }}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^
+
+error: the concat operator `~` must be surrounded by spaces
+ --> <source attribute>:1:4
+       "~b~}}"
+  --> tests/ui/concat.rs:25:21
+   |
+25 | #[template(source = r#"{{~a~b~}}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^
+
+error: the concat operator `~` must be surrounded by spaces
+ --> <source attribute>:1:4
+       " ~b~}}"
+  --> tests/ui/concat.rs:32:21
+   |
+32 | #[template(source = r#"{{~a ~b~}}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^
+
+error: the concat operator `~` must be surrounded by spaces
+ --> <source attribute>:1:4
+       "~ b~}}"
+  --> tests/ui/concat.rs:39:21
+   |
+39 | #[template(source = r#"{{~a~ b~}}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^
+
+error: failed to parse template source
+ --> <source attribute>:1:7
+       "}}"
+  --> tests/ui/concat.rs:46:21
+   |
+46 | #[template(source = r#"{{ a ~ }}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^
+
+error: failed to parse template source
+ --> <source attribute>:1:3
+       "~ b }}"
+  --> tests/ui/concat.rs:52:21
+   |
+52 | #[template(source = r#"{{ ~ b }}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^
+
+error: failed to parse template source
+ --> <source attribute>:1:6
+       "~}}"
+  --> tests/ui/concat.rs:58:21
+   |
+58 | #[template(source = r#"{{~a ~~}}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^
+
+error: failed to parse template source
+ --> <source attribute>:1:3
+       "~ b~}}"
+  --> tests/ui/concat.rs:64:21
+   |
+64 | #[template(source = r#"{{~~ b~}}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^


### PR DESCRIPTION
The string concatenation operator `~` is present in jinja and tera: <https://jinja.palletsprojects.com/en/stable/templates/#other-operators>. While it's not the most important operator, it can come in handy e.g. with filters: `{{ a|upper }}{{ b|upper }}` → `{{ (a ~ b)|upper }}`.