### PR TITLE
chore: Upgrade to Winnow 0.7 

### DIFF
--- a/rinja_parser/Cargo.toml
+++ b/rinja_parser/Cargo.toml
@@ -23,7 +23,7 @@ harness = false
 [dependencies]
 memchr = "2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-winnow = "0.6.23"
+winnow = "0.6.26"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/rinja_parser/Cargo.toml
+++ b/rinja_parser/Cargo.toml
@@ -23,7 +23,7 @@ harness = false
 [dependencies]
 memchr = "2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-winnow = "0.6.26"
+winnow = "0.7.0"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -6,7 +6,7 @@ use winnow::ascii::digit1;
 use winnow::combinator::{
     alt, cut_err, fail, not, opt, peek, preceded, repeat, separated, terminated,
 };
-use winnow::error::{ErrorKind, ParserError as _};
+use winnow::error::ParserError as _;
 use winnow::stream::Stream as _;
 
 use crate::node::CondTest;
@@ -625,11 +625,7 @@ impl<'a> Suffix<'a> {
                         expr = WithSpan::new(Expr::RustMacro(vec![name], args), before_suffix)
                     }
                     _ => {
-                        return Err(winnow::error::ErrMode::from_error_kind(
-                            &before_suffix,
-                            ErrorKind::Tag,
-                        )
-                        .cut());
+                        return Err(winnow::error::ErrMode::from_input(&before_suffix).cut());
                     }
                 },
             }

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -424,13 +424,13 @@ impl<'a> Expr<'a> {
         let start = *i;
         let expr = preceded(ws('('), opt(|i: &mut _| Self::parse(i, level, true))).parse_next(i)?;
         let Some(expr) = expr else {
-            let _ = ')'.parse_next(i).map_err(|e: ParseErr<'_>| e)?;
+            let _ = ')'.parse_next(i)?;
             return Ok(WithSpan::new(Self::Tuple(vec![]), start));
         };
 
         let comma = ws(opt(peek(','))).parse_next(i)?;
         if comma.is_none() {
-            let _ = ')'.parse_next(i).map_err(|e: ParseErr<'_>| e)?;
+            let _ = ')'.parse_next(i)?;
             return Ok(WithSpan::new(Self::Group(Box::new(expr)), start));
         }
 

--- a/rinja_parser/src/expr.rs
+++ b/rinja_parser/src/expr.rs
@@ -424,13 +424,13 @@ impl<'a> Expr<'a> {
         let start = *i;
         let expr = preceded(ws('('), opt(|i: &mut _| Self::parse(i, level, true))).parse_next(i)?;
         let Some(expr) = expr else {
-            let _ = ')'.parse_next(i)?;
+            let _ = ')'.parse_next(i).map_err(|e: ParseErr<'_>| e)?;
             return Ok(WithSpan::new(Self::Tuple(vec![]), start));
         };
 
         let comma = ws(opt(peek(','))).parse_next(i)?;
         if comma.is_none() {
-            let _ = ')'.parse_next(i)?;
+            let _ = ')'.parse_next(i).map_err(|e: ParseErr<'_>| e)?;
             return Ok(WithSpan::new(Self::Group(Box::new(expr)), start));
         }
 

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -308,6 +308,14 @@ impl<'a> ErrorContext<'a> {
             message: Some(message.into()),
         }
     }
+
+    fn backtrack(self) -> winnow::error::ErrMode<Self> {
+        winnow::error::ErrMode::Backtrack(self)
+    }
+
+    fn cut(self) -> winnow::error::ErrMode<Self> {
+        winnow::error::ErrMode::Cut(self)
+    }
 }
 
 impl<'a> winnow::error::ParserError<&'a str> for ErrorContext<'a> {
@@ -332,12 +340,6 @@ impl<'a, E: std::fmt::Display> FromExternalError<&'a str, E> for ErrorContext<'a
             span: (*input).into(),
             message: Some(Cow::Owned(e.to_string())),
         }
-    }
-}
-
-impl<'a> From<ErrorContext<'a>> for winnow::error::ErrMode<ErrorContext<'a>> {
-    fn from(cx: ErrorContext<'a>) -> Self {
-        Self::Cut(cx)
     }
 }
 
