### PR TITLE
Simplify versioning in non-published crates (ie tests and examples)

### DIFF
--- a/bench-build/Cargo.toml
+++ b/bench-build/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "bench-build"
-version = "0.14.0"
+version = "0.0.0"
 authors = ["askama-rs developers"]
 edition = "2024"
 rust-version = "1.88"
 publish = false
 
 [dependencies]
-askama = { path = "../askama", version = "0.15.0", default-features = false, features = ["std"] }
-askama_macros = { path = "../askama_macros", version = "0.15.0", features = ["std"] }
+askama = { path = "../askama", default-features = false, features = ["std"] }
+askama_macros = { path = "../askama_macros", version = "0.15.1", features = ["std"] }
 
 [features]
 default = []

--- a/examples/actix-web-app/Cargo.toml
+++ b/examples/actix-web-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-app"
-version = "0.14.0"
+version = "0.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -9,7 +9,7 @@ publish = false
 # and actix-web as your web-framework.
 [dependencies]
 actix-web = { version = "4.9.0", default-features = false, features = ["macros"] }
-askama = { version = "0.15.0", path = "../../askama" }
+askama = { path = "../../askama" }
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 
 # serde and strum are used to parse (deserialize) and generate (serialize) information

--- a/examples/axum-app/Cargo.toml
+++ b/examples/axum-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-app"
-version = "0.14.0"
+version = "0.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # This is an example application that uses both askama as template engine,
 # and axum as your web-framework.
 [dependencies]
-askama = { version = "0.15.0", path = "../../askama" }
+askama = { path = "../../askama" }
 axum = "0.8.1"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 

--- a/examples/poem-app/Cargo.toml
+++ b/examples/poem-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poem-app"
-version = "0.14.0"
+version = "0.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # This is an example application that uses both askama as template engine,
 # and poem as your web-framework.
 [dependencies]
-askama = { version = "0.15.0", path = "../../askama" }
+askama = { path = "../../askama" }
 poem = "3.1.6"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 

--- a/examples/rocket-app/Cargo.toml
+++ b/examples/rocket-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-app"
-version = "0.14.0"
+version = "0.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # This is an example application that uses both askama as template engine,
 # and rocket as your web-framework.
 [dependencies]
-askama = { version = "0.15.0", path = "../../askama" }
+askama = { path = "../../askama" }
 rocket = "0.5.1"
 
 # strum is used to parse and serialize information between web requests,

--- a/examples/salvo-app/Cargo.toml
+++ b/examples/salvo-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salvo-app"
-version = "0.14.0"
+version = "0.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # This is an example application that uses both askama as template engine,
 # and salvo as your web-framework.
 [dependencies]
-askama = { version = "0.15.0", path = "../../askama" }
+askama = { path = "../../askama" }
 salvo = { version = "0.78.0", default-features = false, features = ["http1", "logging", "server"] }
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 

--- a/examples/warp-app/Cargo.toml
+++ b/examples/warp-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-app"
-version = "0.14.0"
+version = "0.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # This is an example application that uses both askama as template engine,
 # and actix-web as your web-framework.
 [dependencies]
-askama = { version = "0.15.0", path = "../../askama" }
+askama = { path = "../../askama" }
 http = "0.2.12"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 warp = "0.3.7"

--- a/testing-alloc/Cargo.toml
+++ b/testing-alloc/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "askama_testing-alloc"
-version = "0.15.0"
+version = "0.0.0"
 authors = ["askama-rs developers"]
 edition = "2024"
 rust-version = "1.88"
 publish = false
 
 [dev-dependencies]
-askama = { path = "../askama", version = "0.15.0", default-features = false, features = ["alloc", "derive"] }
+askama = { path = "../askama", default-features = false, features = ["alloc", "derive"] }
 
 assert_matches = "1.5.0"
 

--- a/testing-no-std/Cargo.toml
+++ b/testing-no-std/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "askama_testing-no-std"
-version = "0.15.0"
+version = "0.0.0"
 authors = ["askama-rs developers"]
 edition = "2024"
 rust-version = "1.88"
 publish = false
 
 [dev-dependencies]
-askama = { path = "../askama", version = "0.15.0", default-features = false, features = ["derive"] }
+askama = { path = "../askama", default-features = false, features = ["derive"] }
 
 assert_matches = "1.5.0"
 

--- a/testing-renamed/Cargo.toml
+++ b/testing-renamed/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "askama_testing-renamed"
-version = "0.15.0"
+version = "0.0.0"
 authors = ["askama-rs developers"]
 edition = "2024"
 rust-version = "1.88"
 publish = false
 
 [dev-dependencies]
-some_name = { package = "askama", path = "../askama", version = "0.15.0", default-features = false, features = ["derive"] }
+some_name = { package = "askama", path = "../askama", default-features = false, features = ["derive"] }
 
 assert_matches = "1.5.0"
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama_testing"
-version = "0.15.0"
+version = "0.0.0"
 authors = ["askama-rs developers"]
 edition = "2024"
 rust-version = "1.88"
@@ -11,7 +11,7 @@ name = "all"
 harness = false
 
 [dependencies]
-askama = { path = "../askama", version = "0.15.0" }
+askama = { path = "../askama" }
 
 serde_json = { version = "1.0", optional = true }
 
@@ -19,8 +19,8 @@ serde_json = { version = "1.0", optional = true }
 core = { package = "intentionally-empty", version = "1.0.0" }
 
 [dev-dependencies]
-askama = { path = "../askama", version = "0.15.0", features = ["code-in-doc", "serde_json"] }
-askama_parser = { path = "../askama_parser", version = "0.15.0" }
+askama = { path = "../askama", features = ["code-in-doc", "serde_json"] }
+askama_parser = { path = "../askama_parser" }
 
 assert_matches = "1.5.0"
 criterion = "0.8"


### PR DESCRIPTION
Just realized that `examples`, `bench-build` and `tests` had their version keeping up with `askama`'s, which is not really useful (and makes `grep` a bit too happy) and also removed the version of `askama` deps in these cases.