### PR TITLE
Fix #563: filesizeformat with proper accuracy

### DIFF
--- a/askama/src/filters/humansize.rs
+++ b/askama/src/filters/humansize.rs
@@ -1,8 +1,6 @@
 use core::convert::Infallible;
 use core::fmt;
-use core::mem::MaybeUninit;
 
-use crate::ascii_str::{AsciiChar, AsciiStr};
 use crate::{FastWritable, NO_VALUES, Values};
 
 /// Returns adequate string representation (in KB, ..) of number of bytes
@@ -12,7 +10,7 @@ use crate::{FastWritable, NO_VALUES, Values};
 /// # use askama::Template;
 /// #[derive(Template)]
 /// #[template(
-///     source = "Filesize: {{ size_in_bytes|filesizeformat }}.",
+///     source = "Filesize: {{ size_in_bytes | filesizeformat }}.",
 ///     ext = "html"
 /// )]
 /// struct Example {
@@ -23,12 +21,18 @@ use crate::{FastWritable, NO_VALUES, Values};
 /// assert_eq!(tmpl.to_string(),  "Filesize: 1.23 MB.");
 /// ```
 #[inline]
-pub fn filesizeformat(b: f32) -> Result<FilesizeFormatFilter, Infallible> {
-    Ok(FilesizeFormatFilter(b))
+pub fn filesizeformat(bytes: u128, precision: u8) -> Result<FilesizeFormatFilter, Infallible> {
+    Ok(FilesizeFormatFilter { bytes, precision })
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct FilesizeFormatFilter(f32);
+pub struct FilesizeFormatFilter {
+    /// The number of bytes to format nicely
+    bytes: u128,
+    /// The precision with which to display the generated string.
+    /// This determines the number of digits after the decimal separator.
+    precision: u8,
+}
 
 impl fmt::Display for FilesizeFormatFilter {
     #[inline]
@@ -43,82 +47,211 @@ impl FastWritable for FilesizeFormatFilter {
         dest: &mut W,
         values: &dyn Values,
     ) -> crate::Result<()> {
-        if self.0 < 1e3 {
-            (self.0 as u32).write_into(dest, values)?;
-            Ok(dest.write_str(" B")?)
-        } else if let Some((prefix, factor)) = SI_PREFIXES
+        if self.bytes < 1000 {
+            (self.bytes as u32).write_into(dest, values)?;
+            return Ok(dest.write_str(" B")?);
+        }
+
+        // find appropriate unit to format in
+        let unit = SI_PREFIXES
             .iter()
-            .copied()
-            .find_map(|(prefix_factor, max)| (self.0 < max).then_some(prefix_factor))
-        {
-            // u32 is big enough to hold the number 999_999
-            let scaled = (self.0 * factor) as u32;
-            (scaled / 100).write_into(dest, values)?;
-            format_frac(&mut MaybeUninit::uninit(), prefix, scaled).write_into(dest, values)
-        } else {
-            too_big(self.0, dest)
+            .take_while(|siprefix| siprefix.lower_bound <= self.bytes)
+            .last()
+            .unwrap_or(&SI_PREFIXES[SI_PREFIXES.len() - 1]);
+        // divide number up into "full" units, and remainder
+        let integer = self.bytes / unit.lower_bound;
+        let remainder = self.bytes % unit.lower_bound;
+
+        // Compute fractional part with desired precision
+        // limit precision to the chosen unit's exponent - a greater precision will just
+        // generated tailing 0s that will be dropped.
+        let precision = self.precision.min(unit.exponent);
+
+        // integer portion (before decimal point)
+        integer.write_into(dest, values)?;
+        if precision > 0 {
+            let mut scale = 10u128.pow(precision as u32);
+            let mut fractional = remainder.saturating_mul(scale) / unit.lower_bound;
+            if fractional > 0 {
+                '.'.write_into(dest, values)?;
+                for _ in 0..precision {
+                    scale /= 10;
+                    let digit = (b'0' + (fractional / scale) as u8) as char;
+                    digit.write_into(dest, values)?;
+                    fractional %= scale;
+                    if fractional == 0 {
+                        break;
+                    }
+                }
+            }
+        }
+        ' '.write_into(dest, values)?;
+        unit.prefix_char.write_into(dest, values)?;
+        'B'.write_into(dest, values)?;
+
+        Ok(())
+    }
+}
+
+struct SiPrefix {
+    /// SI-prefix character that is prepended to the unit (B) as scaler.
+    prefix_char: char,
+    /// The smallest number of bytes that will be represented using this si-prefix.
+    /// This is 10 ^ self.exponent
+    lower_bound: u128,
+    /// The exponent (10 ^ exponent) that calculates this si-prefix's lower bound.
+    exponent: u8,
+}
+impl SiPrefix {
+    const fn new(prefix_char: char, exponent: u8) -> Self {
+        Self {
+            prefix_char,
+            lower_bound: 10u128.pow(exponent as u32),
+            exponent,
         }
     }
 }
 
-/// Formats `buffer` to contain the decimal point, decimal places and unit
-fn format_frac(buffer: &mut MaybeUninit<[AsciiChar; 8]>, prefix: AsciiChar, scaled: u32) -> &str {
-    // LLVM generates better byte code for register sized buffers
-    let buffer = buffer.write(AsciiStr::new_sized("..0 kB"));
-    buffer[4] = prefix;
-
-    let frac = scaled % 100;
-    let buffer = if frac == 0 {
-        &buffer[3..6]
-    } else {
-        let digits = AsciiChar::two_digits(frac);
-        if digits[1] == AsciiChar::new(b'0') {
-            // the decimal separator '.' is already contained in buffer[1]
-            buffer[2] = digits[0];
-            &buffer[1..6]
-        } else {
-            // the decimal separator '.' is already contained in buffer[0]
-            [buffer[1], buffer[2]] = digits;
-            &buffer[0..6]
-        }
-    };
-    AsciiStr::from_slice(buffer).as_str()
-}
-
-#[cold]
-fn too_big<W: fmt::Write + ?Sized>(value: f32, dest: &mut W) -> crate::Result<()> {
-    // the value exceeds 999 QB, so we omit the decimal places
-    Ok(write!(dest, "{:.0} QB", value / 1e30)?)
-}
-
-/// `((si_prefix, factor), limit)`, the factor is offset by 10**2 to account for 2 decimal places
-const SI_PREFIXES: &[((AsciiChar, f32), f32)] = &[
-    ((AsciiChar::new(b'k'), 1e-1), 1e6),
-    ((AsciiChar::new(b'M'), 1e-4), 1e9),
-    ((AsciiChar::new(b'G'), 1e-7), 1e12),
-    ((AsciiChar::new(b'T'), 1e-10), 1e15),
-    ((AsciiChar::new(b'P'), 1e-13), 1e18),
-    ((AsciiChar::new(b'E'), 1e-16), 1e21),
-    ((AsciiChar::new(b'Z'), 1e-19), 1e24),
-    ((AsciiChar::new(b'Y'), 1e-22), 1e27),
-    ((AsciiChar::new(b'R'), 1e-25), 1e30),
-    ((AsciiChar::new(b'Q'), 1e-28), 1e33),
+/// The set of supported SI-Prefixes.
+/// The fitting prefix for a given number of bytes is selected by choosing the prefix with
+/// the highest lower_bound, that is lower than the number of bytes.
+const SI_PREFIXES: &[SiPrefix] = &[
+    SiPrefix::new('k', 3),
+    SiPrefix::new('M', 6),
+    SiPrefix::new('G', 9),
+    SiPrefix::new('T', 12),
+    SiPrefix::new('P', 15),
+    SiPrefix::new('E', 18),
+    SiPrefix::new('Z', 21),
+    SiPrefix::new('Y', 24),
+    SiPrefix::new('R', 27),
+    SiPrefix::new('Q', 30),
 ];
 
 #[test]
 #[cfg(feature = "alloc")]
-fn test_filesizeformat() {
+fn test_filesizeformat_edgecases() {
     use alloc::string::ToString;
 
-    assert_eq!(filesizeformat(0.).unwrap().to_string(), "0 B");
-    assert_eq!(filesizeformat(999.).unwrap().to_string(), "999 B");
-    assert_eq!(filesizeformat(1000.).unwrap().to_string(), "1 kB");
-    assert_eq!(filesizeformat(1023.).unwrap().to_string(), "1.02 kB");
-    assert_eq!(filesizeformat(1024.).unwrap().to_string(), "1.02 kB");
-    assert_eq!(filesizeformat(1100.).unwrap().to_string(), "1.1 kB");
-    assert_eq!(filesizeformat(9_499_014.).unwrap().to_string(), "9.49 MB");
+    assert_eq!(filesizeformat(1000, 0).unwrap().to_string(), "1 kB");
+
     assert_eq!(
-        filesizeformat(954_548_589.2).unwrap().to_string(),
+        filesizeformat(954_548_589_125_249_215_468, 0)
+            .unwrap()
+            .to_string(),
+        "954 EB"
+    );
+    assert_eq!(
+        filesizeformat(954_548_589_125_249_215_468, 10)
+            .unwrap()
+            .to_string(),
+        "954.5485891252 EB"
+    );
+    assert_eq!(
+        filesizeformat(954_548_589_125_249_215_468, 255)
+            .unwrap()
+            .to_string(),
+        "954.548589125249215468 EB"
+    );
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn test_filesizeformat_prec2() {
+    use alloc::string::ToString;
+
+    assert_eq!(filesizeformat(0, 2).unwrap().to_string(), "0 B");
+    assert_eq!(filesizeformat(999, 2).unwrap().to_string(), "999 B");
+    assert_eq!(filesizeformat(1000, 2).unwrap().to_string(), "1 kB");
+    assert_eq!(filesizeformat(1023, 2).unwrap().to_string(), "1.02 kB");
+    assert_eq!(filesizeformat(1024, 2).unwrap().to_string(), "1.02 kB");
+    assert_eq!(filesizeformat(1025, 2).unwrap().to_string(), "1.02 kB");
+    assert_eq!(filesizeformat(1100, 2).unwrap().to_string(), "1.1 kB");
+    assert_eq!(filesizeformat(9_499_014, 2).unwrap().to_string(), "9.49 MB");
+    assert_eq!(
+        filesizeformat(954_548_589, 2).unwrap().to_string(),
         "954.54 MB"
+    );
+    assert_eq!(
+        filesizeformat(300_000_000_000, 2).unwrap().to_string(),
+        "300 GB"
+    );
+    assert_eq!(
+        filesizeformat(600_000_000_000, 2).unwrap().to_string(),
+        "600 GB"
+    );
+    assert_eq!(
+        filesizeformat(7_000_000_000_000, 2).unwrap().to_string(),
+        "7 TB"
+    );
+    assert_eq!(
+        filesizeformat(2_300_000_000_000_000, 2)
+            .unwrap()
+            .to_string(),
+        "2.3 PB"
+    );
+    assert_eq!(
+        filesizeformat(9_900_000_000_000_000_000, 2)
+            .unwrap()
+            .to_string(),
+        "9.9 EB"
+    );
+    assert_eq!(
+        filesizeformat(4_500_000_000_000_000_000_000, 2)
+            .unwrap()
+            .to_string(),
+        "4.5 ZB"
+    );
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn test_filesizeformat_prec3() {
+    use alloc::string::ToString;
+
+    assert_eq!(filesizeformat(0, 3).unwrap().to_string(), "0 B");
+    assert_eq!(filesizeformat(999, 3).unwrap().to_string(), "999 B");
+    assert_eq!(filesizeformat(1000, 3).unwrap().to_string(), "1 kB");
+    assert_eq!(filesizeformat(1023, 3).unwrap().to_string(), "1.023 kB");
+    assert_eq!(filesizeformat(1024, 3).unwrap().to_string(), "1.024 kB");
+    assert_eq!(filesizeformat(1025, 3).unwrap().to_string(), "1.025 kB");
+    assert_eq!(filesizeformat(1100, 3).unwrap().to_string(), "1.1 kB");
+    assert_eq!(
+        filesizeformat(9_499_014, 3).unwrap().to_string(),
+        "9.499 MB"
+    );
+    assert_eq!(
+        filesizeformat(954_548_589, 3).unwrap().to_string(),
+        "954.548 MB"
+    );
+    assert_eq!(
+        filesizeformat(300_000_000_000, 3).unwrap().to_string(),
+        "300 GB"
+    );
+    assert_eq!(
+        filesizeformat(600_000_000_000, 3).unwrap().to_string(),
+        "600 GB"
+    );
+    assert_eq!(
+        filesizeformat(7_000_000_000_000, 3).unwrap().to_string(),
+        "7 TB"
+    );
+    assert_eq!(
+        filesizeformat(2_300_000_000_000_000, 3)
+            .unwrap()
+            .to_string(),
+        "2.3 PB"
+    );
+    assert_eq!(
+        filesizeformat(9_900_000_000_000_000_000, 3)
+            .unwrap()
+            .to_string(),
+        "9.9 EB"
+    );
+    assert_eq!(
+        filesizeformat(4_500_000_000_000_000_000_000, 3)
+            .unwrap()
+            .to_string(),
+        "4.5 ZB"
     );
 }

--- a/book/src/filters.md
+++ b/book/src/filters.md
@@ -226,12 +226,23 @@ Escape &lt;&gt;&amp;
 Returns adequate string representation (in KB, ..) of number of bytes:
 
 ```jinja
-{{ 1000 | filesizeformat }}
+{{ 1024 | filesizeformat }}
 ```
 
 Output:
 ```text
-1 KB
+1.02 KB
+```
+
+Control the resulting precision with the optional `precision` argument:
+
+```jinja
+{{ 1024 | filesizeformat(precision = 3) }}
+```
+
+Output:
+```text
+1.024 KB
 ```
 
 ### fmt

--- a/fuzzing/fuzz/src/filters.rs
+++ b/fuzzing/fuzz/src/filters.rs
@@ -63,7 +63,9 @@ fn run_text(filter: Text<'_>) -> Result<(), askama::Error> {
         TextFilter::Urlencode => filters::urlencode(input)?.to_dev_null(),
         TextFilter::UrlencodeStrict => filters::urlencode_strict(input)?.to_dev_null(),
         TextFilter::Escape(escaper) => filters::escape(input, escaper)?.to_dev_null(),
-        TextFilter::Filesizeformat(size) => filters::filesizeformat(size)?.to_dev_null(),
+        TextFilter::Filesizeformat(size, precision) => {
+            filters::filesizeformat(size, precision)?.to_dev_null()
+        }
         TextFilter::Json => filters::json(input)?.to_dev_null(),
         TextFilter::JsonPretty(prefix) => filters::json_pretty(input, prefix)?.to_dev_null(),
     };
@@ -95,7 +97,9 @@ impl fmt::Display for Text<'_> {
             TextFilter::Urlencode => format!("urlencode({input:?})"),
             TextFilter::UrlencodeStrict => format!("urlencode_strict({input:?})"),
             TextFilter::Escape(e) => format!("escape({input:?}, {e})"),
-            TextFilter::Filesizeformat(size) => format!("filesizeformat({size:?})"),
+            TextFilter::Filesizeformat(size, precision) => {
+                format!("filesizeformat({size:?}, {precision:?})")
+            }
             TextFilter::Json => format!("json({input:?})"),
             TextFilter::JsonPretty(prefix) => format!("json_pretty({input:?}, {prefix})"),
         };
@@ -175,7 +179,7 @@ enum TextFilter<'a> {
     Urlencode,
     UrlencodeStrict,
     Escape(Escaper),
-    Filesizeformat(f32),
+    Filesizeformat(u128, u8),
     Json,
     JsonPretty(Prefix<'a>),
 }

--- a/testing/tests/filters.rs
+++ b/testing/tests/filters.rs
@@ -453,7 +453,7 @@ fn test_linebreaks() {
 fn test_filesizeformat() {
     #[derive(Template)]
     #[template(
-        source = r#"{% if let Some(x) = s %}{{x|filesizeformat}}{% endif %}"#,
+        source = r#"{% if let Some(x) = s %}{{ x | filesizeformat }}{% endif %}"#,
         ext = "html"
     )]
     struct S {
@@ -461,6 +461,15 @@ fn test_filesizeformat() {
     }
 
     assert_eq!(S { s: Some(12) }.render().unwrap(), "12 B");
+}
+
+#[test]
+fn test_filesizeformat_with_precision() {
+    #[derive(Template)]
+    #[template(source = r#"{{ 1024 | filesizeformat(precision = 3) }}"#, ext = "html")]
+    struct FileSizeFormatPrecision {}
+
+    assert_eq!(FileSizeFormatPrecision {}.render().unwrap(), "1.024 kB");
 }
 
 #[test]


### PR DESCRIPTION
I refactored the current `humansize` / `filesize` implementation from `f32` to `u128` and added more unit-tests.
Additionally, the new refactoring now allows changing the requested precision (not yet plumbed on the code generation side).

`u128` is required to handle the SI Prefixes:
```rust
    ((AsciiChar::new(b'Z'), 1e-19), 1e24),
    ((AsciiChar::new(b'Y'), 1e-22), 1e27),
    ((AsciiChar::new(b'R'), 1e-25), 1e30),
    ((AsciiChar::new(b'Q'), 1e-28), 1e33),
```

Getting something as performant as the original version is quite challenging. Here are my benchmark results for the current solution:

Benchmarks (time for `250000000` format & display invocations):
- Original (`f32`): `1.9542559s`
- This MR, but with `u64`: `2.638588188s`
- This MR (`u128`): `3.29419516s`