### PR TITLE
refactor(parser): Be explicit about `i`nput state

### DIFF
--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -249,17 +249,19 @@ impl<'a> Expr<'a> {
     fn concat(i: &'a str, level: Level) -> ParseResult<'a, WithSpan<'a, Self>> {
         fn concat_expr(i: &str, level: Level) -> ParseResult<'_, Option<WithSpan<'_, Expr<'_>>>> {
             let ws1 = |i| opt(skip_ws1).parse_next(i);
-            let (j, data) = opt((ws1, '~', ws1, |i| Expr::muldivmod(i, level))).parse_next(i)?;
+
+            let start = i;
+            let (i, data) = opt((ws1, '~', ws1, |i| Expr::muldivmod(i, level))).parse_next(i)?;
             if let Some((t1, _, t2, expr)) = data {
                 if t1.is_none() || t2.is_none() {
                     return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                         "the concat operator `~` must be surrounded by spaces",
-                        i,
+                        start,
                     )));
                 }
-                Ok((j, Some(expr)))
+                Ok((i, Some(expr)))
             } else {
-                Ok((j, None))
+                Ok((i, None))
             }
         }
 

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -282,12 +282,13 @@ impl<'a> Expr<'a> {
 
     fn is_as(i: &'a str, level: Level) -> ParseResult<'a, WithSpan<'a, Self>> {
         let start = i;
-        let (before_keyword, lhs) = Self::filtered(i, level)?;
-        let (j, rhs) = opt(ws(identifier)).parse_next(before_keyword)?;
+        let (i, lhs) = Self::filtered(i, level)?;
+        let before_keyword = i;
+        let (i, rhs) = opt(ws(identifier)).parse_next(i)?;
         let i = match rhs {
-            Some("is") => j,
+            Some("is") => i,
             Some("as") => {
-                let (i, target) = opt(identifier).parse_next(j)?;
+                let (i, target) = opt(identifier).parse_next(i)?;
                 let target = target.unwrap_or_default();
                 if crate::PRIMITIVE_TYPES.contains(&target) {
                     return Ok((i, WithSpan::new(Self::As(Box::new(lhs), target), start)));
@@ -306,7 +307,10 @@ impl<'a> Expr<'a> {
                     )));
                 }
             }
-            _ => return Ok((before_keyword, lhs)),
+            _ => {
+                let i = before_keyword;
+                return Ok((i, lhs));
+            }
         };
 
         let (i, rhs) =

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -961,10 +961,11 @@ fn filter<'a>(
     i: &'a str,
     level: &mut Level,
 ) -> ParseResult<'a, (&'a str, Option<Vec<WithSpan<'a, Expr<'a>>>>)> {
-    let (j, _) = ws(('|', not('|'))).parse_next(i)?;
+    let start = i;
+    let (i, _) = ws(('|', not('|'))).parse_next(i)?;
 
-    *level = level.nest(i)?.1;
-    cut_err((ws(identifier), opt(|i| Expr::arguments(i, *level, false)))).parse_next(j)
+    *level = level.nest(start)?.1;
+    cut_err((ws(identifier), opt(|i| Expr::arguments(i, *level, false)))).parse_next(i)
 }
 
 /// Returns the common parts of two paths.

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -131,14 +131,16 @@ impl<'a> Node<'a> {
             ws(keyword("break")),
             opt(Whitespace::parse),
         );
-        let (j, (pws, _, nws)) = p.parse_next(i)?;
+
+        let start = i;
+        let (i, (pws, _, nws)) = p.parse_next(i)?;
         if !s.is_in_loop() {
             return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                 "you can only `break` inside a `for` loop",
-                i,
+                start,
             )));
         }
-        Ok((j, Self::Break(WithSpan::new(Ws(pws, nws), i))))
+        Ok((i, Self::Break(WithSpan::new(Ws(pws, nws), start))))
     }
 
     fn r#continue(i: &'a str, s: &State<'_>) -> ParseResult<'a, Self> {

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -668,11 +668,11 @@ impl<'a> Macro<'a> {
                 }),
             ),
         );
-        let (j, (pws1, _, (name, params, nws1, _))) = start.parse_next(i)?;
+        let (i, (pws1, _, (name, params, nws1, _))) = start.parse_next(i)?;
         if is_rust_keyword(name) {
             return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                 format!("'{name}' is not a valid name for a macro"),
-                i,
+                start_s,
             )));
         }
 
@@ -681,17 +681,17 @@ impl<'a> Macro<'a> {
 
             let mut iter = params.iter();
             while let Some((arg_name, default_value)) = iter.next() {
-                check_duplicated_name(&mut names, arg_name, i)?;
+                check_duplicated_name(&mut names, arg_name, start_s)?;
                 if default_value.is_some() {
                     for (new_arg_name, default_value) in iter.by_ref() {
-                        check_duplicated_name(&mut names, new_arg_name, i)?;
+                        check_duplicated_name(&mut names, new_arg_name, start_s)?;
                         if default_value.is_none() {
                             return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                                 format!(
                                     "all arguments following `{arg_name}` should have a default \
                                          value, `{new_arg_name}` doesn't have a default value"
                                 ),
-                                i,
+                                start_s,
                             )));
                         }
                     }
@@ -723,7 +723,7 @@ impl<'a> Macro<'a> {
                 ),
             ),
         );
