### PR TITLE
derive: keep track of called macros

### DIFF
--- a/rinja_derive/src/heritage.rs
+++ b/rinja_derive/src/heritage.rs
@@ -51,7 +51,7 @@ pub(crate) struct Context<'a> {
     pub(crate) parsed: &'a Parsed,
 }
 
-impl Context<'_> {
+impl<'a> Context<'a> {
     pub(crate) fn empty(parsed: &Parsed) -> Context<'_> {
         Context {
             nodes: &[],
@@ -64,11 +64,11 @@ impl Context<'_> {
         }
     }
 
-    pub(crate) fn new<'n>(
+    pub(crate) fn new(
         config: &Config,
-        path: &'n Path,
-        parsed: &'n Parsed,
-    ) -> Result<Context<'n>, CompileError> {
+        path: &'a Path,
+        parsed: &'a Parsed,
+    ) -> Result<Self, CompileError> {
         let mut extends = None;
         let mut blocks = HashMap::default();
         let mut macros = HashMap::default();
@@ -142,10 +142,11 @@ impl Context<'_> {
     }
 
     pub(crate) fn generate_error(&self, msg: impl fmt::Display, node: Span<'_>) -> CompileError {
-        CompileError::new(
-            msg,
-            self.path.map(|path| FileInfo::of(node, path, self.parsed)),
-        )
+        CompileError::new(msg, self.file_info_of(node))
+    }
+
+    pub(crate) fn file_info_of(&self, node: Span<'a>) -> Option<FileInfo<'a>> {
+        self.path.map(|path| FileInfo::of(node, path, self.parsed))
     }
 }
 

--- a/testing/templates/macro-recursion-1.html
+++ b/testing/templates/macro-recursion-1.html
@@ -1,0 +1,5 @@
+{% import "macro-recursion-2.html" as next %}
+
+{% macro some_macro %}
+    {% call next::some_macro %}
+{% endmacro %}

--- a/testing/templates/macro-recursion-2.html
+++ b/testing/templates/macro-recursion-2.html
@@ -1,0 +1,5 @@
+{% import "macro-recursion-3.html" as next %}
+
+{% macro some_macro %}
+    {% call next::some_macro %}
+{% endmacro %}

--- a/testing/templates/macro-recursion-3.html
+++ b/testing/templates/macro-recursion-3.html
@@ -1,0 +1,5 @@
+{% import "macro-recursion-1.html" as next %}
+
+{% macro some_macro %}
+    {% call next::some_macro %}
+{% endmacro %}

--- a/testing/tests/ui/macro-recursion.rs
+++ b/testing/tests/ui/macro-recursion.rs
@@ -1,0 +1,41 @@
+use rinja::Template;
+
+#[derive(Template)]
+#[template(
+    source = "
+        {% macro one %}{% call one %}{% endmacro %}
+        {% call one %}
+    ",
+    ext = "html"
+)]
+struct Direct;
+
+#[derive(Template)]
+#[template(
+    source = "
+        {% macro one %}{% call two %}{% endmacro %}
+        {% macro two %}{% call three %}{% endmacro %}
+        {% macro three %}{% call four %}{% endmacro %}
+        {% macro four %}{% call five %}{% endmacro %}
+        {% macro five %}{% call one %}{% endmacro %}
+        {% call one %}
+    ",
+    ext = "html"
+)]
+struct Indirect;
+
+#[derive(Template)]
+#[template(
+    source = r#"
+        {% import "macro-recursion-1.html" as next %}
+        {% macro some_macro %}
+            {% call next::some_macro %}
+        {% endmacro %}
+        {% call some_macro %}
+    "#,
+    ext = "html"
+)]
+struct AcrossImports;
+
+fn main() {
+}

--- a/testing/tests/ui/macro-recursion.stderr
+++ b/testing/tests/ui/macro-recursion.stderr
@@ -1,0 +1,61 @@
+error: Found recursion in macro calls:
+ --> Direct.html:3:10
+       " call one %}\n    "
+         --> Direct.html:2:25
+       " call one %}{% endmacro %}\n        {% call one %}\n    "
+ --> tests/ui/macro-recursion.rs:5:14
+  |
+5 |       source = "
+  |  ______________^
+6 | |         {% macro one %}{% call one %}{% endmacro %}
+7 | |         {% call one %}
+8 | |     ",
+  | |_____^
+
+error: Found recursion in macro calls:
+ --> Indirect.html:7:10
+       " call one %}\n    "
+         --> Indirect.html:2:25
+       " call two %}{% endmacro %}\n        {% macro two %}{% call three %}{% endmacro %}"...
+         --> Indirect.html:3:25
+       " call three %}{% endmacro %}\n        {% macro three %}{% call four %}{% endmacro"...
+         --> Indirect.html:4:27
+       " call four %}{% endmacro %}\n        {% macro four %}{% call five %}{% endmacro %"...
+         --> Indirect.html:5:26
+       " call five %}{% endmacro %}\n        {% macro five %}{% call one %}{% endmacro %}"...
+         --> Indirect.html:6:26
+       " call one %}{% endmacro %}\n        {% call one %}\n    "
+  --> tests/ui/macro-recursion.rs:15:14
+   |
+15 |       source = "
+   |  ______________^
+16 | |         {% macro one %}{% call two %}{% endmacro %}
+17 | |         {% macro two %}{% call three %}{% endmacro %}
+18 | |         {% macro three %}{% call four %}{% endmacro %}
+...  |
+21 | |         {% call one %}
+22 | |     ",
+   | |_____^
+
+error: Found recursion in macro calls:
+ --> AcrossImports.html:6:10
+       " call some_macro %}\n    "
+         --> AcrossImports.html:4:14
+       " call next::some_macro %}\n        {% endmacro %}\n        {% call some_macro %}\n "...
+         --> testing/templates/macro-recursion-1.html:4:6
+       " call next::some_macro %}\n{% endmacro %}"
+         --> testing/templates/macro-recursion-2.html:4:6
+       " call next::some_macro %}\n{% endmacro %}"
+         --> testing/templates/macro-recursion-3.html:4:6
+       " call next::some_macro %}\n{% endmacro %}"
+  --> tests/ui/macro-recursion.rs:29:14
+   |
+29 |       source = r#"
+   |  ______________^
+30 | |         {% import "macro-recursion-1.html" as next %}
+31 | |         {% macro some_macro %}
+32 | |             {% call next::some_macro %}
+33 | |         {% endmacro %}
+34 | |         {% call some_macro %}
+35 | |     "#,
+   | |______^


### PR DESCRIPTION
Recursive macro calls, direct and indirect, would cause a stackoverflow.

This PR lets the macro call handler keep track of the stack of called macros we are currently in, so we can abort with an error message instead of panicking.

Resolves <https://github.com/rinja-rs/rinja/issues/283>.