### PR TITLE
filter_fn: Further improve invalid invocation compile error messages

### DIFF
--- a/askama/src/filters/mod.rs
+++ b/askama/src/filters/mod.rs
@@ -59,3 +59,17 @@ const MAX_LEN: usize = 10_000;
 pub trait ValidArgIdx<const IDX: usize> {
     const VALID: bool = true;
 }
+
+/// Internal marker trait that is used by the `filter_fn` proc-macro to produce nicer error messages
+/// too few arguments were passed to a filter invocation.
+#[doc(hidden)]
+#[diagnostic::on_unimplemented(
+    message = "Invalid filter function invocation. Not all required arguments were supplied.",
+    label = "Filter function"
+)]
+pub trait ValidFilterInvocation: Sized {
+    #[inline(always)]
+    fn wrap(self) -> Self {
+        self
+    }
+}

--- a/askama_derive/src/filter_fn.rs
+++ b/askama_derive/src/filter_fn.rs
@@ -576,10 +576,12 @@ impl FilterSignature {
         let required_args = self.args_required.iter().map(|a| &a.ident);
         let optional_args = self.args_optional.iter().map(|a| &a.ident);
 
+        let impl_generics = quote! { #(#required_generics: #required_generic_bounds,)* };
+        let impl_struct_generics = quote! { '_, #(#required_generics,)* #(#required_flags,)* };
         quote! {
             // if all required arguments have been supplied (P0 == true, P1 == true)
             // ... the execute() method is "unlocked":
-            impl<#(#required_generics: #required_generic_bounds,)*> #ident<'_, #(#required_generics,)* #(#required_flags,)*> {
+            impl<#impl_generics> #ident<#impl_struct_generics> {
                 #[inline(always)]
                 pub fn execute<#(#input_bounds,)*>(self, #input_ident: #input_ty, #env_ident: #env_ty) #result_ty {
                     // map filter variables with original name into scope
@@ -589,6 +591,8 @@ impl FilterSignature {
                     #filter_impl
                 }
             }
+
+            impl<#impl_generics> askama::filters::ValidFilterInvocation for #ident<#impl_struct_generics> {}
         }
     }
 }

--- a/askama_derive/src/generator/filter.rs
+++ b/askama_derive/src/generator/filter.rs
@@ -132,12 +132,13 @@ impl<'a> Generator<'a, '_> {
         let input_expr = self.visit_arg(ctx, &args[0], ctx.span_for_node(args[0].span()))?;
         let var_values = crate::var_values();
 
