### PR TITLE
feat: Add support for array repeat syntax: `[<element_expr>; <cnt_expr>]`

### DIFF
--- a/askama_derive/src/generator/node.rs
+++ b/askama_derive/src/generator/node.rs
@@ -201,6 +201,7 @@ impl<'a> Generator<'a, '_> {
             | Expr::Var(_)
             | Expr::Path(_)
             | Expr::Array(_)
+            | Expr::ArrayRepeat(_, _)
             | Expr::AssociatedItem(_, _)
             | Expr::Index(_, _)
             | Expr::Filter(_)
@@ -1675,6 +1676,7 @@ fn is_cacheable(expr: &WithSpan<Box<Expr<'_>>>) -> bool {
         Expr::Path(_) => true,
         // Check recursively:
         Expr::Array(args) => args.iter().all(is_cacheable),
+        Expr::ArrayRepeat(elem, cnt) => is_cacheable(elem) && is_cacheable(cnt),
         Expr::AssociatedItem(lhs, _) => is_cacheable(lhs),
         Expr::Index(lhs, rhs) => is_cacheable(lhs) && is_cacheable(rhs),
         Expr::Filter(v) => v.arguments.iter().all(is_cacheable),

--- a/testing/tests/array.rs
+++ b/testing/tests/array.rs
@@ -1,0 +1,61 @@
+use askama::Template;
+
+// # Array Repeat:      [<element>; <count>]
+// ###################################################################################################
+
+#[test]
+fn test_array_repeat_in_macro_args() {
+    #[derive(Template)]
+    #[template(
+        source = r#"
+            {%- macro test_macro(title, my_arg = [""; 0]) -%}
+                {{ title }}:
+                {%- if !my_arg.is_empty() -%}
+                    [
+                    {%- for entry in my_arg -%}
+                        {{ entry }},
+                    {%- endfor -%}
+                    ]
+                {%- else -%}
+                    []
+                {%- endif -%}
+            {%- endmacro -%}
+
+            {{- test_macro("default") -}}
+            {{- test_macro("set_empty", my_arg = [""; 0]) -}}
+            {{- test_macro("set", my_arg = ["hello!"]) -}}
+        "#,
+        ext = "txt"
+    )]
+    struct ArrayRepeatInMacros;
+
+    let t = ArrayRepeatInMacros;
+    assert_eq!(t.render().unwrap(), "default:[]set_empty:[]set:[hello!,]");
+}
+
+#[test]
+fn test_array_repeat_in_for() {
+    #[derive(Template)]
+    #[template(
+        source = r#"[
+            {%- for elem in [""; 0] -%}
+                {{ elem }}
+            {%- endfor -%}
+        ]"#,
+        ext = "txt"
+    )]
+    struct ArrayRepeatInForLoop;
+
+    let t = ArrayRepeatInForLoop;
+    assert_eq!(t.render().unwrap(), "[]");
+}
+
+#[test]
+fn test_array_repeat_in_assignment() {
+    #[derive(Template)]
+    #[template(source = r#"{%- let my_arr = [""; 0] -%}"#, ext = "txt")]
+    struct ArrayRepeatInAssignment;
+
+    let t = ArrayRepeatInAssignment;
+    t.render().unwrap();
+}

--- a/testing/tests/ui/invalid_array_repeat.rs
+++ b/testing/tests/ui/invalid_array_repeat.rs
@@ -1,0 +1,38 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(source = r#"{% let my_arr = [;] %}"#, ext = "txt")]
+struct Empty;
+
+#[derive(Template)]
+#[template(source = r#"{% let my_arr = [;0] %}"#, ext = "txt")]
+struct EmptyElement;
+
+#[derive(Template)]
+#[template(source = r#"{% let my_arr = ["";] %}"#, ext = "txt")]
+struct EmptyCount;
+
+#[derive(Template)]
+#[template(source = r#"{% let my_arr = [,;] %}"#, ext = "txt")]
+struct StrayElementComma;
+
+#[derive(Template)]
+#[template(source = r#"{% let my_arr = [; 10, 10] %}"#, ext = "txt")]
+struct StrayCountComma;
+
+#[derive(Template)]
+#[template(source = r#"{% let my_arr = [,;,] %}"#, ext = "txt")]
+struct StrayCommas;
+
+#[derive(Template)]
+#[template(source = r#"{% let my_arr = ["";10;10] %}"#, ext = "txt")]
+struct MultipleSemicolons;
+
+#[derive(Template)]
+#[template(
+    source = r#"{{ [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[ }}"#,
+    ext = "txt"
+)]
+struct RecursionLimit;
+
+fn main() {}

--- a/testing/tests/ui/invalid_array_repeat.stderr
+++ b/testing/tests/ui/invalid_array_repeat.stderr
@@ -1,0 +1,63 @@
+error: expected element expression for array repeat syntax
+ --> <source attribute>:1:17
+       ";] %}"
+ --> tests/ui/invalid_array_repeat.rs:4:21
+  |
+4 | #[template(source = r#"{% let my_arr = [;] %}"#, ext = "txt")]
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected element expression for array repeat syntax
+ --> <source attribute>:1:17
+       ";0] %}"
+ --> tests/ui/invalid_array_repeat.rs:8:21
+  |
+8 | #[template(source = r#"{% let my_arr = [;0] %}"#, ext = "txt")]
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected count expression for array repeat syntax after `;`
+ --> <source attribute>:1:20
+       "] %}"
+  --> tests/ui/invalid_array_repeat.rs:12:21
+   |
+12 | #[template(source = r#"{% let my_arr = ["";] %}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected element expression for array repeat syntax
+ --> <source attribute>:1:17
+       ",;] %}"
+  --> tests/ui/invalid_array_repeat.rs:16:21
+   |
+16 | #[template(source = r#"{% let my_arr = [,;] %}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected element expression for array repeat syntax
+ --> <source attribute>:1:17
+       "; 10, 10] %}"
+  --> tests/ui/invalid_array_repeat.rs:20:21
+   |
+20 | #[template(source = r#"{% let my_arr = [; 10, 10] %}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected element expression for array repeat syntax
+ --> <source attribute>:1:17
+       ",;,] %}"
+  --> tests/ui/invalid_array_repeat.rs:24:21
+   |
+24 | #[template(source = r#"{% let my_arr = [,;,] %}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: failed to parse template source
+ --> <source attribute>:1:22
+       ";10] %}"
+  --> tests/ui/invalid_array_repeat.rs:28:21
+   |
+28 | #[template(source = r#"{% let my_arr = ["";10;10] %}"#, ext = "txt")]
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: your template code is too deeply nested, or the last expression is too complex
+ --> <source attribute>:1:67
+       "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[ }}"
+  --> tests/ui/invalid_array_repeat.rs:33:14
+   |
+33 |     source = r#"{{ [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[ }}"#,
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Please take a good look at the parser stuff and make sure I didn't accidentally break normal arrays :sweat_smile: 

Implements: #625