### PR TITLE
Add `CARGO_MANIFEST_DIR` as second templates default location

### DIFF
--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -105,7 +105,7 @@ impl Config {
         let config_path = key.0.config_path.as_deref();
         let root = key.0.root.as_ref();
 
-        let default_dirs = vec![root.join("templates")];
+        let default_dirs = vec![root.join("templates"), root.to_path_buf()];
 
         let mut syntaxes = HashMap::default();
         syntaxes.insert(DEFAULT_SYNTAX_NAME.to_string(), SyntaxAndCache::default());
@@ -397,10 +397,12 @@ mod tests {
 
     #[test]
     fn test_default_config() {
-        let mut root = manifest_root();
-        root.push("templates");
+        let root = manifest_root();
         let config = Config::new("", None, None, None, None).unwrap();
-        assert_eq!(config.dirs, vec![root]);
+        assert_eq!(
+            config.dirs,
+            vec![root.join("templates", root.to_path_buf())]
+        );
     }
 
     #[cfg(feature = "config")]

--- a/askama_derive/src/lib.rs
+++ b/askama_derive/src/lib.rs
@@ -79,12 +79,11 @@ macro_rules! make_derive_template {
         /// E.g. `path = "foo.html"`
         ///
         /// Sets the path to the template file.
-        /// The path is interpreted as relative to the configured template directories
-        /// (by default, this is a `templates` directory next to your `Cargo.toml`).
-        /// The file name extension is used to infer an escape mode (see below). In
-        /// web framework integrations, the path's extension may also be used to
-        /// infer the content type of the resulting response.
-        /// Cannot be used together with `source`.
+        /// The path is interpreted as relative to the configured template directories (by default,
+        /// this is a `templates` directory next to your `Cargo.toml` or the directory where
+        /// `Cargo.toml` is). The file name extension is used to infer an escape mode (see below).
+        /// In web framework integrations, the path's extension may also be used to infer the
+        /// content type of the resulting response. Cannot be used together with `source`.
         ///
         /// ### source
         ///


### PR DESCRIPTION
In build environments where `CARGO_MANIFEST_DIR` is not set, the templates paths are prepended with a `templates` directory that doesn't exist in a random place. For instance, in Android's Soong, askama ends up looking for the `templates` directory in the root of the Android code. By adding the `root` directory as well, it gives us the chance to specify a relative path from wherever the compilation happens.

Note that this cannot be solved with `askama.toml` either because its location is tied to `CARGO_MANIFEST_DIR` too.