-        let (i, (contents, (_, pws2, _, nws2))) = end.parse_next(j)?;
+        let (i, (contents, (_, pws2, _, nws2))) = end.parse_next(i)?;
 
         Ok((
             i,

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -267,7 +267,6 @@ pub struct When<'a> {
 
 impl<'a> When<'a> {
     fn r#else(i: &'a str, s: &State<'_>) -> ParseResult<'a, WithSpan<'a, Self>> {
-        let start = i;
         let mut p = (
             |i| s.tag_block_start(i),
             opt(Whitespace::parse),
@@ -281,13 +280,15 @@ impl<'a> When<'a> {
                 ),
             ),
         );
-        let (new_i, (_, pws, _, (nws, _, nodes))) = p.parse_next(i)?;
+
+        let start = i;
+        let (i, (_, pws, _, (nws, _, nodes))) = p.parse_next(i)?;
         Ok((
-            new_i,
+            i,
             WithSpan::new(
                 Self {
                     ws: Ws(pws, nws),
-                    target: vec![Target::Placeholder(WithSpan::new((), i))],
+                    target: vec![Target::Placeholder(WithSpan::new((), start))],
                     nodes,
                 },
                 start,

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -149,14 +149,16 @@ impl<'a> Node<'a> {
             ws(keyword("continue")),
             opt(Whitespace::parse),
         );
-        let (j, (pws, _, nws)) = p.parse_next(i)?;
+
+        let start = i;
+        let (i, (pws, _, nws)) = p.parse_next(i)?;
         if !s.is_in_loop() {
             return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                 "you can only `continue` inside a `for` loop",
-                i,
+                start,
             )));
         }
-        Ok((j, Self::Continue(WithSpan::new(Ws(pws, nws), i))))
+        Ok((i, Self::Continue(WithSpan::new(Ws(pws, nws), start))))
     }
 
     fn expr(i: &'a str, s: &State<'_>) -> ParseResult<'a, Self> {

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -170,8 +170,9 @@ impl<'a> Target<'a> {
         Ok((i, (src, target)))
     }
 
-    fn rest(start: &'a str) -> ParseResult<'a, Self> {
-        let (i, (ident, _)) = (opt((identifier, ws('@'))), "..").parse_next(start)?;
+    fn rest(i: &'a str) -> ParseResult<'a, Self> {
+        let start = i;
+        let (i, (ident, _)) = (opt((identifier, ws('@'))), "..").parse_next(i)?;
         Ok((
             i,
             Self::Rest(WithSpan::new(ident.map(|(ident, _)| ident), start)),

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -1,5 +1,5 @@
 use winnow::Parser;
-use winnow::combinator::{alt, opt, preceded, separated1};
+use winnow::combinator::{alt, opt, peek, preceded, separated1};
 use winnow::token::one_of;
 
 use crate::{
@@ -130,7 +130,7 @@ impl<'a> Target<'a> {
         let start = i;
         let (i, rest) = opt(Self::rest.with_recognized()).parse_next(i)?;
         if let Some(rest) = rest {
-            let (_, chr) = ws(opt(one_of([',', ':']))).parse_next(i)?;
+            let (i, chr) = peek(ws(opt(one_of([',', ':'])))).parse_next(i)?;
             if let Some(chr) = chr {
                 return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                     format!(

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -27,14 +27,13 @@ pub enum Target<'a> {
 impl<'a> Target<'a> {
     /// Parses multiple targets with `or` separating them
     pub(super) fn parse(i: &'a str, s: &State<'_>) -> ParseResult<'a, Self> {
-        let (new_i, target) = separated1(|i| s.nest(i, |i| Self::parse_one(i, s)), ws("or"))
+        separated1(|i| s.nest(i, |i| Self::parse_one(i, s)), ws("or"))
             .map(|v: Vec<_>| v)
             .map(|mut opts| match opts.len() {
                 1 => opts.pop().unwrap(),
                 _ => Self::OrChain(opts),
             })
-            .parse_next(i)?;
-        Ok((new_i, target))
+            .parse_next(i)
     }
 
     /// Parses a single target without an `or`, unless it is wrapped in parentheses.

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -102,12 +102,13 @@ impl<'a> Target<'a> {
         }
 
         // neither literal nor struct nor path
-        let (new_i, name) = identifier.parse_next(i)?;
+        let i_before_identifier = i;
+        let (i, name) = identifier.parse_next(i)?;
         let target = match name {
-            "_" => Self::Placeholder(WithSpan::new((), i)),
-            _ => verify_name(i, name)?,
+            "_" => Self::Placeholder(WithSpan::new((), i_before_identifier)),
+            _ => verify_name(i_before_identifier, name)?,
         };
-        Ok((new_i, target))
+        Ok((i, target))
     }
 
     fn lit(i: &'a str) -> ParseResult<'a, Self> {


### PR DESCRIPTION
Instead of parsers returning a `j` or `new_i` and conditionally chaining back into `i` later, this has parsers always return `i`, requiring explicit updating of `i`.  The one time `j` is still used to just because we can't mix a `let` and a mutation of an existing variable.

This is needed for Winnow 0.5 as `i` changes from `Fn(&str) -> (I, O)` to `Fn(&mut &str) -> O`, requiring the explicit updating that this PR does.

imo this also improves the visibility of control flow and so I feel like this is justifiable on its own, in addition to reducing my merge conflicts. I'll likely need to do more of this as I continue my 0.5 work or as other people make changes to the parser.