### PR TITLE
docs: fix recursive example in template_syntax.md

### DIFF
--- a/book/src/template_syntax.md
+++ b/book/src/template_syntax.md
@@ -797,16 +797,17 @@ A Comment
 Recursive implementations should preferably use a custom iterator and
 use a plain loop. If that is not doable, call `.render()`
 directly by using an expression as shown below.
-Including self does not work, see #105 and #220 .
 
 ```rust
 use rinja::Template;
 
 #[derive(Template)]
 #[template(source = r#"
-//! {% for item in children %}
-   {{ item }}
+{{ name }} {
+{% for item in children %}
+   {{ item.render()? }}
 {% endfor %}
+}
 "#, ext = "html", escape = "none")]
 struct Item<'a> {
     name: &'a str,


### PR DESCRIPTION
The original description mentions askama issues which is confusing, since they don't exist in rinja repo and, most importantly, the example doesn't compile at all. This fixes both issues.

## Output

Tested with the following code:

```rust
use rinja::Template;

#[derive(Template)]
#[template(source = r#"
{{ name }} {
{% for item in children %}
   {{ item.render().unwrap() }}
{% endfor %}
}
"#, ext = "html", escape = "none")]
struct Item<'a> {
    name: &'a str,
    children: &'a [Item<'a>],
}

fn main() {
    let xd = Item {
        name: "test1",
        children: &[
            Item {
                name: "test2",
                children: &[
                    Item {
                        name: "test3",
                        children: &[]
                    }
                ]
            }
        ]
    };

    println!("{}", xd.render().unwrap());
}
```

Which prints:

```
test1 {

   
test2 {

   
test3 {

}


}


}
```

## Old behavior

The old code fails to compile with:

```
error: reached the recursion limit while instantiating `filters::escape::_::<impl FastWritable for &Item<'_>>::write_into::<filters::escape::EscapeWriter<&mut filters::escape::EscapeWriter<..., ...>, ...>>`
   --> /home/m4tx/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rinja-0.3.5/src/filters/escape.rs:511:17
    |
511 |                 <T>::write_into(self, dest)
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: `filters::escape::_::<impl FastWritable for &T>::write_into` defined here
   --> /home/m4tx/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rinja-0.3.5/src/filters/escape.rs:510:13
    |
510 |             fn write_into<W: fmt::Write + ?Sized>(&self, dest: &mut W) -> fmt::Result {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: the full type name has been written to '/home/m4tx/projects/rust-test/target/debug/deps/rust_test-7872518c4b30a6ab.long-type.txt'
```