### PR TITLE
Some function call fixes

### DIFF
--- a/askama_parser/src/tests.rs
+++ b/askama_parser/src/tests.rs
@@ -1724,3 +1724,12 @@ fn test_unclosed_prefixed_string() {
         );
     }
 }
+
+#[test]
+fn test_excessive_call_depth() {
+    let mut call = "a()".to_string();
+    for _ in 0..1000 {
+        call = format!("a({call})");
+    }
+    assert!(Ast::from_str(&format!("{{{{ {call} }}}}"), None, &Syntax::default()).is_err());
+}

--- a/testing/tests/ui/calls.rs
+++ b/testing/tests/ui/calls.rs
@@ -1,0 +1,51 @@
+use askama::Template;
+
+#[derive(Template)]
+#[template(ext = "txt", source = r#"{{ call( }}"#)]
+struct UnclosedCall1;
+
+#[derive(Template)]
+#[template(ext = "txt", source = r#"{{ call(a }}"#)]
+struct UnclosedCall2;
+
+#[derive(Template)]
+#[template(ext = "txt", source = r#"{{ call(a, }}"#)]
+struct UnclosedCall3;
+
+#[derive(Template)]
+#[template(ext = "txt", source = r#"{{ call(a, b }}"#)]
+struct UnclosedCall4;
+
+#[derive(Template)]
+#[template(ext = "txt", source = r#"{{ call(a, b, }}"#)]
+struct UnclosedCall5;
+
+#[derive(Template)]
+#[template(ext = "txt", source = r#"{{ call(,) }}"#)]
+struct CommaWithoutAnyArguments1;
+
+#[derive(Template)]
+#[template(ext = "txt", source = r#"{{ call(, a) }}"#)]
+struct CommaWithoutAnyArguments2;
+
+#[derive(Template)]
+#[template(ext = "txt", source = r#"{{ call(, a,) }}"#)]
+struct CommaWithoutAnyArguments3;
+
+#[derive(Template)]
+#[template(ext = "txt", source = r#"{{ call(, a, }}"#)]
+struct CommaWithoutAnyArguments4;
+
+#[derive(Template)]
+#[template(ext = "txt", source = r#"{{ call(a,,) }}"#)]
+struct MultipleCommas1;
+
+#[derive(Template)]
+#[template(ext = "txt", source = r#"{{ call(a,, b,) }}"#)]
+struct MultipleCommas2;
+
+#[derive(Template)]
+#[template(ext = "txt", source = r#"{{ call(a, b,,) }}"#)]
+struct MultipleCommas3;
+
+fn main() {}

--- a/testing/tests/ui/calls.stderr
+++ b/testing/tests/ui/calls.stderr
@@ -1,0 +1,95 @@
+error: matching closing `)` is missing
+ --> <source attribute>:1:7
+       "( }}"
+ --> tests/ui/calls.rs:4:34
+  |
+4 | #[template(ext = "txt", source = r#"{{ call( }}"#)]
+  |                                  ^^^^^^^^^^^^^^^^
+
+error: matching closing `)` is missing
+ --> <source attribute>:1:7
+       "(a }}"
+ --> tests/ui/calls.rs:8:34
+  |
+8 | #[template(ext = "txt", source = r#"{{ call(a }}"#)]
+  |                                  ^^^^^^^^^^^^^^^^^
+
+error: matching closing `)` is missing
+ --> <source attribute>:1:7
+       "(a, }}"
+  --> tests/ui/calls.rs:12:34
+   |
+12 | #[template(ext = "txt", source = r#"{{ call(a, }}"#)]
+   |                                  ^^^^^^^^^^^^^^^^^^
+
+error: matching closing `)` is missing
+ --> <source attribute>:1:7
+       "(a, b }}"
+  --> tests/ui/calls.rs:16:34
+   |
+16 | #[template(ext = "txt", source = r#"{{ call(a, b }}"#)]
+   |                                  ^^^^^^^^^^^^^^^^^^^^
+
+error: matching closing `)` is missing
+ --> <source attribute>:1:7
+       "(a, b, }}"
+  --> tests/ui/calls.rs:20:34
+   |
+20 | #[template(ext = "txt", source = r#"{{ call(a, b, }}"#)]
+   |                                  ^^^^^^^^^^^^^^^^^^^^^
+
+error: expected an expression, found a comma in argument list
+ --> <source attribute>:1:8
+       ",) }}"
+  --> tests/ui/calls.rs:24:34
+   |
+24 | #[template(ext = "txt", source = r#"{{ call(,) }}"#)]
+   |                                  ^^^^^^^^^^^^^^^^^^
+
+error: expected an expression, found a comma in argument list
+ --> <source attribute>:1:8
+       ", a) }}"
+  --> tests/ui/calls.rs:28:34
+   |
+28 | #[template(ext = "txt", source = r#"{{ call(, a) }}"#)]
+   |                                  ^^^^^^^^^^^^^^^^^^^^
+
+error: expected an expression, found a comma in argument list
+ --> <source attribute>:1:8
+       ", a,) }}"
+  --> tests/ui/calls.rs:32:34
+   |
+32 | #[template(ext = "txt", source = r#"{{ call(, a,) }}"#)]
+   |                                  ^^^^^^^^^^^^^^^^^^^^^
+
+error: expected an expression, found a comma in argument list
+ --> <source attribute>:1:8
+       ", a, }}"
+  --> tests/ui/calls.rs:36:34
+   |
+36 | #[template(ext = "txt", source = r#"{{ call(, a, }}"#)]
+   |                                  ^^^^^^^^^^^^^^^^^^^^
+
+error: expected an expression, found a comma in argument list
+ --> <source attribute>:1:10
+       ",) }}"
+  --> tests/ui/calls.rs:40:34
+   |
+40 | #[template(ext = "txt", source = r#"{{ call(a,,) }}"#)]
+   |                                  ^^^^^^^^^^^^^^^^^^^^
+
+error: expected an expression, found a comma in argument list
+ --> <source attribute>:1:10
+       ", b,) }}"
+  --> tests/ui/calls.rs:44:34
+   |
+44 | #[template(ext = "txt", source = r#"{{ call(a,, b,) }}"#)]
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected an expression, found a comma in argument list
+ --> <source attribute>:1:13
+       ",) }}"
+  --> tests/ui/calls.rs:48:34
+   |
+48 | #[template(ext = "txt", source = r#"{{ call(a, b,,) }}"#)]
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^

