### PR TITLE
derive: a safe-guard to disable bindings a unit struct was expected

### DIFF
--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -2311,6 +2311,7 @@ impl<'a, 'h> Generator<'a, 'h> {
             }
             Target::Path(path) => {
                 self.visit_path(buf, path);
+                buf.write("{}");
             }
             Target::StrLit(s) => {
                 if first_level {

--- a/rinja_derive/src/tests.rs
+++ b/rinja_derive/src/tests.rs
@@ -636,10 +636,10 @@ fn check_escaping_at_compile_time() {
         {%- endmatch %}"#,
         r#"writer.write_str("The card is")?;
         match &self.suit {
-            Suit::Clubs | Suit::Spades => {
+            Suit::Clubs {} | Suit::Spades {} => {
                 writer.write_str(" black")?;
             }
-            Suit::Diamonds | Suit::Hearts => {
+            Suit::Diamonds {} | Suit::Hearts {} => {
                 writer.write_str(" red")?;
             }
         }"#,

--- a/testing/tests/ui/match-unit-structs.rs
+++ b/testing/tests/ui/match-unit-structs.rs
@@ -1,0 +1,24 @@
+use rinja::Template;
+
+enum Greeting {
+    Hello,
+    Hey,
+    Hi,
+}
+
+#[derive(Template)]
+#[template(
+    ext = "txt",
+    source = r#"
+{%- match greeting -%}
+    {%- when Hello -%} Hello!
+    {%- when Hey -%} Hey!
+    {%- when Hi -%} Hi!
+{%- endmatch -%}"#
+)]
+struct Greeter {
+    greeting: Greeting,
+}
+
+fn main() {
+}

--- a/testing/tests/ui/match-unit-structs.stderr
+++ b/testing/tests/ui/match-unit-structs.stderr
@@ -1,0 +1,35 @@
+error[E0422]: cannot find struct, variant or union type `Hello` in this scope
+ --> tests/ui/match-unit-structs.rs:9:10
+  |
+9 | #[derive(Template)]
+  |          ^^^^^^^^ not found in this scope
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this variant
+  |
+1 + use crate::Greeting::Hello;
+  |
+
+error[E0422]: cannot find struct, variant or union type `Hey` in this scope
+ --> tests/ui/match-unit-structs.rs:9:10
+  |
+9 | #[derive(Template)]
+  |          ^^^^^^^^ not found in this scope
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this variant
+  |
+1 + use crate::Greeting::Hey;
+  |
+
+error[E0422]: cannot find struct, variant or union type `Hi` in this scope
+ --> tests/ui/match-unit-structs.rs:9:10
+  |
+9 | #[derive(Template)]
+  |          ^^^^^^^^ not found in this scope
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this variant
+  |
+1 + use crate::Greeting::Hi;
+  |


### PR DESCRIPTION
This does not fix the error, as rinja is not able to tell was the actually intended to do, but rust gives you a guide what the error is, and the error is not silently ignored.

Related issue: <https://github.com/rinja-rs/rinja/issues/267>.