### PR TITLE
Simplify `Cargo.toml` files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,11 @@ members = [
     "testing/tests/clippy_lints",
 ]
 resolver = "2"
+
+[workspace.package]
+version = "0.15.4"
+homepage = "https://askama.rs/"
+repository = "https://github.com/askama-rs/askama"
+license = "MIT OR Apache-2.0"
+edition = "2024"
+rust-version = "1.88"

--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "askama"
-version = "0.15.4"
+version.workspace = true
 description = "Type-safe, compiled Jinja-like templates for Rust"
 keywords = ["markup", "template", "jinja2", "html"]
 categories = ["template-engine"]
-homepage = "https://askama.rs/"
-repository = "https://github.com/askama-rs/askama"
-license = "MIT OR Apache-2.0"
-edition = "2024"
-rust-version = "1.88"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 features = ["full"]

--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "askama_derive"
-version = "0.15.4"
+version.workspace = true
 description = "Code generator of Askama templating engine"
 homepage = "https://github.com/askama-rs/askama"
-repository = "https://github.com/askama-rs/askama"
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-edition = "2024"
-rust-version = "1.88"
+repository.workspace = true
+license.workspace = true
+readme.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/askama_escape/Cargo.toml
+++ b/askama_escape/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "askama_escape"
-version = "0.15.4"
+version.workspace = true
 description = "HTML escaping, extracted from Askama"
 keywords = ["html", "escaping"]
 categories = ["no-std", "no-std::no-alloc"]
-homepage = "https://askama.rs/"
-repository = "https://github.com/askama-rs/askama"
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-edition = "2024"
-rust-version = "1.88"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+readme.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]

--- a/askama_macros/Cargo.toml
+++ b/askama_macros/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "askama_macros"
-version = "0.15.4"
+version.workspace = true
 description = "Procedural macro package for Askama"
-homepage = "https://github.com/askama-rs/askama"
-repository = "https://github.com/askama-rs/askama"
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-edition = "2024"
-rust-version = "1.88"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+readme.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/askama_parser/Cargo.toml
+++ b/askama_parser/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "askama_parser"
-version = "0.15.4"
+version.workspace = true
 description = "Parser for Askama templates"
 documentation = "https://docs.rs/askama"
 keywords = ["markup", "template", "jinja2", "html"]
 categories = ["template-engine"]
-homepage = "https://github.com/askama-rs/askama"
-repository = "https://github.com/askama-rs/askama"
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-edition = "2024"
-rust-version = "1.88"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+readme.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Some common fields can be moved in the workspace, then we can use them from there directly. :)