### PR TITLE
derive: fail if requested template block is missing

### DIFF
--- a/rinja_derive/src/lib.rs
+++ b/rinja_derive/src/lib.rs
@@ -284,21 +284,23 @@ fn build_template_item(
 
     let ctx = &contexts[&input.path];
     let heritage = if !ctx.blocks.is_empty() || ctx.extends.is_some() {
-        let heritage = Heritage::new(ctx, &contexts);
-
-        if let Some((block_name, block_span)) = input.block {
-            if !heritage.blocks.contains_key(&block_name) {
-                return Err(CompileError::no_file_info(
-                    format_args!("cannot find block `{block_name}`"),
-                    Some(block_span),
-                ));
-            }
-        }
-
-        Some(heritage)
+        Some(Heritage::new(ctx, &contexts))
     } else {
         None
     };
+
+    if let Some((block_name, block_span)) = input.block {
+        let has_block = match &heritage {
+            Some(heritage) => heritage.blocks.contains_key(block_name),
+            None => ctx.blocks.contains_key(block_name),
+        };
+        if !has_block {
+            return Err(CompileError::no_file_info(
+                format_args!("cannot find block `{block_name}`"),
+                Some(block_span),
+            ));
+        }
+    }
 
     if input.print == Print::Ast || input.print == Print::All {
         eprintln!("{:?}", templates[&input.path].nodes());

--- a/testing/templates/no-block-with-base-template.txt
+++ b/testing/templates/no-block-with-base-template.txt
@@ -1,0 +1,1 @@
+{% extends "no-block-with-include-times-2.txt" %}

--- a/testing/templates/no-block-with-include-times-2.txt
+++ b/testing/templates/no-block-with-include-times-2.txt
@@ -1,0 +1,1 @@
+{% include "no-block-with-include.txt" %}

--- a/testing/templates/no-block-with-include.txt
+++ b/testing/templates/no-block-with-include.txt
@@ -1,0 +1,1 @@
+{% include "no-block.txt" %}

--- a/testing/tests/ui/no-block.rs
+++ b/testing/tests/ui/no-block.rs
@@ -1,0 +1,28 @@
+use rinja::Template;
+
+#[derive(Template)]
+#[template(
+    ext = "txt",
+    source = "{% block not_a %}{% endblock %}",
+    block = "a"
+)]
+struct SourceTemplate;
+
+#[derive(Template)]
+#[template(path = "no-block.txt", block = "a")]
+struct PathTemplate;
+
+#[derive(Template)]
+#[template(path = "no-block-with-include.txt", block = "a")]
+struct NoBlockWithInclude;
+
+#[derive(Template)]
+#[template(path = "no-block-with-include-times-2.txt", block = "a")]
+struct NoBlockWithIncludeTimes2;
+
+#[derive(Template)]
+#[template(path = "no-block-with-base-template.txt", block = "a")]
+struct NoBlockWithBaseTemplate;
+
+fn main() {
+}

--- a/testing/tests/ui/no-block.stderr
+++ b/testing/tests/ui/no-block.stderr
@@ -1,0 +1,29 @@
+error: cannot find block `a`
+ --> tests/ui/no-block.rs:7:13
+  |
+7 |     block = "a"
+  |             ^^^
+
+error: cannot find block `a`
+  --> tests/ui/no-block.rs:12:43
+   |
+12 | #[template(path = "no-block.txt", block = "a")]
+   |                                           ^^^
+
+error: cannot find block `a`
+  --> tests/ui/no-block.rs:16:56
+   |
+16 | #[template(path = "no-block-with-include.txt", block = "a")]
+   |                                                        ^^^
+
+error: cannot find block `a`
+  --> tests/ui/no-block.rs:20:64
+   |
+20 | #[template(path = "no-block-with-include-times-2.txt", block = "a")]
+   |                                                                ^^^
+
+error: cannot find block `a`
+  --> tests/ui/no-block.rs:24:62
+   |
+24 | #[template(path = "no-block-with-base-template.txt", block = "a")]
+   |                                                              ^^^


### PR DESCRIPTION
Previously it was only tested if the block exists if there were any blocks. If there weren't any, then an empty result would be rendered.

Fixes #336.