### PR TITLE
Don't format with `overflow_delimited_expr`

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -3,7 +3,6 @@ group_imports = "StdExternalCrate"
 imports_granularity = "Module"
 newline_style = "Unix"
 normalize_comments = true
-overflow_delimited_expr = true
 style_edition = "2024"
 unstable_features = true
 use_field_init_shorthand = true

--- a/rinja/src/helpers.rs
+++ b/rinja/src/helpers.rs
@@ -44,11 +44,14 @@ where
     #[inline]
     fn next(&mut self) -> Option<(<I as Iterator>::Item, LoopItem)> {
         self.iter.next().map(|(index, item)| {
-            (item, LoopItem {
-                index,
-                first: index == 0,
-                last: self.iter.peek().is_none(),
-            })
+            (
+                item,
+                LoopItem {
+                    index,
+                    first: index == 0,
+                    last: self.iter.peek().is_none(),
+                },
+            )
         })
     }
 }

--- a/rinja_derive/src/config.rs
+++ b/rinja_derive/src/config.rs
@@ -645,19 +645,22 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(config.escapers, vec![
-            (str_set(&["js"]), "::my_filters::Js".into()),
-            (
-                str_set(&[
-                    "askama", "html", "htm", "j2", "jinja", "jinja2", "rinja", "svg", "xml"
-                ]),
-                "rinja::filters::Html".into()
-            ),
-            (
-                str_set(&["md", "none", "txt", "yml", ""]),
-                "rinja::filters::Text".into()
-            ),
-        ]);
+        assert_eq!(
+            config.escapers,
+            vec![
+                (str_set(&["js"]), "::my_filters::Js".into()),
+                (
+                    str_set(&[
+                        "askama", "html", "htm", "j2", "jinja", "jinja2", "rinja", "svg", "xml"
+                    ]),
+                    "rinja::filters::Html".into()
+                ),
+                (
+                    str_set(&["md", "none", "txt", "yml", ""]),
+                    "rinja::filters::Text".into()
+                ),
+            ]
+        );
     }
 
     #[cfg(feature = "config")]

--- a/rinja_derive/src/lib.rs
+++ b/rinja_derive/src/lib.rs
@@ -441,10 +441,14 @@ impl fmt::Display for FileInfo<'_> {
                 source_after = error_info.source_after,
             )
         } else {
-            write!(f, "\n --> {}", match std::env::current_dir() {
-                Ok(cwd) => fmt_left!(move "{}", strip_common(&cwd, self.path)),
-                Err(_) => fmt_right!("{}", self.path.display()),
-            })
+            write!(
+                f,
+                "\n --> {}",
+                match std::env::current_dir() {
+                    Ok(cwd) => fmt_left!(move "{}", strip_common(&cwd, self.path)),
+                    Err(_) => fmt_right!("{}", self.path.display()),
+                }
+            )
         }
     }
 }