@@ -762,7 +764,7 @@ impl State<'_, '_> {
                 control.escape_default(),
                 self.syntax.block_end.escape_default(),
             );
-            Err(ParseErr::backtrack(ErrorContext::new(message, *i).into()))
+            Err(ErrorContext::new(message, *i).backtrack())
         } else {
             Ok(())
         }

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -13,7 +13,7 @@ use std::{fmt, str};
 use winnow::Parser;
 use winnow::ascii::take_escaped;
 use winnow::combinator::{alt, cut_err, delimited, fail, not, opt, peek, preceded, repeat};
-use winnow::error::{ErrorKind, FromExternalError};
+use winnow::error::FromExternalError;
 use winnow::stream::{AsChar, Stream as _};
 use winnow::token::{any, one_of, take_till, take_while};
 
@@ -311,25 +311,28 @@ impl<'a> ErrorContext<'a> {
 }
 
 impl<'a> winnow::error::ParserError<&'a str> for ErrorContext<'a> {
-    fn from_error_kind(input: &&'a str, _code: ErrorKind) -> Self {
+    #[allow(deprecated)]
+    fn from_error_kind(input: &&'a str, _code: winnow::error::ErrorKind) -> Self {
         Self {
             span: (*input).into(),
             message: None,
         }
     }
 
+    #[allow(deprecated)]
     fn append(
         self,
         _: &&'a str,
         _: &<&str as winnow::stream::Stream>::Checkpoint,
-        _: ErrorKind,
+        _: winnow::error::ErrorKind,
     ) -> Self {
         self
     }
 }
 
 impl<'a, E: std::fmt::Display> FromExternalError<&'a str, E> for ErrorContext<'a> {
