### PR TITLE
Canonicalize include paths before emitting

### DIFF
--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -172,11 +172,10 @@ impl<'a> Generator<'a> {
                 Source::Source(_) => path != &*self.input.path,
             };
             if path_is_valid {
-                let canonical_path = path.canonicalize().unwrap();
-                let include_path = canonical_path.to_str().unwrap();
                 buf.write(format_args!(
                     "const _: &[rinja::helpers::core::primitive::u8] =\
-                        rinja::helpers::core::include_bytes!({include_path:#?});",
+                        rinja::helpers::core::include_bytes!({:#?});",
+                    path.canonicalize().as_deref().unwrap_or(path),
                 ));
             }
         }

--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -172,10 +172,11 @@ impl<'a> Generator<'a> {
                 Source::Source(_) => path != &*self.input.path,
             };
             if path_is_valid {
-                let path = path.to_str().unwrap();
+                let canonical_path = path.canonicalize().unwrap();
+                let include_path = canonical_path.to_str().unwrap();
                 buf.write(format_args!(
                     "const _: &[rinja::helpers::core::primitive::u8] =\
-                        rinja::helpers::core::include_bytes!({path:#?});",
+                        rinja::helpers::core::include_bytes!({include_path:#?});",
                 ));
             }
         }

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -191,9 +191,9 @@ fn check_if_let() {
 
     // In this test we make sure that every used template gets referenced exactly once.
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("templates");
-    let path1 = path.join("include1.html");
-    let path2 = path.join("include2.html");
-    let path3 = path.join("include3.html");
+    let path1 = path.join("include1.html").canonicalize().unwrap();
+    let path2 = path.join("include2.html").canonicalize().unwrap();
+    let path3 = path.join("include3.html").canonicalize().unwrap();
     compare(
         r#"{% include "include1.html" %}"#,
         &format!(


### PR DESCRIPTION
This allows `CARGO_MANIFEST_DIR` to be a relative path, which can be useful in non-cargo build systems.

---

Cherry-picked from <https://github.com/djc/askama/pull/1107>.