### PR TITLE
Update duplicated blocks warning message and add warning about not compiling starting next version

### DIFF
--- a/askama_derive/src/heritage.rs
+++ b/askama_derive/src/heritage.rs
@@ -119,6 +119,11 @@ impl<'a> Context<'a> {
                                 "⚠️ {:#}: block `{}` was already called at `{:#}` so the previous one will be ignored",
                                 current, &*b.name, prev,
                             );
+                            eprintln!(
+                                "  You can repeat blocks by using the `template` proc-macro blocks: \
+                                 https://askama.readthedocs.io/en/latest/creating_templates.html#blocks"
+                            );
+                            eprintln!("⚠️⚠️⚠️ This will stop compiling starting next version!");
                         } else if extends.is_none() {
                             called_blocks.check_if_already_called(*b.name, current);
                             called_blocks

--- a/testing/tests/custom_ui/duplicated-block-call.stderr
+++ b/testing/tests/custom_ui/duplicated-block-call.stderr
@@ -1,2 +1,6 @@
 ⚠️ Foo.txt:3:3: block `foo` was already called at `Foo.txt:2:3` so the previous one will be ignored
+  You can repeat blocks by using the `template` proc-macro blocks: https://askama.readthedocs.io/en/latest/creating_templates.html#blocks
+⚠️⚠️⚠️ This will stop compiling starting next version!
 ⚠️ testing/templates/extend-duplicated.html:4:3: block `content` was already called at `testing/templates/extend-duplicated.html:3:3` so the previous one will be ignored
+  You can repeat blocks by using the `template` proc-macro blocks: https://askama.readthedocs.io/en/latest/creating_templates.html#blocks
+⚠️⚠️⚠️ This will stop compiling starting next version!

--- a/testing/tests/custom_ui/duplicated_block_calls.stderr
+++ b/testing/tests/custom_ui/duplicated_block_calls.stderr
@@ -1,1 +1,3 @@
 ⚠️ X.txt:4:3: block `content` was already called at `X.txt:3:3` so the previous one will be ignored
+  You can repeat blocks by using the `template` proc-macro blocks: https://askama.readthedocs.io/en/latest/creating_templates.html#blocks
+⚠️⚠️⚠️ This will stop compiling starting next version!


### PR DESCRIPTION
Part of #668.

cc @Kijewski 