### PR TITLE
fix: allow clippy::elidable_lifetime_names for auto derived impls

### DIFF
--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -310,6 +310,8 @@ pub fn derive_template(input: TokenStream, import_askama: fn() -> TokenStream) -
             dead_code,
             // We intentionally add extraneous underscores in type and variable names.
             non_camel_case_types, non_snake_case,
+            // The generated code contains elidable lifetime.
+            clippy::elidable_lifetime_names,
             // We have too little context information to generate better code.
             // The generated source does not have to be perfect, anyway.
             clippy::double_parens, clippy::identity_op, clippy::into_iter_on_ref,


### PR DESCRIPTION
As explained in <https://github.com/askama-rs/askama/issues/643> this seem to be a regression introduced in v0.15.0.

This fix allows clippy::elidable_lifetime_names explicitly and removes the _false positive_ when enabling clippy::pedantic.

Fixes #643