-    fn from_external_error(input: &&'a str, _kind: ErrorKind, e: E) -> Self {
+    #[allow(deprecated)]
+    fn from_external_error(input: &&'a str, _kind: winnow::error::ErrorKind, e: E) -> Self {
         Self {
             span: (*input).into(),
             message: Some(Cow::Owned(e.to_string())),

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -444,8 +444,7 @@ fn num_lit<'a>(i: &mut &'a str) -> ParseResult<'a, Num<'a>> {
     let int_with_base = (opt('-'), |i: &mut _| {
         let (base, kind) = preceded('0', alt(('b'.value(2), 'o'.value(8), 'x'.value(16))))
             .with_taken()
-            .parse_next(i)
-            .map_err(|e: ParseErr<'_>| e)?;
+            .parse_next(i)?;
         match opt(separated_digits(base, false)).parse_next(i)? {
             Some(_) => Ok(()),
             None => Err(winnow::error::ErrMode::Cut(ErrorContext::new(
@@ -460,9 +459,7 @@ fn num_lit<'a>(i: &mut &'a str) -> ParseResult<'a, Num<'a>> {
     let float = |i: &mut &'a str| -> ParseResult<'a, ()> {
         let has_dot = opt(('.', separated_digits(10, true))).parse_next(i)?;
         let has_exp = opt(|i: &mut _| {
-            let (kind, op) = (one_of(['e', 'E']), opt(one_of(['+', '-'])))
-                .parse_next(i)
-                .map_err(|e: ParseErr<'_>| e)?;
+            let (kind, op) = (one_of(['e', 'E']), opt(one_of(['+', '-']))).parse_next(i)?;
             match opt(separated_digits(10, op.is_none())).parse_next(i)? {
                 Some(_) => Ok(()),
                 None => Err(winnow::error::ErrMode::Cut(ErrorContext::new(
@@ -559,8 +556,7 @@ fn str_lit_without_prefix<'a>(i: &mut &'a str) -> ParseResult<'a> {
         opt(take_escaped(take_till(1.., ['\\', '"']), '\\', any)),
         '"',
     )
-    .parse_next(i)
-    .map_err(|e: ParseErr<'_>| e)?;
+    .parse_next(i)?;
     Ok(s.unwrap_or_default())
 }
 
@@ -597,8 +593,7 @@ fn char_lit<'a>(i: &mut &'a str) -> ParseResult<'a, CharLit<'a>> {
             '\'',
         ),
     )
-        .parse_next(i)
-        .map_err(|e: ParseErr<'_>| e)?;
+        .parse_next(i)?;
 
     let Some(s) = s else {
         i.reset(&start);
@@ -756,8 +751,7 @@ impl State<'_, '_> {
             peek(delimited('%', alt(('-', '~', '+')).map(Some), '}')),
             fail, // rollback on partial matches in the previous line
         ))
-        .parse_next(i)
-        .map_err(|e: ParseErr<'_>| e)?;
+        .parse_next(i)?;
         if let Some(control) = control {
             let message = format!(
                 "unclosed block, you likely meant to apply whitespace control: \"{}{}\"",

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -120,7 +120,7 @@ impl<'a> Node<'a> {
         .parse_next(i)?;
         match closed {
             true => Ok(node),
-            false => Err(ErrorContext::unclosed("block", s.syntax.block_end, start).into()),
+            false => Err(ErrorContext::unclosed("block", s.syntax.block_end, start).cut()),
         }
     }
 
@@ -188,7 +188,7 @@ impl<'a> Node<'a> {
         .parse_next(i)?;
         match closed {
             true => Ok(Self::Expr(Ws(pws, nws), expr)),
-            false => Err(ErrorContext::unclosed("expression", s.syntax.expr_end, start).into()),
+            false => Err(ErrorContext::unclosed("expression", s.syntax.expr_end, start).cut()),
         }
     }
 
@@ -1352,7 +1352,7 @@ impl<'a> Comment<'a> {
                 let tag = opt(skip_till(splitter, |i: &mut _| tag(i, s))).parse_next(i)?;
                 let Some((inclusive, tag)) = tag else {
                     return Err(
-                        ErrorContext::unclosed("comment", s.syntax.comment_end, start).into(),
+                        ErrorContext::unclosed("comment", s.syntax.comment_end, start).cut(),
                     );
                 };
                 match tag {

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -11,8 +11,8 @@ use winnow::{ModalParser, Parser};
 
 use crate::memchr_splitter::{Splitter1, Splitter2, Splitter3};
 use crate::{
-    ErrorContext, Expr, Filter, ParseErr, ParseResult, Span, State, Target, WithSpan, filter,
-    identifier, is_rust_keyword, keyword, skip_till, skip_ws0, str_lit_without_prefix, ws,
+    ErrorContext, Expr, Filter, ParseResult, Span, State, Target, WithSpan, filter, identifier,
+    is_rust_keyword, keyword, skip_till, skip_ws0, str_lit_without_prefix, ws,
 };
 
 #[derive(Debug, PartialEq)]
@@ -56,7 +56,7 @@ impl<'a> Node<'a> {
             }
         };
         opt(|i: &mut _| unexpected_tag(i, s)).parse_next(i)?;
-        let is_eof = opt(eof).parse_next(i).map_err(|e: ParseErr<'_>| e)?;
+        let is_eof = opt(eof).parse_next(i)?;
         if is_eof.is_none() {
             return Err(winnow::error::ErrMode::Cut(ErrorContext::new(
                 "cannot parse entire template\n\
@@ -1076,7 +1076,7 @@ pub struct Lit<'a> {
 impl<'a> Lit<'a> {
     fn parse(i: &mut &'a str, s: &State<'_, '_>) -> ParseResult<'a, WithSpan<'a, Self>> {
         let start = *i;
-        not(eof).parse_next(i).map_err(|e: ParseErr<'_>| e)?;
+        not(eof).parse_next(i)?;
 
         let candidate_finder = Splitter3::new(
             s.syntax.block_start,
@@ -1096,7 +1096,7 @@ impl<'a> Lit<'a> {
                 return fail.parse_next(i);
             }
             Some(content) => content,
-            None => rest.parse_next(i).map_err(|e: ParseErr<'_>| e)?, /* there is no {block,comment,expr}_start: take everything */
+            None => rest.parse_next(i)?, /* there is no {block,comment,expr}_start: take everything */
         };
         Ok(WithSpan::new(Self::split_ws_parts(content), start))
     }

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -1,13 +1,13 @@
 use std::collections::HashSet;
 use std::str::{self, FromStr};
 
-use winnow::Parser;
 use winnow::combinator::{
     alt, cut_err, delimited, empty, eof, fail, not, opt, peek, preceded, repeat, separated,
     terminated,
 };
 use winnow::stream::Stream as _;
 use winnow::token::{any, literal, rest};
+use winnow::{ModalParser, Parser};
 
 use crate::memchr_splitter::{Splitter1, Splitter2, Splitter3};
 use crate::{
@@ -218,8 +218,8 @@ impl<'a> Node<'a> {
 
 fn cut_node<'a, O>(
     kind: Option<&'static str>,
-    inner: impl Parser<&'a str, O, ErrorContext<'a>>,
-) -> impl Parser<&'a str, O, ErrorContext<'a>> {
+    inner: impl ModalParser<&'a str, O, ErrorContext<'a>>,
+) -> impl ModalParser<&'a str, O, ErrorContext<'a>> {
     let mut inner = cut_err(inner);
     move |i: &mut &'a str| {
         let start = *i;
@@ -1414,7 +1414,7 @@ pub struct Ws(pub Option<Whitespace>, pub Option<Whitespace>);
 fn end_node<'a, 'g: 'a>(
     node: &'g str,
     expected: &'g str,
-) -> impl Parser<&'a str, &'a str, ErrorContext<'a>> + 'g {
+) -> impl ModalParser<&'a str, &'a str, ErrorContext<'a>> + 'g {
     move |i: &mut &'a str| {
         let start = i.checkpoint();
         let actual = ws(identifier).parse_next(i)?;

--- a/rinja_parser/src/target.rs
+++ b/rinja_parser/src/target.rs
@@ -1,6 +1,6 @@
-use winnow::Parser;
 use winnow::combinator::{alt, opt, peek, preceded, separated};
 use winnow::token::one_of;
+use winnow::{ModalParser, Parser};
 
 use crate::{
     CharLit, ErrorContext, Num, ParseErr, ParseResult, PathOrIdentifier, State, StrLit, WithSpan,
@@ -217,7 +217,7 @@ fn verify_name<'a>(
 fn collect_targets<'a, T>(
     i: &mut &'a str,
     delim: char,
-    one: impl Parser<&'a str, T, ErrorContext<'a>>,
+    one: impl ModalParser<&'a str, T, ErrorContext<'a>>,
 ) -> ParseResult<'a, (bool, Vec<T>)> {
     let opt_comma = ws(opt(',')).map(|o| o.is_some());
     let mut opt_end = ws(opt(one_of(delim))).map(|o| o.is_some());


### PR DESCRIPTION
~~I am not thrilled with the fact that annotations of some kind (I used
no-op `map_err`s here) are needed for the errors and will be digging
into this to better understand why.  The code in `toml_edit` is very
similar and yet it doesn't need them.~~

Those `map_err`s were needed to workaround `impl From for ErrMode`.  `ErrMode` is now optional, so its unclear when calling a generic error if its returning a `ErrorContext` or a `ErrMode<ErrorContext>`.  See winnow-rs/winnow#735