### PR TITLE
parser: simplify `{# comment #}` parsing

### DIFF
--- a/askama_parser/src/memchr_splitter.rs
+++ b/askama_parser/src/memchr_splitter.rs
@@ -59,7 +59,6 @@ macro_rules! new_memchr_type {
 }
 
 new_memchr_type!(Splitter1 split1_unchecked memchr a);
-new_memchr_type!(Splitter2 split2_unchecked memchr2 a b);
 new_memchr_type!(Splitter3 split3_unchecked memchr3 a b c);
 
 #[test]
@@ -69,12 +68,6 @@ fn candidate_finder() {
         Some(("abc", "tefg")),
     );
     assert_eq!(Splitter1::new("xyz").split("abctefg"), None);
-
-    assert_eq!(
-        Splitter2::new("xyz", "foo").split("abctefg"),
-        Some(("abcte", "fg")),
-    );
-    assert_eq!(Splitter2::new("oof", "xyz").split("abctefg"), None);
 
     assert_eq!(
         Splitter3::new("oof", "apples", "xyz").split("abctefg"),

--- a/testing/tests/ui/unclosed-nodes.stderr
+++ b/testing/tests/ui/unclosed-nodes.stderr
@@ -63,32 +63,32 @@ error: failed to parse template source
    |                     ^^^^^^^^^^^^^
 
 error: unclosed comment, missing "#}"
- --> <source attribute>:1:2
-       " comment"
+ --> <source attribute>:1:0
+       "{# comment"
   --> tests/ui/unclosed-nodes.rs:36:21
    |
 36 | #[template(source = "{# comment", ext = "txt")]
    |                     ^^^^^^^^^^^^
 
 error: unclosed comment, missing "#}"
- --> <source attribute>:1:2
-       " comment "
+ --> <source attribute>:1:0
+       "{# comment "
   --> tests/ui/unclosed-nodes.rs:40:21
    |
 40 | #[template(source = "{# comment ", ext = "txt")]
    |                     ^^^^^^^^^^^^^
 
 error: unclosed comment, missing "#}"
- --> <source attribute>:1:2
-       " comment -"
+ --> <source attribute>:1:0
+       "{# comment -"
   --> tests/ui/unclosed-nodes.rs:44:21
    |
 44 | #[template(source = "{# comment -", ext = "txt")]
    |                     ^^^^^^^^^^^^^^
 
 error: unclosed comment, missing "#}"
- --> <source attribute>:1:2
-       " comment -#"
+ --> <source attribute>:1:0
+       "{# comment -#"
   --> tests/ui/unclosed-nodes.rs:48:21
    |
 48 | #[template(source = "{# comment -#", ext = "txt")]


### PR DESCRIPTION
`winnow`'s `take_until` with feature `simd` enabled is implemented like our "optimized" `skip_till`. There is no need to reinvent the wheel.

I intend to remove our home-grown `skip_till` / `memchr_splitter.rs` in subsequent PRs.