### PR TITLE
derive: don't suppress fatal errors in integer parsing

### DIFF
--- a/askama_parser/src/lib.rs
+++ b/askama_parser/src/lib.rs
@@ -476,7 +476,7 @@ fn num_lit<'a>(i: &mut &'a str) -> ParseResult<'a, Num<'a>> {
         }
     };
 
-    let num = if let Ok(Some(num)) = opt(int_with_base.take()).parse_next(i) {
+    let num = if let Some(num) = opt(int_with_base.take()).parse_next(i)? {
         let suffix =
             opt(|i: &mut _| num_lit_suffix("integer", INTEGER_TYPES, start, i)).parse_next(i)?;
         Num::Int(num, suffix)

--- a/askama_parser/src/tests.rs
+++ b/askama_parser/src/tests.rs
@@ -1415,3 +1415,11 @@ fn underscore_is_an_identifier() {
     assert_eq!(result.unwrap(), "_");
     assert_eq!(input, "");
 }
+
+#[test]
+fn there_is_no_digit_two_in_a_binary_integer() {
+    let syntax = Syntax::default();
+    assert!(Ast::from_str("{{ 0b2 }}", None, &syntax).is_err());
+    assert!(Ast::from_str("{{ 0o9 }}", None, &syntax).is_err());
+    assert!(Ast::from_str("{{ 0xg }}", None, &syntax).is_err());
+}


### PR DESCRIPTION
Fixes <https://github.com/askama-rs/askama/issues/445>.