### PR TITLE
fix(derive): use call_site to avoid linter false positives

### DIFF
--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use parser::node::{Call, Macro, Whitespace};
 use parser::{CharLit, Expr, FloatKind, IntKind, Num, StrLit, WithSpan};
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote_spanned};
 use syn::Token;
 
@@ -166,7 +166,7 @@ impl<'a, 'h> Generator<'a, 'h> {
     ) -> Result<usize, CompileError> {
         let ctx = &self.contexts[&self.input.path];
 
-        let span = self.input.ast.ident.span();
+        let span = Span::call_site();
         let target = match tmpl_kind {
             TmplKind::Struct => quote_spanned!(span=> askama::Template),
             TmplKind::Variant => quote_spanned!(span=> askama::helpers::EnumVariantTemplate),
@@ -273,7 +273,7 @@ impl<'a, 'h> Generator<'a, 'h> {
 
         use syn::{GenericParam, Ident, Lifetime, LifetimeParam, Token};
 
-        let span = block.span;
+        let span = Span::call_site();
         let ident = &self.input.ast.ident;
 
         let doc = format!(

--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -411,7 +411,6 @@ impl AnyTemplateArgs {
 
 pub(crate) struct Block {
     pub(crate) name: String,
-    pub(crate) span: Span,
 }
 
 pub(crate) struct TemplateArgs {
@@ -478,7 +477,6 @@ impl TemplateArgs {
                 .into_iter()
                 .map(|value| Block {
                     name: value.value(),
-                    span: value.span(),
                 })
                 .collect(),
             print: args.print.unwrap_or_default(),

--- a/askama_derive/src/integration.rs
+++ b/askama_derive/src/integration.rs
@@ -36,7 +36,7 @@ pub(crate) fn write_header(ast: &DeriveInput, buf: &mut Buffer, target: TokenStr
 /// Implement `Display` for the given item.
 fn impl_display(ast: &DeriveInput, buf: &mut Buffer) {
     let ident = &ast.ident;
-    let span = ident.span();
+    let span = Span::call_site();
     let msg =
         // format!(" Implement the [`Display`][core::fmt::Display] trait for [`{ident}`]");
         format!(" Implement the [`format!()`][askama::helpers::std::format] trait for [`{ident}`]");
@@ -66,7 +66,7 @@ fn impl_display(ast: &DeriveInput, buf: &mut Buffer) {
 
 /// Implement `FastWritable` for the given item.
 fn impl_fast_writable(ast: &DeriveInput, buf: &mut Buffer) {
-    let span = ast.span();
+    let span = Span::call_site();
     write_header(ast, buf, quote_spanned!(span => askama::FastWritable));
     quote_into!(buf, span, {
         {


### PR DESCRIPTION
Implements the suggestion from https://github.com/askama-rs/askama/issues/643#issuecomment-3690599397 by using `Span::call_site()`.

Applied call-site spans to generated impl headers/targets, fixing https://github.com/askama-rs/askama/issues/642.

Fixes https://github.com/askama-rs/askama/issues/642
Fixes https://github.com/askama-rs/askama/issues/643