### PR TITLE
Allow parallel compilation of `serde` and `serde_derive`

### DIFF
--- a/rinja/Cargo.toml
+++ b/rinja/Cargo.toml
@@ -30,7 +30,7 @@ itoa = "1.0.11"
 
 # needed by feature "serde_json"
 serde = { version = "1.0", optional = true, default-features = false }
-serde_json = { version = "1.0", optional = true, default-features = false, features = [] }
+serde_json = { version = "1.0", optional = true, default-features = false }
 
 # needed by feature "urlencode"
 percent-encoding = { version = "2.1.0", optional = true, default-features = false }

--- a/rinja_derive/Cargo.toml
+++ b/rinja_derive/Cargo.toml
@@ -21,7 +21,8 @@ parser = { package = "rinja_parser", version = "=0.3.5", path = "../rinja_parser
 
 basic-toml = { version = "0.1.1", optional = true }
 pulldown-cmark = { version = "0.12.0", optional = true, default-features = false }
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }
 
 memchr = "2"
 quote = { version = "1", default-features = false }
@@ -41,7 +42,7 @@ syn = { version = "2.0.3", features = ["full"] }
 alloc = []
 blocks = ["syn/full"]
 code-in-doc = ["dep:pulldown-cmark"]
-config = ["dep:serde", "dep:basic-toml", "parser/config"]
+config = ["dep:basic-toml", "dep:serde", "dep:serde_derive", "parser/config"]
 urlencode = []
 serde_json = []
 std = ["alloc"]

--- a/rinja_derive/src/config.rs
+++ b/rinja_derive/src/config.rs
@@ -10,7 +10,7 @@ use parser::node::Whitespace;
 use parser::{ParseError, Parsed, Syntax, SyntaxBuilder};
 use proc_macro2::Span;
 #[cfg(feature = "config")]
-use serde::Deserialize;
+use serde_derive::Deserialize;
 
 use crate::{CompileError, FileInfo, OnceMap};
 
@@ -314,7 +314,7 @@ impl RawConfig<'_> {
     }
 }
 
-#[cfg_attr(feature = "config", derive(serde::Deserialize))]
+#[cfg_attr(feature = "config", derive(Deserialize))]
 struct General<'a> {
     #[cfg_attr(feature = "config", serde(borrow))]
     dirs: Option<Vec<&'a str>>,

--- a/rinja_derive_standalone/Cargo.toml
+++ b/rinja_derive_standalone/Cargo.toml
@@ -25,7 +25,8 @@ parser = { package = "rinja_parser", version = "=0.3.5", path = "../rinja_parser
 
 basic-toml = { version = "0.1.1", optional = true }
 pulldown-cmark = { version = "0.12.0", optional = true, default-features = false }
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }
 
 memchr = "2"
 quote = { version = "1", default-features = false }
@@ -48,7 +49,7 @@ __standalone = []
 
 blocks = ["syn/full"]
 code-in-doc = ["dep:pulldown-cmark"]
-config = ["dep:serde", "dep:basic-toml", "parser/config"]
+config = ["dep:basic-toml", "dep:serde", "dep:serde_derive", "parser/config"]
 urlencode = []
 serde_json = []
 

--- a/rinja_parser/Cargo.toml
+++ b/rinja_parser/Cargo.toml
@@ -22,11 +22,12 @@ harness = false
 
 [dependencies]
 memchr = "2"
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }
 winnow = "0.7.0"
 
 [dev-dependencies]
 criterion = "0.5"
 
 [features]
-config = ["dep:serde"]
+config = ["dep:serde", "dep:serde_derive"]

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -855,7 +855,7 @@ fn fmt_syntax(name: &str, inner: &InnerSyntax<'_>, f: &mut fmt::Formatter<'_>) -
 }
 
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq)]
-#[cfg_attr(feature = "config", derive(serde::Deserialize))]
+#[cfg_attr(feature = "config", derive(serde_derive::Deserialize))]
 pub struct SyntaxBuilder<'a> {
     pub name: &'a str,
     pub block_start: Option<&'a str>,

--- a/rinja_parser/src/node.rs
+++ b/rinja_parser/src/node.rs
@@ -447,7 +447,7 @@ impl<'a> CondTest<'a> {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, Debug, Hash)]
-#[cfg_attr(feature = "config", derive(serde::Deserialize))]
+#[cfg_attr(feature = "config", derive(serde_derive::Deserialize))]
 #[cfg_attr(feature = "config", serde(field_identifier, rename_all = "lowercase"))]
 pub enum Whitespace {
     #[default]


### PR DESCRIPTION
`cargo tree -p rinja -F full` master vs PR:

[![](https://i.ibb.co/C5PdNwLr/Bildschirmfoto-vom-2025-02-09-04-45-57.png)](https://ibb.co/tMLfkHRd)