-        quote_into!(buf, span, { {
+        quote_into!(buf, span, {{
             #assertion_block
-            #filter_path::default()
-                #arg_setter_invocations
-                .execute(#input_expr, #var_values)?}
-        });
+            askama::filters::ValidFilterInvocation::wrap(
+                #filter_path::default()
+                    #arg_setter_invocations
+            ).execute(#input_expr, #var_values)?
+        }});
 
         Ok(DisplayWrap::Unwrapped)
     }

--- a/askama_derive/src/tests.rs
+++ b/askama_derive/src/tests.rs
@@ -1205,7 +1205,10 @@ fn test_filter_with_path() {
         r#"
         match (
             &((&&askama::filters::AutoEscaper::new(
-                &({ b::c::d::default().execute(&(self.a), __askama_values)? }),
+                &({
+                    askama::filters::ValidFilterInvocation::wrap(b::c::d::default())
+                        .execute(&(self.a), __askama_values)?
+                }),
                 askama::filters::Text,
             ))
                 .askama_auto_escape()?),
@@ -1463,7 +1466,12 @@ fn regression_tests_span_change() {
             __askama_writer.write_str("Hello, ")?;
             match (
                 &((&&askama::filters::AutoEscaper::new(
-                    &({ filters::cased::default().execute(&(self.user), __askama_values)? }),
+                &({
+                    askama::filters::ValidFilterInvocation::wrap(
+                            filters::cased::default(),
+                        )
+                        .execute(&(self.user), __askama_values)?
+                }),
                     askama::filters::Text,
                 ))
                     .askama_auto_escape()?),
@@ -1484,7 +1492,12 @@ fn regression_tests_span_change() {
             __askama_writer.write_str("Hello, ")?;
             match (
                 &((&&askama::filters::AutoEscaper::new(
-                    &({ filters::cased::default().execute(&(self.user), __askama_values)? }),
+                &({
+                    askama::filters::ValidFilterInvocation::wrap(
+                            filters::cased::default(),
+                        )
+                        .execute(&(self.user), __askama_values)?
+                }),
                     askama::filters::Text,
                 ))
                     .askama_auto_escape()?),

--- a/testing/tests/ui/filter-invocation-invalid-arguments.rs
+++ b/testing/tests/ui/filter-invocation-invalid-arguments.rs
@@ -2,12 +2,19 @@ use askama::Template;
 
 mod filters {
     #[askama::filter_fn]
-    pub fn noargs(input: impl std::fmt::Display, _env: &dyn askama::Values) -> askama::Result<String> {
+    pub fn noargs(
+        input: impl std::fmt::Display,
+        _env: &dyn askama::Values,
+    ) -> askama::Result<String> {
         Ok(format!("{input}"))
     }
 
     #[askama::filter_fn]
-    pub fn req1(input: impl std::fmt::Display, _env: &dyn askama::Values, req1: usize) -> askama::Result<String> {
+    pub fn req1(
+        input: impl std::fmt::Display,
+        _env: &dyn askama::Values,
+        req1: usize,
+    ) -> askama::Result<String> {
         Ok(format!("{input}{req1}"))
     }
 }
@@ -17,13 +24,29 @@ mod filters {
 struct InvokeNoArgFilterWithArgs;
 
 #[derive(Template)]
-#[template(source = r#"{{ "i like cake" | noargs(3, "test") }}"#, ext = "html")]
+#[template(source = r#"{{ "i like cake" | noargs(req1 = 3) }}"#, ext = "html")]
+struct InvokeNoArgFilterWithNamedArg;
+
+// ---------------------------------------------
+
+#[derive(Template)]
+#[template(source = r#"{{ "i like cake" | req1 }}"#, ext = "html")]
+struct InvokeReq1FilterWithoutArgs;
+
+#[derive(Template)]
+#[template(source = r#"{{ "i like cake" | req1(3, "test") }}"#, ext = "html")]
 struct InvokeReq1FilterWith2Args;
 
 #[derive(Template)]
-#[template(source = r#"{{ "i like cake" | noargs(req1 = 3, nonexisting = "test") }}"#, ext = "html")]
-struct InvokeReq1FilterWith2ArgsNamed;
+#[template(source = r#"{{ "i like cake" | req1(req2 = 42) }}"#, ext = "html")]
+struct InvokeReq1FilterWithUnknownNamedArg;
+
+// ---------------------------------------------
 
 fn main() {
     InvokeNoArgFilterWithArgs.render().unwrap();
+    InvokeNoArgFilterWithNamedArg.render().unwrap();
+    InvokeReq1FilterWithoutArgs.render().unwrap();
+    InvokeReq1FilterWith2Args.render().unwrap();
+    InvokeReq1FilterWithUnknownNamedArg.render().unwrap();
 }

--- a/testing/tests/ui/filter-invocation-invalid-arguments.stderr
+++ b/testing/tests/ui/filter-invocation-invalid-arguments.stderr
@@ -1,18 +1,18 @@
 error[E0599]: no method named `with_0` found for struct `noargs<'filter>` in the current scope
-  --> tests/ui/filter-invocation-invalid-arguments.rs:15:10
+  --> tests/ui/filter-invocation-invalid-arguments.rs:22:10
    |
  4 |     #[askama::filter_fn]
    |     -------------------- method `with_0` not found for this struct
 ...
-15 | #[derive(Template)]
+22 | #[derive(Template)]
    |          ^^^^^^^^ method not found in `noargs<'_>`
    |
    = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: Argument at position 0 is invalid on filter noargs<'_>. Too many arguments supplied?
-  --> tests/ui/filter-invocation-invalid-arguments.rs:15:10
+  --> tests/ui/filter-invocation-invalid-arguments.rs:22:10
    |
-15 | #[derive(Template)]
+22 | #[derive(Template)]
    |          ^^^^^^^^ Filter function
    |
 help: the trait `ValidArgIdx<0>` is not implemented for `noargs<'_>`
@@ -22,50 +22,85 @@ help: the trait `ValidArgIdx<0>` is not implemented for `noargs<'_>`
    |     ^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Template` which comes from the expansion of the attribute macro `askama::filter_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0599]: no method named `with_0` found for struct `noargs<'filter>` in the current scope
-  --> tests/ui/filter-invocation-invalid-arguments.rs:19:10
-   |
- 4 |     #[askama::filter_fn]
-   |     -------------------- method `with_0` not found for this struct
-...
-19 | #[derive(Template)]
-   |          ^^^^^^^^ method not found in `noargs<'_>`
-   |
-   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: Argument at position 1 is invalid on filter noargs<'_>. Too many arguments supplied?
-  --> tests/ui/filter-invocation-invalid-arguments.rs:19:10
-   |
-19 | #[derive(Template)]
-   |          ^^^^^^^^ Filter function
-   |
-help: the trait `ValidArgIdx<1>` is not implemented for `noargs<'_>`
-  --> tests/ui/filter-invocation-invalid-arguments.rs:4:5
-   |
- 4 |     #[askama::filter_fn]
-   |     ^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the derive macro `Template` which comes from the expansion of the attribute macro `askama::filter_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0599]: no method named `with_req1` found for struct `noargs<'filter>` in the current scope
-  --> tests/ui/filter-invocation-invalid-arguments.rs:23:10
+  --> tests/ui/filter-invocation-invalid-arguments.rs:26:10
    |
  4 |     #[askama::filter_fn]
    |     -------------------- method `with_req1` not found for this struct
 ...
-23 | #[derive(Template)]
+26 | #[derive(Template)]
    |          ^^^^^^^^ method not found in `noargs<'_>`
    |
    = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: Argument at position 1 is invalid on filter noargs<'_>. Too many arguments supplied?
-  --> tests/ui/filter-invocation-invalid-arguments.rs:23:10
+error[E0277]: Argument at position 0 is invalid on filter noargs<'_>. Too many arguments supplied?
+  --> tests/ui/filter-invocation-invalid-arguments.rs:26:10
    |
-23 | #[derive(Template)]
+26 | #[derive(Template)]
    |          ^^^^^^^^ Filter function
    |
-help: the trait `ValidArgIdx<1>` is not implemented for `noargs<'_>`
+help: the trait `ValidArgIdx<0>` is not implemented for `noargs<'_>`
   --> tests/ui/filter-invocation-invalid-arguments.rs:4:5
    |
  4 |     #[askama::filter_fn]
    |     ^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Template` which comes from the expansion of the attribute macro `askama::filter_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: Invalid filter function invocation. Not all required arguments were supplied.
+  --> tests/ui/filter-invocation-invalid-arguments.rs:32:10
+   |
+32 | #[derive(Template)]
+   |          ^^^^^^^^ Filter function
+   |
+help: the trait `ValidFilterInvocation` is not implemented for `req1<'_>`
+  --> tests/ui/filter-invocation-invalid-arguments.rs:12:5
+   |
+12 |     #[askama::filter_fn]
+   |     ^^^^^^^^^^^^^^^^^^^^
+   = help: the trait `ValidFilterInvocation` is implemented for `req1<'_, true>`
+   = note: this error originates in the derive macro `Template` which comes from the expansion of the attribute macro `askama::filter_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: no method named `execute` found for struct `req1<'_>` in the current scope
+  --> tests/ui/filter-invocation-invalid-arguments.rs:32:10
+   |
+12 |     #[askama::filter_fn]
+   |     -------------------- method `execute` not found for this struct
+...
+32 | #[derive(Template)]
+   |          ^^^^^^^^ method not found in `req1<'_>`
+   |
+   = note: the method was found for
+           - `req1<'_, true>`
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: no method named `with_1` found for struct `req1<'filter, REQUIRED_ARG_FLAG_0>` in the current scope
+  --> tests/ui/filter-invocation-invalid-arguments.rs:36:10
+   |
+12 |     #[askama::filter_fn]
+   |     -------------------- method `with_1` not found for this struct
+...
+36 | #[derive(Template)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: Argument at position 1 is invalid on filter req1<'_>. Too many arguments supplied?
+  --> tests/ui/filter-invocation-invalid-arguments.rs:36:10
+   |
+36 | #[derive(Template)]
+   |          ^^^^^^^^ Filter function
+   |
+   = help: the trait `ValidArgIdx<1>` is not implemented for `req1<'_>`
+           but trait `ValidArgIdx<0>` is implemented for it
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: no method named `with_req2` found for struct `req1<'filter, REQUIRED_ARG_FLAG_0>` in the current scope
+  --> tests/ui/filter-invocation-invalid-arguments.rs:40:10
+   |
+12 |     #[askama::filter_fn]
+   |     -------------------- method `with_req2` not found for this struct
+...
+40 | #[derive(Template)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This round improves compile error messages for when not all required arguments have been supplied.
Previously, this was just a: "method .execute() does not exist".