### PR TITLE
Use cargo reference manifest section order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,3 @@
 [workspace]
-members = [
-    "rinja",
-    "rinja_derive",
-    "rinja_parser",
-    "testing",
-]
+members = ["rinja", "rinja_derive", "rinja_parser", "testing"]
 resolver = "2"

--- a/examples/actix-web-app/Cargo.toml
+++ b/examples/actix-web-app/Cargo.toml
@@ -1,7 +1,3 @@
-# In a real application you would not need this section. It is only used in here, so that this
-# example can have a more lenient MSRV (minimum supported rust version) than rinja as a whole.
-[workspace]
-members = ["."]
 
 [package]
 name = "actix-web-app"
@@ -28,3 +24,8 @@ env_logger = "0.11.3"
 log = "0.4.22"
 pretty-error-debug = "0.3.0"
 thiserror = "2.0.3"
+
+# In a real application you would not need this section. It is only used in here, so that this
+# example can have a more lenient MSRV (minimum supported rust version) than rinja as a whole.
+[workspace]
+members = ["."]

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -1,6 +1,3 @@
-
-[workspace]
-members = [".", "fuzz"]
 [package]
 name = "rinja_fuzzing"
 version = "0.1.0"
@@ -17,3 +14,6 @@ thiserror = "2.0.3"
 
 [profile.release]
 debug = 1
+
+[workspace]
+members = [".", "fuzz"]

--- a/rinja_derive/.rustfmt.toml
+++ b/rinja_derive/.rustfmt.toml
@@ -1,0 +1,1 @@
+../.rustfmt.toml

--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -17,12 +17,6 @@ rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 [lib]
 proc-macro = true
 
-[features]
-code-in-doc = ["dep:pulldown-cmark"]
-config = ["dep:serde", "dep:basic-toml", "parser/config"]
-urlencode = []
-serde_json = []
-
 [dependencies]
 parser = { package = "rinja_parser", version = "=0.3.5", path = "../rinja_parser" }
 
@@ -43,6 +37,12 @@ console = "0.15.8"
 prettyplease = "0.2.20"
 similar = "2.6.0"
 syn = { version = "2.0.3", features = ["full"] }
+
+[features]
+code-in-doc = ["dep:pulldown-cmark"]
+config = ["dep:serde", "dep:basic-toml", "parser/config"]
+urlencode = []
+serde_json = []
 
 [lints.rust]
 # Used in `rinja_derive_standalone` which uses the same source folder, but is not a proc-macro.

--- a/rinja_derive/_typos.toml
+++ b/rinja_derive/_typos.toml
@@ -1,0 +1,1 @@
+../_typos.toml

--- a/rinja_derive/deny.toml
+++ b/rinja_derive/deny.toml
@@ -1,0 +1,1 @@
+../deny.toml

--- a/rinja_derive/tomlfmt.toml
+++ b/rinja_derive/tomlfmt.toml
@@ -1,0 +1,1 @@
+../tomlfmt.toml

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -1,5 +1,3 @@
-[workspace]
-members = ["."]
 
 [package]
 name = "rinja_derive_standalone"
@@ -17,14 +15,10 @@ publish = false
 all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
-[features]
-default = ["__standalone"]
-__standalone = []
-
-code-in-doc = ["dep:pulldown-cmark"]
-config = ["dep:serde", "dep:basic-toml", "parser/config"]
-urlencode = []
-serde_json = []
+[[bench]]
+name = "derive-template"
+harness = false
+required-features = ["__standalone"]
 
 [dependencies]
 parser = { package = "rinja_parser", version = "=0.3.5", path = "../rinja_parser" }
@@ -48,7 +42,14 @@ prettyplease = "0.2.20"
 similar = "2.6.0"
 syn = { version = "2.0.3", features = ["full"] }
 
-[[bench]]
-name = "derive-template"
-harness = false
-required-features = ["__standalone"]
+[features]
+default = ["__standalone"]
+__standalone = []
+
+code-in-doc = ["dep:pulldown-cmark"]
+config = ["dep:serde", "dep:basic-toml", "parser/config"]
+urlencode = []
+serde_json = []
+
+[workspace]
+members = ["."]

--- a/rinja_parser/Cargo.toml
+++ b/rinja_parser/Cargo.toml
@@ -17,8 +17,9 @@ rust-version = "1.80"
 all-features = true
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 
-[features]
-config = ["dep:serde"]
+[[bench]]
+name = "from_str"
+harness = false
 
 [dependencies]
 memchr = "2"
@@ -28,6 +29,5 @@ winnow = "0.4"
 [dev-dependencies]
 criterion = "0.5"
 
-[[bench]]
-name = "from_str"
-harness = false
+[features]
+config = ["dep:serde"]

--- a/tomlfmt.toml
+++ b/tomlfmt.toml
@@ -1,1 +1,23 @@
-table_order = ["workspace", "package", "badges", "lib", "features", "dependencies", "build-dependencies", "dev-dependencies", "bench"]
+# Keep in the same order as <https://doc.rust-lang.org/cargo/reference/manifest.html>
+table_order = [
+    "package",
+    # targets
+    "lib",
+    "bin",
+    "example",
+    "test",
+    "bench",
+    # dependencies
+    "dependencies",
+    "dev-dependencies",
+    "build-dependencies",
+    "target",
+    # misc
+    "badges",
+    "features",
+    "lints",
+    "patch",
+    "replace",
+    "profile",
+    "workspace",
+]


### PR DESCRIPTION
In [#131] I added a check that ensures that the section in `Cargo.toml` (and there values) are in a specific order. I invented the order quite randomly, in the order which I thought might be useful.

This PR changes the order to be the same as in Cargo's reference about [The Manifest Format]. Also some missing softlinks were added.

[#131]: <https://github.com/rinja-rs/rinja/pull/131>
[The Manifest Format]: <https://doc.rust-lang.org/cargo/reference/manifest.html>