### PR TITLE
Added support for typst in default text escapers

### DIFF
--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -373,7 +373,7 @@ static DEFAULT_ESCAPERS: &[(&[&str], &str)] = &[
         ],
         "Html",
     ),
-    (&["md", "none", "txt", "yml", ""], "Text"),
+    (&["md", "none", "txt", "typ", "yml", ""], "Text"),
 ];
 
 #[cfg(test)]
@@ -656,7 +656,7 @@ mod tests {
                     "askama::filters::Html".into()
                 ),
                 (
-                    str_set(&["md", "none", "txt", "yml", ""]),
+                    str_set(&["md", "none", "txt", "typ", "yml", ""]),
                     "askama::filters::Text".into()
                 ),
             ]


### PR DESCRIPTION
I did this exact Pull Request in what today is named 'askama-old' repository. These changes were successfully merged; however, they occurred after Rinja's fork, which means they are missing from the current codebase.