--- a/rinja_parser/src/lib.rs
+++ b/rinja_parser/src/lib.rs
@@ -1417,10 +1417,13 @@ mod test {
         // Check with `b` prefix.
         assert_eq!(
             char_lit.parse_peek("b'a'").unwrap(),
-            ("", crate::CharLit {
-                prefix: Some(crate::CharPrefix::Binary),
-                content: "a"
-            })
+            (
+                "",
+                crate::CharLit {
+                    prefix: Some(crate::CharPrefix::Binary),
+                    content: "a"
+                }
+            )
         );
 
         // Should fail.
@@ -1438,17 +1441,23 @@ mod test {
     fn test_str_lit() {
         assert_eq!(
             str_lit.parse_peek(r#"b"hello""#).unwrap(),
-            ("", StrLit {
-                prefix: Some(StrPrefix::Binary),
-                content: "hello"
-            })
+            (
+                "",
+                StrLit {
+                    prefix: Some(StrPrefix::Binary),
+                    content: "hello"
+                }
+            )
         );
         assert_eq!(
             str_lit.parse_peek(r#"c"hello""#).unwrap(),
-            ("", StrLit {
-                prefix: Some(StrPrefix::CLike),
-                content: "hello"
-            })
+            (
+                "",
+                StrLit {
+                    prefix: Some(StrPrefix::CLike),
+                    content: "hello"
+                }
+            )
         );
         assert!(str_lit.parse_peek(r#"d"hello""#).is_err());
     }

--- a/rinja_parser/src/tests.rs
+++ b/rinja_parser/src/tests.rs
@@ -121,9 +121,13 @@ fn test_parse_numbers() {
 fn test_parse_var() {
     let s = Syntax::default();
 
-    assert_eq!(Ast::from_str("{{ foo }}", None, &s).unwrap().nodes, vec![
-        Node::Expr(Ws(None, None), WithSpan::no_span(Expr::Var("foo")))
-    ]);
+    assert_eq!(
+        Ast::from_str("{{ foo }}", None, &s).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            WithSpan::no_span(Expr::Var("foo"))
+        )]
+    );
     assert_eq!(
         Ast::from_str("{{ foo_bar }}", None, &s).unwrap().nodes,
         vec![Node::Expr(
@@ -132,18 +136,26 @@ fn test_parse_var() {
         )],
     );
 
-    assert_eq!(Ast::from_str("{{ none }}", None, &s).unwrap().nodes, vec![
-        Node::Expr(Ws(None, None), WithSpan::no_span(Expr::Var("none")))
-    ]);
+    assert_eq!(
+        Ast::from_str("{{ none }}", None, &s).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            WithSpan::no_span(Expr::Var("none"))
+        )]
+    );
 }
 
 #[test]
 fn test_parse_const() {
     let s = Syntax::default();
 
-    assert_eq!(Ast::from_str("{{ FOO }}", None, &s).unwrap().nodes, vec![
-        Node::Expr(Ws(None, None), WithSpan::no_span(Expr::Path(vec!["FOO"])))
-    ]);
+    assert_eq!(
+        Ast::from_str("{{ FOO }}", None, &s).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            WithSpan::no_span(Expr::Path(vec!["FOO"]))
+        )]
+    );
     assert_eq!(
         Ast::from_str("{{ FOO_BAR }}", None, &s).unwrap().nodes,
         vec![Node::Expr(
@@ -152,18 +164,26 @@ fn test_parse_const() {
         )],
     );
 
-    assert_eq!(Ast::from_str("{{ NONE }}", None, &s).unwrap().nodes, vec![
-        Node::Expr(Ws(None, None), WithSpan::no_span(Expr::Path(vec!["NONE"])))
-    ]);
+    assert_eq!(
+        Ast::from_str("{{ NONE }}", None, &s).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            WithSpan::no_span(Expr::Path(vec!["NONE"]))
+        )]
+    );
 }
 
 #[test]
 fn test_parse_path() {
     let s = Syntax::default();
 
-    assert_eq!(Ast::from_str("{{ None }}", None, &s).unwrap().nodes, vec![
-        Node::Expr(Ws(None, None), WithSpan::no_span(Expr::Path(vec!["None"])))
-    ]);
+    assert_eq!(
+        Ast::from_str("{{ None }}", None, &s).unwrap().nodes,
+        vec![Node::Expr(
+            Ws(None, None),
+            WithSpan::no_span(Expr::Path(vec!["None"]))
+        )]
+    );
     assert_eq!(
         Ast::from_str("{{ Some(123) }}", None, &s).unwrap().nodes,
         vec![Node::Expr(
@@ -325,36 +345,41 @@ fn test_rust_macro() {
             WithSpan::no_span(Expr::RustMacro(vec!["alloc", "vec"], "1, 2, 3")),
         )],
     );
-    assert_eq!(Ast::from_str("{{a!()}}", None, &syntax).unwrap().nodes, [
-        Node::Expr(
+    assert_eq!(
+        Ast::from_str("{{a!()}}", None, &syntax).unwrap().nodes,
+        [Node::Expr(
             Ws(None, None),
             WithSpan::no_span(Expr::RustMacro(vec!["a"], ""))
-        )
-    ]);
-    assert_eq!(Ast::from_str("{{a !()}}", None, &syntax).unwrap().nodes, [
-        Node::Expr(
+        )]
+    );
+    assert_eq!(
+        Ast::from_str("{{a !()}}", None, &syntax).unwrap().nodes,
+        [Node::Expr(
             Ws(None, None),
             WithSpan::no_span(Expr::RustMacro(vec!["a"], ""))
-        )
-    ]);
-    assert_eq!(Ast::from_str("{{a! ()}}", None, &syntax).unwrap().nodes, [
-        Node::Expr(
+        )]
+    );
+    assert_eq!(
+        Ast::from_str("{{a! ()}}", None, &syntax).unwrap().nodes,
+        [Node::Expr(
             Ws(None, None),
             WithSpan::no_span(Expr::RustMacro(vec!["a"], ""))
-        )
-    ]);
-    assert_eq!(Ast::from_str("{{a ! ()}}", None, &syntax).unwrap().nodes, [
-        Node::Expr(
+        )]
+    );
+    assert_eq!(
+        Ast::from_str("{{a ! ()}}", None, &syntax).unwrap().nodes,
+        [Node::Expr(
             Ws(None, None),
             WithSpan::no_span(Expr::RustMacro(vec!["a"], ""))
-        )
-    ]);
-    assert_eq!(Ast::from_str("{{A!()}}", None, &syntax).unwrap().nodes, [
-        Node::Expr(
+        )]
+    );
+    assert_eq!(
+        Ast::from_str("{{A!()}}", None, &syntax).unwrap().nodes,
+        [Node::Expr(
             Ws(None, None),
             WithSpan::no_span(Expr::RustMacro(vec!["A"], ""))
-        )
-    ]);
+        )]
+    );
     assert_eq!(
         &*Ast::from_str("{{a.b.c!( hello )}}", None, &syntax)
             .unwrap_err()
@@ -1103,30 +1128,48 @@ fn fuzzed_excessive_syntax_lengths() {
         Some("\0]***NEWFILE\u{1f}***:7/v/.-3/\u{1b}/~~~~z~0/*:7/v/./t/t/.p//NEWVILE**::7/v");
 
     for (kind, syntax_builder) in [
-        ("opening block", SyntaxBuilder {
-            block_start: LONG_DELIM,
-            ..SyntaxBuilder::default()
-        }),
-        ("closing block", SyntaxBuilder {
-            block_end: LONG_DELIM,
-            ..SyntaxBuilder::default()
-        }),
-        ("opening expression", SyntaxBuilder {
-            expr_start: LONG_DELIM,
-            ..SyntaxBuilder::default()
-        }),
-        ("closing expression", SyntaxBuilder {
-            expr_end: LONG_DELIM,
-            ..SyntaxBuilder::default()
-        }),
-        ("opening comment", SyntaxBuilder {
-            comment_start: LONG_DELIM,
-            ..SyntaxBuilder::default()
-        }),
-        ("closing comment", SyntaxBuilder {
-            comment_end: LONG_DELIM,
-            ..SyntaxBuilder::default()
-        }),
+        (
+            "opening block",
+            SyntaxBuilder {
+                block_start: LONG_DELIM,
+                ..SyntaxBuilder::default()
+            },
+        ),
+        (
+            "closing block",
+            SyntaxBuilder {
+                block_end: LONG_DELIM,
+                ..SyntaxBuilder::default()
+            },
+        ),
+        (
+            "opening expression",
+            SyntaxBuilder {
+                expr_start: LONG_DELIM,
+                ..SyntaxBuilder::default()
+            },
+        ),
+        (
+            "closing expression",
+            SyntaxBuilder {
+                expr_end: LONG_DELIM,
+                ..SyntaxBuilder::default()
+            },
+        ),
+        (
+            "opening comment",
+            SyntaxBuilder {
+                comment_start: LONG_DELIM,
+                ..SyntaxBuilder::default()
+            },
+        ),
+        (
+            "closing comment",
+            SyntaxBuilder {
+                comment_end: LONG_DELIM,
+                ..SyntaxBuilder::default()
+            },
+        ),
     ] {
         let err = syntax_builder.to_syntax().unwrap_err();
         assert_eq!(


### PR DESCRIPTION
The default value for `overflow_delimited_expr = true` was reverted to `false`: [rust-lang/rust#136312].

[rust-lang/rust#136312]: https://redirect.github.com/rust-lang/rust/pull/136312