--- a/testing/tests/ui/excessive_nesting.stderr
+++ b/testing/tests/ui/excessive_nesting.stderr
@@ -1,6 +1,6 @@
 error: your template code is too deeply nested, or the last expression is too complex
- --> <source attribute>:15:58
-       "%}{%if 1%}{%if 1%}{%if 1%}\n    {%if 1%}{%if 1%}{%if 1%}{%if 1%}{%if 1%}{%if 1%}{"...
+ --> <source attribute>:15:51
+       "}{%if 1%}{%if 1%}{%if 1%}{%if 1%}\n    {%if 1%}{%if 1%}{%if 1%}{%if 1%}{%if 1%}{%"...
    --> tests/ui/excessive_nesting.rs:5:14
     |
   5 |       source = "

--- a/testing/tests/ui/filter-recursion.stderr
+++ b/testing/tests/ui/filter-recursion.stderr
@@ -1,6 +1,6 @@
 error: your template code is too deeply nested, or the last expression is too complex
- --> testing/templates/filter-recursion.html:1:277
-       "|A|AA|A|A|A|A|AA|A|A|A|A|AA|A|A|A|A|AA|A|A|A||A|A|AA|A|A|A|A|AA|A|A|A|A|AA|A|A|A"...
+ --> testing/templates/filter-recursion.html:1:275
+       "|A|A|AA|A|A|A|A|AA|A|A|A|A|AA|A|A|A|A|AA|A|A|A||A|A|AA|A|A|A|A|AA|A|A|A|A|AA|A|A"...
  --> tests/ui/filter-recursion.rs:4:19
   |
 4 | #[template(path = "filter-recursion.html")]

--- a/testing/tests/ui/fuzzed_recursion_depth_mul_deref.stderr
+++ b/testing/tests/ui/fuzzed_recursion_depth_mul_deref.stderr
@@ -1,6 +1,6 @@
 error: your template code is too deeply nested, or the last expression is too complex
- --> testing/templates/fuzzed-recursion-mul-deref.txt:2:486
-       "!**y**false|yz***y**false|z**yz**s**fa*galse|iz**!**y**false|yz***y**f*!**y**fal"...
+ --> testing/templates/fuzzed-recursion-mul-deref.txt:2:485
+       "*!**y**false|yz***y**false|z**yz**s**fa*galse|iz**!**y**false|yz***y**f*!**y**fa"...
  --> tests/ui/fuzzed_recursion_depth_mul_deref.rs:4:19
   |
 4 | #[template(path = "fuzzed-recursion-mul-deref.txt")]


### PR DESCRIPTION
* Parsing function calls is expensive. Make sure not to stack overflow.
* We only need to to call `level.nest()` if we descent, but we need to call it before we descent.

I de-indented a good chunk of the code, so the diff might be more readable with hidden white-space changes.

Fixes <https://github.com/askama-rs/askama/issues/682>.