### PR TITLE
Remove `publish = false` from `askama_macros` Cargo.toml file

### DIFF
--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2024"
 rust-version = "1.88"
-publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/askama_macros/Cargo.toml
+++ b/askama_macros/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2024"
 rust-version = "1.88"
-publish = false
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Was added in https://github.com/askama-rs/askama/pull/434. Not sure why but since it's blocking the new release...