### PR TITLE
 parser: deny all rust keywords as target names  and add `gen` to keywords

### DIFF
--- a/rinja_derive/src/generator.rs
+++ b/rinja_derive/src/generator.rs
@@ -10,8 +10,8 @@ use parser::node::{
     Whitespace, Ws,
 };
 use parser::{
-    CharLit, CharPrefix, Expr, Filter, FloatKind, IntKind, Node, Num, Span, StrLit, StrPrefix,
-    Target, WithSpan,
+    CharLit, CharPrefix, Expr, Filter, FloatKind, IntKind, MAX_RUST_KEYWORD_LEN, Node, Num,
+    RUST_KEYWORDS, Span, StrLit, StrPrefix, Target, WithSpan,
 };
 use rustc_hash::FxBuildHasher;
 
@@ -2999,18 +2999,19 @@ fn normalize_identifier(ident: &str) -> &str {
     // While the code does not need it, please keep the list sorted when adding new
     // keywords.
 
-    if ident.len() > parser::node::MAX_KW_LEN {
+    if ident.len() > MAX_RUST_KEYWORD_LEN {
         return ident;
     }
-    let kws = parser::node::KWS[ident.len()];
+    let kws = RUST_KEYWORDS[ident.len()];
 
-    let mut padded_ident = [b'_'; parser::node::MAX_KW_LEN];
+    let mut padded_ident = [b'_'; MAX_RUST_KEYWORD_LEN];
     padded_ident[..ident.len()].copy_from_slice(ident.as_bytes());
 
     // Since the individual buckets are quite short, a linear search is faster than a binary search.
-    let replacement = match kws.iter().find(|probe| {
-        padded_ident == <[u8; parser::node::MAX_KW_LEN]>::try_from(&probe[2..]).unwrap()
-    }) {
+    let replacement = match kws
+        .iter()
+        .find(|probe| padded_ident == <[u8; MAX_RUST_KEYWORD_LEN]>::try_from(&probe[2..]).unwrap())
+    {
         Some(replacement) => replacement,
         None => return ident,
     };

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -1141,6 +1141,7 @@ pub const RUST_KEYWORDS: &[&[[u8; MAX_RUST_RAW_KEYWORD_LEN]]] = {
         *b"r#box_____",
         *b"r#dyn_____",
         *b"r#for_____",
+        *b"r#gen_____",
         *b"r#let_____",
         *b"r#mod_____",
         *b"r#mut_____",

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -1122,12 +1122,121 @@ const PRIMITIVE_TYPES: &[&str] = &{
     list
 };
 
+#[doc(hidden)]
+pub const MAX_RUST_KEYWORD_LEN: usize = 8;
+const MAX_RUST_RAW_KEYWORD_LEN: usize = MAX_RUST_KEYWORD_LEN + 2;
+#[doc(hidden)]
+pub const RUST_KEYWORDS: &[&[[u8; MAX_RUST_RAW_KEYWORD_LEN]]] = {
+    // FIXME: Replace `u8` with `[core:ascii::Char; MAX_REPL_LEN]` once
+    //        <https://github.com/rust-lang/rust/issues/110998> is stable.
+
+    const KW2: &[[u8; MAX_RUST_RAW_KEYWORD_LEN]] = &[
+        *b"r#as______",
+        *b"r#do______",
+        *b"r#fn______",
+        *b"r#if______",
+        *b"r#in______",
+    ];
+    const KW3: &[[u8; MAX_RUST_RAW_KEYWORD_LEN]] = &[
+        *b"r#box_____",
+        *b"r#dyn_____",
+        *b"r#for_____",
+        *b"r#let_____",
+        *b"r#mod_____",
+        *b"r#mut_____",
+        *b"r#pub_____",
+        *b"r#ref_____",
+        *b"r#try_____",
+        *b"r#use_____",
+    ];
+    const KW4: &[[u8; MAX_RUST_RAW_KEYWORD_LEN]] = &[
+        *b"r#else____",
+        *b"r#enum____",
+        *b"r#impl____",
+        *b"r#move____",
+        *b"r#priv____",
+        *b"r#true____",
+        *b"r#type____",
+    ];
+    const KW5: &[[u8; MAX_RUST_RAW_KEYWORD_LEN]] = &[
+        *b"r#async___",
+        *b"r#await___",
+        *b"r#break___",
+        *b"r#const___",
+        *b"r#crate___",
+        *b"r#false___",
+        *b"r#final___",
+        *b"r#macro___",
+        *b"r#match___",
+        *b"r#trait___",
+        *b"r#where___",
+        *b"r#while___",
+        *b"r#yield___",
+    ];
+    const KW6: &[[u8; MAX_RUST_RAW_KEYWORD_LEN]] = &[
+        *b"r#become__",
+        *b"r#extern__",
+        *b"r#return__",
+        *b"r#static__",
+        *b"r#struct__",
+        *b"r#typeof__",
+        *b"r#unsafe__",
+    ];
+    const KW7: &[[u8; MAX_RUST_RAW_KEYWORD_LEN]] = &[*b"r#unsized_", *b"r#virtual_"];
+    const KW8: &[[u8; MAX_RUST_RAW_KEYWORD_LEN]] =
+        &[*b"r#abstract", *b"r#continue", *b"r#override"];
+
+    &[&[], &[], KW2, KW3, KW4, KW5, KW6, KW7, KW8]
+};
+
+// These ones are only used in the parser, hence why they're private.
+const KWS_EXTRA: &[&[[u8; MAX_RUST_RAW_KEYWORD_LEN]]] = {
+    const KW4: &[[u8; MAX_RUST_RAW_KEYWORD_LEN]] =
+        &[*b"r#loop____", *b"r#self____", *b"r#Self____"];
+    const KW5: &[[u8; MAX_RUST_RAW_KEYWORD_LEN]] = &[*b"r#super___", *b"r#union___"];
+
+    &[&[], &[], &[], &[], KW4, KW5, &[], &[], &[]]
+};
+
+fn is_rust_keyword(ident: &str) -> bool {
+    fn is_rust_keyword_inner(
+        kws: &[&[[u8; MAX_RUST_RAW_KEYWORD_LEN]]],
+        padded_ident: &[u8; MAX_RUST_KEYWORD_LEN],
+        ident_len: usize,
+    ) -> bool {
+        // Since the individual buckets are quite short, a linear search is faster than a binary search.
+        kws[ident_len]
+            .iter()
+            .any(|&probe| padded_ident == &probe[2..])
+    }
+
+    let ident_len = ident.len();
+    if ident_len > MAX_RUST_KEYWORD_LEN {
+        return false;
+    }
+
+    let mut padded_ident = [b'_'; MAX_RUST_KEYWORD_LEN];
+    padded_ident[..ident.len()].copy_from_slice(ident.as_bytes());
+
+    is_rust_keyword_inner(RUST_KEYWORDS, &padded_ident, ident_len)
+        || is_rust_keyword_inner(KWS_EXTRA, &padded_ident, ident_len)
+}
+
 #[cfg(not(windows))]
 #[cfg(test)]
 mod test {
     use std::path::Path;
 
     use super::*;
+
+    #[track_caller]
+    fn ensure_utf8_inner(entry: &[&[[u8; MAX_RUST_RAW_KEYWORD_LEN]]]) {
+        for kws in entry {
+            for kw in *kws {
+                assert!(std::str::from_utf8(kw).is_ok(), "not UTF-8: {kw:?}");
+            }
+        }
+    }
 
     #[test]
     fn test_strip_common() {
@@ -1297,12 +1406,28 @@ mod test {
         );
         assert!(str_lit.parse_peek(r#"d"hello""#).is_err());
     }
-}
 
-#[test]
-fn assert_span_size() {
-    assert_eq!(
-        std::mem::size_of::<Span<'static>>(),
-        std::mem::size_of::<*const ()>()
-    );
+    #[test]
+    fn assert_span_size() {
+        assert_eq!(
+            std::mem::size_of::<Span<'static>>(),
+            std::mem::size_of::<*const ()>()
+        );
+    }
+
+    // Ensure that all raw keyword strings are UTF-8, because we use `from_utf8_unchecked()`.
+    #[test]
+    fn ensure_utf8() {
+        assert_eq!(RUST_KEYWORDS.len(), KWS_EXTRA.len());
+        ensure_utf8_inner(RUST_KEYWORDS);
+        ensure_utf8_inner(KWS_EXTRA);
+    }
+
+    #[test]
+    fn test_is_rust_keyword() {
+        assert!(is_rust_keyword("super"));
+        assert!(is_rust_keyword("become"));
+        assert!(!is_rust_keyword("supeeeer"));
+        assert!(!is_rust_keyword("sur"));
+    }
 }

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -4,7 +4,8 @@ use winnow::token::one_of;
 
 use crate::{
     CharLit, ErrorContext, Num, ParseErr, ParseResult, PathOrIdentifier, State, StrLit, WithSpan,
-    bool_lit, char_lit, identifier, keyword, num_lit, path_or_identifier, str_lit, ws,
+    bool_lit, char_lit, identifier, is_rust_keyword, keyword, num_lit, path_or_identifier, str_lit,
+    ws,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -194,14 +195,14 @@ fn verify_name<'a>(
     input: &'a str,
     name: &'a str,
 ) -> Result<Target<'a>, winnow::error::ErrMode<ErrorContext<'a>>> {
-    if name == "self" {
+    if is_rust_keyword(name) {
         Err(winnow::error::ErrMode::Cut(ErrorContext::new(
-            format!("cannot use `{name}` as a name"),
+            format!("cannot use `{name}` as a name: it is a rust keyword"),
             input,
         )))
     } else if name.starts_with("__rinja") {
         Err(winnow::error::ErrMode::Cut(ErrorContext::new(
-            format!("cannot use `{name}` as a name: it's reserved for `rinja`"),
+            format!("cannot use `{name}` as a name: it is reserved for `rinja`"),
             input,
         )))
     } else {

--- a/testing/tests/ui/assign-to-rinja.rs
+++ b/testing/tests/ui/assign-to-rinja.rs
@@ -8,5 +8,66 @@ struct Define;
 #[template(source = r#"{% let __rinja_var = "var" %}"#, ext = "html")]
 struct Assign;
 
+macro_rules! test_kw {
+    ($name:tt $source:literal) => {
+        #[derive(Template)]
+        #[template(source = $source, ext = "html")]
+        struct $name;
+    };
+}
+
+test_kw!(Abstract "{% let abstract %}");
+test_kw!(As "{% let as %}");
+test_kw!(Async "{% let async %}");
+test_kw!(Await "{% let await %}");
+test_kw!(Become "{% let become %}");
+test_kw!(Box "{% let box %}");
+test_kw!(Break "{% let break %}");
+test_kw!(Const "{% let const %}");
+test_kw!(Continue "{% let continue %}");
+test_kw!(Crate "{% let crate %}");
+test_kw!(Do "{% let do %}");
+test_kw!(Dyn "{% let dyn %}");
+test_kw!(Else "{% let else %}");
+test_kw!(Enum "{% let enum %}");
+test_kw!(Extern "{% let extern %}");
+test_kw!(False "{% let false %}");
+test_kw!(Final "{% let final %}");
+test_kw!(Fn "{% let fn %}");
+test_kw!(For "{% let for %}");
+test_kw!(If "{% let if %}");
+test_kw!(Impl "{% let impl %}");
+test_kw!(In "{% let in %}");
+test_kw!(Let "{% let let %}");
+test_kw!(Loop "{% let loop %}");
+test_kw!(Macro "{% let macro %}");
+test_kw!(Match "{% let match %}");
+test_kw!(Mod "{% let mod %}");
+test_kw!(Move "{% let move %}");
+test_kw!(Mut "{% let mut %}");
+test_kw!(Override "{% let override %}");
+test_kw!(Priv "{% let priv %}");
+test_kw!(Pub "{% let pub %}");
+test_kw!(Ref "{% let ref %}");
+test_kw!(Return "{% let return %}");
+test_kw!(LowerSelf "{% let self %}");
+test_kw!(UpperSelf "{% let Self %}");
+test_kw!(Static "{% let static %}");
+test_kw!(Struct "{% let struct %}");
+test_kw!(Super "{% let super %}");
+test_kw!(Trait "{% let trait %}");
+test_kw!(True "{% let true %}");
+test_kw!(Try "{% let try %}");
+test_kw!(Type "{% let type %}");
+test_kw!(Typeof "{% let typeof %}");
+test_kw!(Union "{% let union %}");
+test_kw!(Unsafe "{% let unsafe %}");
+test_kw!(Unsized "{% let unsized %}");
+test_kw!(Use "{% let use %}");
+test_kw!(Virtual "{% let virtual %}");
+test_kw!(Where "{% let where %}");
+test_kw!(While "{% let while %}");
+test_kw!(Yield "{% let yield %}");
+
 fn main() {
 }

--- a/testing/tests/ui/assign-to-rinja.rs
+++ b/testing/tests/ui/assign-to-rinja.rs
@@ -35,6 +35,7 @@ test_kw!(False "{% let false %}");
 test_kw!(Final "{% let final %}");
 test_kw!(Fn "{% let fn %}");
 test_kw!(For "{% let for %}");
+test_kw!(Gen "{% let gen %}");
 test_kw!(If "{% let if %}");
 test_kw!(Impl "{% let impl %}");
 test_kw!(In "{% let in %}");

--- a/testing/tests/ui/assign-to-rinja.stderr
+++ b/testing/tests/ui/assign-to-rinja.stderr
@@ -1,4 +1,4 @@
-error: cannot use `__rinja_var` as a name: it's reserved for `rinja`
+error: cannot use `__rinja_var` as a name: it is reserved for `rinja`
  --> <source attribute>:1:7
        "__rinja_var %}"
  --> tests/ui/assign-to-rinja.rs:4:21
@@ -6,10 +6,426 @@ error: cannot use `__rinja_var` as a name: it's reserved for `rinja`
 4 | #[template(source = r#"{% let __rinja_var %}"#, ext = "html")]
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: cannot use `__rinja_var` as a name: it's reserved for `rinja`
+error: cannot use `__rinja_var` as a name: it is reserved for `rinja`
  --> <source attribute>:1:7
        "__rinja_var = \"var\" %}"
  --> tests/ui/assign-to-rinja.rs:8:21
   |
 8 | #[template(source = r#"{% let __rinja_var = "var" %}"#, ext = "html")]
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot use `abstract` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "abstract %}"
+  --> tests/ui/assign-to-rinja.rs:19:19
+   |
+19 | test_kw!(Abstract "{% let abstract %}");
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error: cannot use `as` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "as %}"
+  --> tests/ui/assign-to-rinja.rs:20:13
+   |
+20 | test_kw!(As "{% let as %}");
+   |             ^^^^^^^^^^^^^^
+
+error: cannot use `async` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "async %}"
+  --> tests/ui/assign-to-rinja.rs:21:16
+   |
+21 | test_kw!(Async "{% let async %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `await` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "await %}"
+  --> tests/ui/assign-to-rinja.rs:22:16
+   |
+22 | test_kw!(Await "{% let await %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `become` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "become %}"
+  --> tests/ui/assign-to-rinja.rs:23:17
+   |
+23 | test_kw!(Become "{% let become %}");
+   |                 ^^^^^^^^^^^^^^^^^^
+
+error: cannot use `box` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "box %}"
+  --> tests/ui/assign-to-rinja.rs:24:14
+   |
+24 | test_kw!(Box "{% let box %}");
+   |              ^^^^^^^^^^^^^^^
+
+error: cannot use `break` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "break %}"
+  --> tests/ui/assign-to-rinja.rs:25:16
+   |
+25 | test_kw!(Break "{% let break %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `const` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "const %}"
+  --> tests/ui/assign-to-rinja.rs:26:16
+   |
+26 | test_kw!(Const "{% let const %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `continue` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "continue %}"
+  --> tests/ui/assign-to-rinja.rs:27:19
+   |
+27 | test_kw!(Continue "{% let continue %}");
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error: cannot use `crate` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "crate %}"
+  --> tests/ui/assign-to-rinja.rs:28:16
+   |
+28 | test_kw!(Crate "{% let crate %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `do` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "do %}"
+  --> tests/ui/assign-to-rinja.rs:29:13
+   |
+29 | test_kw!(Do "{% let do %}");
+   |             ^^^^^^^^^^^^^^
+
+error: cannot use `dyn` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "dyn %}"
+  --> tests/ui/assign-to-rinja.rs:30:14
+   |
+30 | test_kw!(Dyn "{% let dyn %}");
+   |              ^^^^^^^^^^^^^^^
+
+error: cannot use `else` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "else %}"
+  --> tests/ui/assign-to-rinja.rs:31:15
+   |
+31 | test_kw!(Else "{% let else %}");
+   |               ^^^^^^^^^^^^^^^^
+
+error: cannot use `enum` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "enum %}"
+  --> tests/ui/assign-to-rinja.rs:32:15
+   |
+32 | test_kw!(Enum "{% let enum %}");
+   |               ^^^^^^^^^^^^^^^^
+
+error: cannot use `extern` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "extern %}"
+  --> tests/ui/assign-to-rinja.rs:33:17
+   |
+33 | test_kw!(Extern "{% let extern %}");
+   |                 ^^^^^^^^^^^^^^^^^^
+
+error: when you forward-define a variable, you cannot use a literal in place of a variable name
+ --> <source attribute>:1:2
+       " let false %}"
+  --> tests/ui/assign-to-rinja.rs:34:16
+   |
+34 | test_kw!(False "{% let false %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `final` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "final %}"
+  --> tests/ui/assign-to-rinja.rs:35:16
+   |
+35 | test_kw!(Final "{% let final %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `fn` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "fn %}"
+  --> tests/ui/assign-to-rinja.rs:36:13
+   |
+36 | test_kw!(Fn "{% let fn %}");
+   |             ^^^^^^^^^^^^^^
+
+error: cannot use `for` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "for %}"
+  --> tests/ui/assign-to-rinja.rs:37:14
+   |
+37 | test_kw!(For "{% let for %}");
+   |              ^^^^^^^^^^^^^^^
+
+error: cannot use `if` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "if %}"
+  --> tests/ui/assign-to-rinja.rs:38:13
+   |
+38 | test_kw!(If "{% let if %}");
+   |             ^^^^^^^^^^^^^^
+
+error: cannot use `impl` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "impl %}"
+  --> tests/ui/assign-to-rinja.rs:39:15
+   |
+39 | test_kw!(Impl "{% let impl %}");
+   |               ^^^^^^^^^^^^^^^^
+
+error: cannot use `in` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "in %}"
+  --> tests/ui/assign-to-rinja.rs:40:13
+   |
+40 | test_kw!(In "{% let in %}");
+   |             ^^^^^^^^^^^^^^
+
+error: cannot use `let` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "let %}"
+  --> tests/ui/assign-to-rinja.rs:41:14
+   |
+41 | test_kw!(Let "{% let let %}");
+   |              ^^^^^^^^^^^^^^^
+
+error: cannot use `loop` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "loop %}"
+  --> tests/ui/assign-to-rinja.rs:42:15
+   |
+42 | test_kw!(Loop "{% let loop %}");
+   |               ^^^^^^^^^^^^^^^^
+
+error: cannot use `macro` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "macro %}"
+  --> tests/ui/assign-to-rinja.rs:43:16
+   |
+43 | test_kw!(Macro "{% let macro %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `match` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "match %}"
+  --> tests/ui/assign-to-rinja.rs:44:16
+   |
+44 | test_kw!(Match "{% let match %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `mod` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "mod %}"
+  --> tests/ui/assign-to-rinja.rs:45:14
+   |
+45 | test_kw!(Mod "{% let mod %}");
+   |              ^^^^^^^^^^^^^^^
+
+error: cannot use `move` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "move %}"
+  --> tests/ui/assign-to-rinja.rs:46:15
+   |
+46 | test_kw!(Move "{% let move %}");
+   |               ^^^^^^^^^^^^^^^^
+
+error: cannot use `mut` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "mut %}"
+  --> tests/ui/assign-to-rinja.rs:47:14
+   |
+47 | test_kw!(Mut "{% let mut %}");
+   |              ^^^^^^^^^^^^^^^
+
+error: cannot use `override` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "override %}"
+  --> tests/ui/assign-to-rinja.rs:48:19
+   |
+48 | test_kw!(Override "{% let override %}");
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error: cannot use `priv` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "priv %}"
+  --> tests/ui/assign-to-rinja.rs:49:15
+   |
+49 | test_kw!(Priv "{% let priv %}");
+   |               ^^^^^^^^^^^^^^^^
+
+error: cannot use `pub` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "pub %}"
+  --> tests/ui/assign-to-rinja.rs:50:14
+   |
+50 | test_kw!(Pub "{% let pub %}");
+   |              ^^^^^^^^^^^^^^^
+
+error: cannot use `ref` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "ref %}"
+  --> tests/ui/assign-to-rinja.rs:51:14
+   |
+51 | test_kw!(Ref "{% let ref %}");
+   |              ^^^^^^^^^^^^^^^
+
+error: cannot use `return` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "return %}"
+  --> tests/ui/assign-to-rinja.rs:52:17
+   |
+52 | test_kw!(Return "{% let return %}");
+   |                 ^^^^^^^^^^^^^^^^^^
+
+error: cannot use `self` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "self %}"
+  --> tests/ui/assign-to-rinja.rs:53:20
+   |
+53 | test_kw!(LowerSelf "{% let self %}");
+   |                    ^^^^^^^^^^^^^^^^
+
+error: when you forward-define a variable, you cannot use a path or enum variant in place of a variable name
+ --> <source attribute>:1:2
+       " let Self %}"
+  --> tests/ui/assign-to-rinja.rs:54:20
+   |
+54 | test_kw!(UpperSelf "{% let Self %}");
+   |                    ^^^^^^^^^^^^^^^^
+
+error: cannot use `static` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "static %}"
+  --> tests/ui/assign-to-rinja.rs:55:17
+   |
+55 | test_kw!(Static "{% let static %}");
+   |                 ^^^^^^^^^^^^^^^^^^
+
+error: cannot use `struct` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "struct %}"
+  --> tests/ui/assign-to-rinja.rs:56:17
+   |
+56 | test_kw!(Struct "{% let struct %}");
+   |                 ^^^^^^^^^^^^^^^^^^
+
+error: cannot use `super` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "super %}"
+  --> tests/ui/assign-to-rinja.rs:57:16
+   |
+57 | test_kw!(Super "{% let super %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `trait` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "trait %}"
+  --> tests/ui/assign-to-rinja.rs:58:16
+   |
+58 | test_kw!(Trait "{% let trait %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: when you forward-define a variable, you cannot use a literal in place of a variable name
+ --> <source attribute>:1:2
+       " let true %}"
+  --> tests/ui/assign-to-rinja.rs:59:15
+   |
+59 | test_kw!(True "{% let true %}");
+   |               ^^^^^^^^^^^^^^^^
+
+error: cannot use `try` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "try %}"
+  --> tests/ui/assign-to-rinja.rs:60:14
+   |
+60 | test_kw!(Try "{% let try %}");
+   |              ^^^^^^^^^^^^^^^
+
+error: cannot use `type` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "type %}"
+  --> tests/ui/assign-to-rinja.rs:61:15
+   |
+61 | test_kw!(Type "{% let type %}");
+   |               ^^^^^^^^^^^^^^^^
+
+error: cannot use `typeof` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "typeof %}"
+  --> tests/ui/assign-to-rinja.rs:62:17
+   |
+62 | test_kw!(Typeof "{% let typeof %}");
+   |                 ^^^^^^^^^^^^^^^^^^
+
+error: cannot use `union` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "union %}"
+  --> tests/ui/assign-to-rinja.rs:63:16
+   |
+63 | test_kw!(Union "{% let union %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `unsafe` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "unsafe %}"
+  --> tests/ui/assign-to-rinja.rs:64:17
+   |
+64 | test_kw!(Unsafe "{% let unsafe %}");
+   |                 ^^^^^^^^^^^^^^^^^^
+
+error: cannot use `unsized` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "unsized %}"
+  --> tests/ui/assign-to-rinja.rs:65:18
+   |
+65 | test_kw!(Unsized "{% let unsized %}");
+   |                  ^^^^^^^^^^^^^^^^^^^
+
+error: cannot use `use` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "use %}"
+  --> tests/ui/assign-to-rinja.rs:66:14
+   |
+66 | test_kw!(Use "{% let use %}");
+   |              ^^^^^^^^^^^^^^^
+
+error: cannot use `virtual` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "virtual %}"
+  --> tests/ui/assign-to-rinja.rs:67:18
+   |
+67 | test_kw!(Virtual "{% let virtual %}");
+   |                  ^^^^^^^^^^^^^^^^^^^
+
+error: cannot use `where` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "where %}"
+  --> tests/ui/assign-to-rinja.rs:68:16
+   |
+68 | test_kw!(Where "{% let where %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `while` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "while %}"
+  --> tests/ui/assign-to-rinja.rs:69:16
+   |
+69 | test_kw!(While "{% let while %}");
+   |                ^^^^^^^^^^^^^^^^^
+
+error: cannot use `yield` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "yield %}"
+  --> tests/ui/assign-to-rinja.rs:70:16
+   |
+70 | test_kw!(Yield "{% let yield %}");
+   |                ^^^^^^^^^^^^^^^^^

--- a/testing/tests/ui/assign-to-rinja.stderr
+++ b/testing/tests/ui/assign-to-rinja.stderr
@@ -166,266 +166,274 @@ error: cannot use `for` as a name: it is a rust keyword
 37 | test_kw!(For "{% let for %}");
    |              ^^^^^^^^^^^^^^^
 
+error: cannot use `gen` as a name: it is a rust keyword
+ --> <source attribute>:1:7
+       "gen %}"
+  --> tests/ui/assign-to-rinja.rs:38:14
+   |
+38 | test_kw!(Gen "{% let gen %}");
+   |              ^^^^^^^^^^^^^^^
+
 error: cannot use `if` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "if %}"
-  --> tests/ui/assign-to-rinja.rs:38:13
+  --> tests/ui/assign-to-rinja.rs:39:13
    |
-38 | test_kw!(If "{% let if %}");
+39 | test_kw!(If "{% let if %}");
    |             ^^^^^^^^^^^^^^
 
 error: cannot use `impl` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "impl %}"
-  --> tests/ui/assign-to-rinja.rs:39:15
+  --> tests/ui/assign-to-rinja.rs:40:15
    |
-39 | test_kw!(Impl "{% let impl %}");
+40 | test_kw!(Impl "{% let impl %}");
    |               ^^^^^^^^^^^^^^^^
 
 error: cannot use `in` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "in %}"
-  --> tests/ui/assign-to-rinja.rs:40:13
+  --> tests/ui/assign-to-rinja.rs:41:13
    |
-40 | test_kw!(In "{% let in %}");
+41 | test_kw!(In "{% let in %}");
    |             ^^^^^^^^^^^^^^
 
 error: cannot use `let` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "let %}"
-  --> tests/ui/assign-to-rinja.rs:41:14
+  --> tests/ui/assign-to-rinja.rs:42:14
    |
-41 | test_kw!(Let "{% let let %}");
+42 | test_kw!(Let "{% let let %}");
    |              ^^^^^^^^^^^^^^^
 
 error: cannot use `loop` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "loop %}"
-  --> tests/ui/assign-to-rinja.rs:42:15
+  --> tests/ui/assign-to-rinja.rs:43:15
    |
-42 | test_kw!(Loop "{% let loop %}");
+43 | test_kw!(Loop "{% let loop %}");
    |               ^^^^^^^^^^^^^^^^
 
 error: cannot use `macro` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "macro %}"
-  --> tests/ui/assign-to-rinja.rs:43:16
+  --> tests/ui/assign-to-rinja.rs:44:16
    |
-43 | test_kw!(Macro "{% let macro %}");
+44 | test_kw!(Macro "{% let macro %}");
    |                ^^^^^^^^^^^^^^^^^
 
 error: cannot use `match` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "match %}"
-  --> tests/ui/assign-to-rinja.rs:44:16
+  --> tests/ui/assign-to-rinja.rs:45:16
    |
-44 | test_kw!(Match "{% let match %}");
+45 | test_kw!(Match "{% let match %}");
    |                ^^^^^^^^^^^^^^^^^
 
 error: cannot use `mod` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "mod %}"
-  --> tests/ui/assign-to-rinja.rs:45:14
+  --> tests/ui/assign-to-rinja.rs:46:14
    |
-45 | test_kw!(Mod "{% let mod %}");
+46 | test_kw!(Mod "{% let mod %}");
    |              ^^^^^^^^^^^^^^^
 
 error: cannot use `move` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "move %}"
-  --> tests/ui/assign-to-rinja.rs:46:15
+  --> tests/ui/assign-to-rinja.rs:47:15
    |
-46 | test_kw!(Move "{% let move %}");
+47 | test_kw!(Move "{% let move %}");
    |               ^^^^^^^^^^^^^^^^
 
 error: cannot use `mut` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "mut %}"
-  --> tests/ui/assign-to-rinja.rs:47:14
+  --> tests/ui/assign-to-rinja.rs:48:14
    |
-47 | test_kw!(Mut "{% let mut %}");
+48 | test_kw!(Mut "{% let mut %}");
    |              ^^^^^^^^^^^^^^^
 
 error: cannot use `override` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "override %}"
-  --> tests/ui/assign-to-rinja.rs:48:19
+  --> tests/ui/assign-to-rinja.rs:49:19
    |
-48 | test_kw!(Override "{% let override %}");
+49 | test_kw!(Override "{% let override %}");
    |                   ^^^^^^^^^^^^^^^^^^^^
 
 error: cannot use `priv` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "priv %}"
-  --> tests/ui/assign-to-rinja.rs:49:15
+  --> tests/ui/assign-to-rinja.rs:50:15
    |
-49 | test_kw!(Priv "{% let priv %}");
+50 | test_kw!(Priv "{% let priv %}");
    |               ^^^^^^^^^^^^^^^^
 
 error: cannot use `pub` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "pub %}"
-  --> tests/ui/assign-to-rinja.rs:50:14
+  --> tests/ui/assign-to-rinja.rs:51:14
    |
-50 | test_kw!(Pub "{% let pub %}");
+51 | test_kw!(Pub "{% let pub %}");
    |              ^^^^^^^^^^^^^^^
 
 error: cannot use `ref` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "ref %}"
-  --> tests/ui/assign-to-rinja.rs:51:14
+  --> tests/ui/assign-to-rinja.rs:52:14
    |
-51 | test_kw!(Ref "{% let ref %}");
+52 | test_kw!(Ref "{% let ref %}");
    |              ^^^^^^^^^^^^^^^
 
 error: cannot use `return` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "return %}"
-  --> tests/ui/assign-to-rinja.rs:52:17
+  --> tests/ui/assign-to-rinja.rs:53:17
    |
-52 | test_kw!(Return "{% let return %}");
+53 | test_kw!(Return "{% let return %}");
    |                 ^^^^^^^^^^^^^^^^^^
 
 error: cannot use `self` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "self %}"
-  --> tests/ui/assign-to-rinja.rs:53:20
+  --> tests/ui/assign-to-rinja.rs:54:20
    |
-53 | test_kw!(LowerSelf "{% let self %}");
+54 | test_kw!(LowerSelf "{% let self %}");
    |                    ^^^^^^^^^^^^^^^^
 
 error: when you forward-define a variable, you cannot use a path or enum variant in place of a variable name
  --> <source attribute>:1:2
        " let Self %}"
-  --> tests/ui/assign-to-rinja.rs:54:20
+  --> tests/ui/assign-to-rinja.rs:55:20
    |
-54 | test_kw!(UpperSelf "{% let Self %}");
+55 | test_kw!(UpperSelf "{% let Self %}");
    |                    ^^^^^^^^^^^^^^^^
 
 error: cannot use `static` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "static %}"
-  --> tests/ui/assign-to-rinja.rs:55:17
+  --> tests/ui/assign-to-rinja.rs:56:17
    |
-55 | test_kw!(Static "{% let static %}");
+56 | test_kw!(Static "{% let static %}");
    |                 ^^^^^^^^^^^^^^^^^^
 
 error: cannot use `struct` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "struct %}"
-  --> tests/ui/assign-to-rinja.rs:56:17
+  --> tests/ui/assign-to-rinja.rs:57:17
    |
-56 | test_kw!(Struct "{% let struct %}");
+57 | test_kw!(Struct "{% let struct %}");
    |                 ^^^^^^^^^^^^^^^^^^
 
 error: cannot use `super` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "super %}"
-  --> tests/ui/assign-to-rinja.rs:57:16
+  --> tests/ui/assign-to-rinja.rs:58:16
    |
-57 | test_kw!(Super "{% let super %}");
+58 | test_kw!(Super "{% let super %}");
    |                ^^^^^^^^^^^^^^^^^
 
 error: cannot use `trait` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "trait %}"
-  --> tests/ui/assign-to-rinja.rs:58:16
+  --> tests/ui/assign-to-rinja.rs:59:16
    |
-58 | test_kw!(Trait "{% let trait %}");
+59 | test_kw!(Trait "{% let trait %}");
    |                ^^^^^^^^^^^^^^^^^
 
 error: when you forward-define a variable, you cannot use a literal in place of a variable name
  --> <source attribute>:1:2
        " let true %}"
-  --> tests/ui/assign-to-rinja.rs:59:15
+  --> tests/ui/assign-to-rinja.rs:60:15
    |
-59 | test_kw!(True "{% let true %}");
+60 | test_kw!(True "{% let true %}");
    |               ^^^^^^^^^^^^^^^^
 
 error: cannot use `try` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "try %}"
-  --> tests/ui/assign-to-rinja.rs:60:14
+  --> tests/ui/assign-to-rinja.rs:61:14
    |
-60 | test_kw!(Try "{% let try %}");
+61 | test_kw!(Try "{% let try %}");
    |              ^^^^^^^^^^^^^^^
 
 error: cannot use `type` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "type %}"
-  --> tests/ui/assign-to-rinja.rs:61:15
+  --> tests/ui/assign-to-rinja.rs:62:15
    |
-61 | test_kw!(Type "{% let type %}");
+62 | test_kw!(Type "{% let type %}");
    |               ^^^^^^^^^^^^^^^^
 
 error: cannot use `typeof` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "typeof %}"
-  --> tests/ui/assign-to-rinja.rs:62:17
+  --> tests/ui/assign-to-rinja.rs:63:17
    |
-62 | test_kw!(Typeof "{% let typeof %}");
+63 | test_kw!(Typeof "{% let typeof %}");
    |                 ^^^^^^^^^^^^^^^^^^
 
 error: cannot use `union` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "union %}"
-  --> tests/ui/assign-to-rinja.rs:63:16
+  --> tests/ui/assign-to-rinja.rs:64:16
    |
-63 | test_kw!(Union "{% let union %}");
+64 | test_kw!(Union "{% let union %}");
    |                ^^^^^^^^^^^^^^^^^
 
 error: cannot use `unsafe` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "unsafe %}"
-  --> tests/ui/assign-to-rinja.rs:64:17
+  --> tests/ui/assign-to-rinja.rs:65:17
    |
-64 | test_kw!(Unsafe "{% let unsafe %}");
+65 | test_kw!(Unsafe "{% let unsafe %}");
    |                 ^^^^^^^^^^^^^^^^^^
 
 error: cannot use `unsized` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "unsized %}"
-  --> tests/ui/assign-to-rinja.rs:65:18
+  --> tests/ui/assign-to-rinja.rs:66:18
    |
-65 | test_kw!(Unsized "{% let unsized %}");
+66 | test_kw!(Unsized "{% let unsized %}");
    |                  ^^^^^^^^^^^^^^^^^^^
 
 error: cannot use `use` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "use %}"
-  --> tests/ui/assign-to-rinja.rs:66:14
+  --> tests/ui/assign-to-rinja.rs:67:14
    |
-66 | test_kw!(Use "{% let use %}");
+67 | test_kw!(Use "{% let use %}");
    |              ^^^^^^^^^^^^^^^
 
 error: cannot use `virtual` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "virtual %}"
-  --> tests/ui/assign-to-rinja.rs:67:18
+  --> tests/ui/assign-to-rinja.rs:68:18
    |
-67 | test_kw!(Virtual "{% let virtual %}");
+68 | test_kw!(Virtual "{% let virtual %}");
    |                  ^^^^^^^^^^^^^^^^^^^
 
 error: cannot use `where` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "where %}"
-  --> tests/ui/assign-to-rinja.rs:68:16
+  --> tests/ui/assign-to-rinja.rs:69:16
    |
-68 | test_kw!(Where "{% let where %}");
+69 | test_kw!(Where "{% let where %}");
    |                ^^^^^^^^^^^^^^^^^
 
 error: cannot use `while` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "while %}"
-  --> tests/ui/assign-to-rinja.rs:69:16
+  --> tests/ui/assign-to-rinja.rs:70:16
    |
-69 | test_kw!(While "{% let while %}");
+70 | test_kw!(While "{% let while %}");
    |                ^^^^^^^^^^^^^^^^^
 
 error: cannot use `yield` as a name: it is a rust keyword
  --> <source attribute>:1:7
        "yield %}"
-  --> tests/ui/assign-to-rinja.rs:70:16
+  --> tests/ui/assign-to-rinja.rs:71:16
    |
-70 | test_kw!(Yield "{% let yield %}");
+71 | test_kw!(Yield "{% let yield %}");
    |                ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Resolves https://github.com/rinja-rs/askama/issues/1048.

(Does this work across repos?)