### PR TITLE
derive standalone: opt out of native `proc-macro` support

### DIFF
--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -37,10 +37,12 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 memchr = "2"
 mime = "0.3"
 mime_guess = "2"
-proc-macro2 = "1"
-quote = "1"
+quote = { version = "1", default-features = false }
 rustc-hash = "2.0.0"
-syn = "2.0.3"
+syn = { version = "2.0.3", default-features = false, features = ["clone-impls", "derive", "parsing", "printing"] }
+
+# in `rinja_derive_standalone` we opt out of the default features, because we need no native `proc-macro` support
+proc-macro2 = "1"
 
 [dev-dependencies]
 console = "0.15.8"

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -40,10 +40,12 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 memchr = "2"
 mime = "0.3"
 mime_guess = "2"
-proc-macro2 = "1"
-quote = "1"
+quote = { version = "1", default-features = false }
 rustc-hash = "2.0.0"
-syn = "2.0.3"
+syn = { version = "2.0.3", default-features = false, features = ["clone-impls", "derive", "parsing", "printing"] }
+
+# in `rinja_derive_standalone` we opt out of the default features, because we need no native `proc-macro` support
+proc-macro2 = { version = "1", default-features = false }
 
 [dev-dependencies]
 console = "0.15.8"


### PR DESCRIPTION
We know that there is none, because `rinja_derive_standalone` is not run inside of rust, but, as the name says, standalone. This makes the playground WASM data a little smaller.