### PR TITLE
 derive: implement template attribute `blocks`

### DIFF
--- a/rinja/Cargo.toml
+++ b/rinja/Cargo.toml
@@ -44,7 +44,7 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["config", "std", "urlencode"]
-full = ["default", "code-in-doc", "serde_json"]
+full = ["default", "blocks", "code-in-doc", "serde_json"]
 
 alloc = [
     "rinja_derive/alloc",
@@ -52,6 +52,7 @@ alloc = [
     "serde_json?/alloc",
     "percent-encoding?/alloc"
 ]
+blocks = ["rinja_derive/blocks"]
 code-in-doc = ["rinja_derive/code-in-doc"]
 config = ["rinja_derive/config"]
 serde_json = ["rinja_derive/serde_json", "dep:serde", "dep:serde_json"]

--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -39,6 +39,7 @@ syn = { version = "2.0.3", features = ["full"] }
 
 [features]
 alloc = []
+blocks = ["syn/full"]
 code-in-doc = ["dep:pulldown-cmark"]
 config = ["dep:serde", "dep:basic-toml", "parser/config"]
 urlencode = []

--- a/rinja_derive/src/generator/node.rs
+++ b/rinja_derive/src/generator/node.rs
@@ -1013,7 +1013,8 @@ impl<'a> Generator<'a, '_> {
 
         self.write_buf_writable(ctx, buf)?;
 
-        let block_fragment_write = self.input.block == name && self.buf_writable.discard;
+        let block_fragment_write =
+            self.input.block.map(|(block, _)| block) == name && self.buf_writable.discard;
         // Allow writing to the buffer if we're in the block fragment
         if block_fragment_write {
             self.buf_writable.discard = false;

--- a/rinja_derive/src/input.rs
+++ b/rinja_derive/src/input.rs
@@ -76,7 +76,7 @@ impl TemplateInput<'_> {
             || Ok(config.syntaxes.get(config.default_syntax).unwrap()),
             |s| {
                 config.syntaxes.get(s).ok_or_else(|| {
-                    CompileError::no_file_info(format!("syntax `{s}` is undefined"), None)
+                    CompileError::no_file_info(format_args!("syntax `{s}` is undefined"), None)
                 })
             },
         )?;
@@ -98,7 +98,7 @@ impl TemplateInput<'_> {
             })
             .ok_or_else(|| {
                 CompileError::no_file_info(
-                    format!(
+                    format_args!(
                         "no escaper defined for extension '{escaping}'. You can define an escaper \
                         in the config file (named `rinja.toml` by default). {}",
                         MsgValidEscapers(&config.escapers),
@@ -509,7 +509,7 @@ fn no_rinja_code_block(span: Span, ast: &syn::DeriveInput) -> CompileError {
         syn::Data::Union(_) => "union",
     };
     CompileError::no_file_info(
-        format!(
+        format_args!(
             "when using `in_doc` with the value `true`, the {kind}'s documentation needs a \
              `rinja` code block"
         ),
@@ -641,7 +641,7 @@ impl FromStr for Print {
 
 fn cyclic_graph_error(dependency_graph: &[(Arc<Path>, Arc<Path>)]) -> Result<(), CompileError> {
     Err(CompileError::no_file_info(
-        format!(
+        format_args!(
             "cyclic dependency in graph {:#?}",
             dependency_graph
                 .iter()
@@ -776,7 +776,7 @@ const _: () = {
                 .parse_args_with(<Punctuated<Meta, Token![,]>>::parse_terminated)
                 .map_err(|e| {
                     CompileError::no_file_info(
-                        format!("unable to parse template arguments: {e}"),
+                        format_args!("unable to parse template arguments: {e}"),
                         Some(attr.path().span()),
                     )
                 })?;
@@ -907,7 +907,7 @@ const _: () = {
             Ok(())
         } else {
             Err(CompileError::no_file_info(
-                format!("template attribute `{name}` already set"),
+                format_args!("template attribute `{name}` already set"),
                 Some(name.span()),
             ))
         }
@@ -920,7 +920,7 @@ const _: () = {
                 Expr::Group(group) => expr = *group.expr,
                 v => {
                     return Err(CompileError::no_file_info(
-                        format!("template attribute `{name}` expects a literal"),
+                        format_args!("template attribute `{name}` expects a literal"),
                         Some(v.span()),
                     ));
                 }
@@ -933,7 +933,7 @@ const _: () = {
             Ok(s)
         } else {
             Err(CompileError::no_file_info(
-                format!("template attribute `{name}` expects a string literal"),
+                format_args!("template attribute `{name}` expects a string literal"),
                 Some(value.lit.span()),
             ))
         }
@@ -944,7 +944,7 @@ const _: () = {
             Ok(s)
         } else {
             Err(CompileError::no_file_info(
-                format!("template attribute `{name}` expects a boolean value"),
+                format_args!("template attribute `{name}` expects a boolean value"),
                 Some(value.lit.span()),
             ))
         }
@@ -957,7 +957,7 @@ const _: () = {
                 Expr::Group(group) => expr = *group.expr,
                 v => {
                     return Err(CompileError::no_file_info(
-                        format!("template attribute `{name}` expects a path or identifier"),
+                        format_args!("template attribute `{name}` expects a path or identifier"),
                         Some(v.span()),
                     ));
                 }

--- a/rinja_derive/src/input.rs
+++ b/rinja_derive/src/input.rs
@@ -24,7 +24,7 @@ pub(crate) struct TemplateInput<'a> {
     pub(crate) syntax: &'a SyntaxAndCache<'a>,
     pub(crate) source: &'a Source,
     pub(crate) source_span: Option<Span>,
-    pub(crate) block: Option<&'a str>,
+    pub(crate) block: Option<(&'a str, Span)>,
     pub(crate) print: Print,
     pub(crate) escaper: &'a str,
     pub(crate) path: Arc<Path>,
@@ -133,7 +133,7 @@ impl TemplateInput<'_> {
             syntax,
             source,
             source_span: *source_span,
-            block: block.as_deref(),
+            block: block.as_ref().map(|(block, span)| (block.as_str(), *span)),
             print: *print,
             escaper,
             path,
@@ -346,7 +346,7 @@ impl AnyTemplateArgs {
 
 pub(crate) struct TemplateArgs {
     pub(crate) source: (Source, Option<Span>),
-    block: Option<String>,
+    block: Option<(String, Span)>,
     print: Print,
     escaping: Option<String>,
     ext: Option<String>,
@@ -395,7 +395,7 @@ impl TemplateArgs {
                     ));
                 }
             },
-            block: args.block.map(|value| value.value()),
+            block: args.block.map(|value| (value.value(), value.span())),
             print: args.print.unwrap_or_default(),
             escaping: args.escape.map(|value| value.value()),
             ext: args.ext.as_ref().map(|value| value.value()),

--- a/rinja_derive/src/lib.rs
+++ b/rinja_derive/src/lib.rs
@@ -262,7 +262,7 @@ fn build_template_item(
     ast: &syn::DeriveInput,
     enum_ast: Option<&syn::DeriveInput>,
     template_args: &TemplateArgs,
-    tmpl_kind: TmplKind,
+    tmpl_kind: TmplKind<'_>,
 ) -> Result<usize, CompileError> {
     let config_path = template_args.config_path();
     let s = read_config_file(config_path, template_args.config_span)?;

--- a/rinja_derive/src/lib.rs
+++ b/rinja_derive/src/lib.rs
@@ -286,11 +286,11 @@ fn build_template_item(
     let heritage = if !ctx.blocks.is_empty() || ctx.extends.is_some() {
         let heritage = Heritage::new(ctx, &contexts);
 
-        if let Some(block_name) = input.block {
+        if let Some((block_name, block_span)) = input.block {
             if !heritage.blocks.contains_key(&block_name) {
                 return Err(CompileError::no_file_info(
-                    format!("cannot find block {block_name}"),
-                    None,
+                    format_args!("cannot find block `{block_name}`"),
+                    Some(block_span),
                 ));
             }
         }

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -46,6 +46,7 @@ syn = { version = "2.0.3", features = ["full"] }
 default = ["__standalone"]
 __standalone = []
 
+blocks = ["syn/full"]
 code-in-doc = ["dep:pulldown-cmark"]
 config = ["dep:serde", "dep:basic-toml", "parser/config"]
 urlencode = []

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = { version = "1.0", optional = true }
 core = { package = "intentionally-empty", version = "1.0.0" }
 
 [dev-dependencies]
-rinja = { path = "../rinja", version = "0.3.5", features = ["code-in-doc", "serde_json"] }
+rinja = { path = "../rinja", version = "0.3.5", features = ["blocks", "code-in-doc", "serde_json"] }
 
 assert_matches = "1.5.0"
 criterion = "0.5"
@@ -31,7 +31,8 @@ phf = { version = "0.11", features = ["macros" ] }
 trybuild = "1.0.100"
 
 [features]
-default = ["code-in-doc", "serde_json"]
+default = ["blocks", "code-in-doc", "serde_json"]
+blocks = ["rinja/blocks"]
 code-in-doc = ["rinja/code-in-doc"]
 serde_json = ["dep:serde_json", "rinja/serde_json"]
 

--- a/testing/tests/blocks.rs
+++ b/testing/tests/blocks.rs
@@ -1,0 +1,40 @@
+#![cfg(feature = "blocks")]
+
+use std::fmt::Display;
+
+use rinja::Template;
+
+#[test]
+fn test_blocks() {
+    #[derive(Template)]
+    #[template(
+        ext = "txt",
+        source = "
+            {%- block first -%} first=<{{first}}> {%- endblock -%}
+            {%- block second -%} second=<{{second}}> {%- endblock -%}
+            {%- block third -%} third=<{{third}}> {%- endblock -%}
+            {%- block fail -%} better luck next time {%- endblock -%}
+        ",
+        block = "fail",
+        blocks = ["first", "second", "third"]
+    )]
+    struct WithBlocks<'a, S: Display, T>
+    where
+        T: Display,
+    {
+        first: &'a str,
+        second: S,
+        third: &'a T,
+    }
+
+    let tmpl = WithBlocks {
+        first: "number one",
+        second: 2,
+        third: &"bronze",
+    };
+
+    assert_eq!(tmpl.as_first().render().unwrap(), "first=<number one>");
+    assert_eq!(tmpl.as_second().render().unwrap(), "second=<2>");
+    assert_eq!(tmpl.as_third().render().unwrap(), "third=<bronze>");
+    assert_eq!(tmpl.render().unwrap(), "better luck next time");
+}

--- a/testing/tests/ui/enum.rs
+++ b/testing/tests/ui/enum.rs
@@ -1,0 +1,33 @@
+use rinja::Template;
+
+#[derive(Template)]
+enum CratePathOnVariant {
+    #[template(ext = "txt", source = "🫨", rinja = rinja)]
+    Variant,
+}
+
+#[derive(Template)]
+enum CratePathOnVariants {
+    #[template(ext = "txt", source = "🫏", rinja = rinja)]
+    Variant1,
+    #[template(ext = "txt", source = "🪿", rinja = rinja)]
+    Variant2,
+}
+
+#[derive(Template)]
+#[template(ext = "txt", source = "🪼", rinja = rinja)]
+enum CratePathOnBoth {
+    #[template(ext = "txt", source = "🪻", rinja = rinja)]
+    Variant,
+}
+
+#[derive(Template)]
+#[template(ext = "txt", source = "🫛", rinja = rinja)]
+enum CratePathOnAll {
+    #[template(ext = "txt", source = "🫠", rinja = rinja)]
+    Variant1,
+    #[template(ext = "txt", source = "🧌", rinja = rinja)]
+    Variant2,
+}
+
+fn main() {}

--- a/testing/tests/ui/enum.rs
+++ b/testing/tests/ui/enum.rs
@@ -30,4 +30,25 @@ enum CratePathOnAll {
     Variant2,
 }
 
+#[derive(Template)]
+#[template(
+    ext = "txt",
+    source = "
+        {%- block a -%} a {%- endblock -%}
+        {%- block b -%} b {%- endblock -%}
+        {#- no block c -#}
+        {%- block d -%} d {%- endblock -%}
+    ",
+)]
+enum MissingBlockName {
+    #[template(block = "a")]
+    A,
+    #[template(block = "b")]
+    B,
+    #[template(block = "c")]
+    C,
+    #[template(block = "d")]
+    D,
+}
+
 fn main() {}

--- a/testing/tests/ui/enum.stderr
+++ b/testing/tests/ui/enum.stderr
@@ -1,0 +1,23 @@
+error: template attribute `rinja` can only be used on the `enum`, not its variants
+ --> tests/ui/enum.rs:5:43
+  |
+5 |     #[template(ext = "txt", source = "🫨", rinja = rinja)]
+  |                                            ^^^^^
+
+error: template attribute `rinja` can only be used on the `enum`, not its variants
+  --> tests/ui/enum.rs:11:43
+   |
+11 |     #[template(ext = "txt", source = "🫏", rinja = rinja)]
+   |                                            ^^^^^
+
+error: template attribute `rinja` can only be used on the `enum`, not its variants
+  --> tests/ui/enum.rs:20:43
+   |
+20 |     #[template(ext = "txt", source = "🪻", rinja = rinja)]
+   |                                            ^^^^^
+
+error: template attribute `rinja` can only be used on the `enum`, not its variants
+  --> tests/ui/enum.rs:27:43
+   |
+27 |     #[template(ext = "txt", source = "🫠", rinja = rinja)]
+   |                                            ^^^^^

--- a/testing/tests/ui/enum.stderr
+++ b/testing/tests/ui/enum.stderr
@@ -21,3 +21,9 @@ error: template attribute `rinja` can only be used on the `enum`, not its varian
    |
 27 |     #[template(ext = "txt", source = "🫠", rinja = rinja)]
    |                                            ^^^^^
+
+error: cannot find block `c`
+  --> tests/ui/enum.rs:48:24
+   |
+48 |     #[template(block = "c")]
+   |                        ^^^


### PR DESCRIPTION
The new attribute `blocks` is feature-gated because it depends on `syn/full`, which we don't need otherwise.

The implementation is quite big (8 files changed, 269 insertions(+), 9 deletions(-)), but also reasonably self-contained, so I'm still happy. :)

Todos:

- [ ] add documentation

Resolves #328.