### PR TITLE
Update crates version to `0.15.5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.4"
+version = "0.15.5"
 homepage = "https://askama.rs/"
 repository = "https://github.com/askama-rs/askama"
 license = "MIT OR Apache-2.0"

--- a/askama/Cargo.toml
+++ b/askama/Cargo.toml
@@ -27,7 +27,7 @@ harness = false
 itoa = "1.0.11"
 
 # needed by feature "derive"
-askama_macros = { version = "=0.15.4", path = "../askama_macros", default-features = false, optional = true }
+askama_macros = { version = "=0.15.5", path = "../askama_macros", default-features = false, optional = true }
 
 # needed by feature "serde_json"
 serde = { version = "1.0", optional = true, default-features = false }

--- a/askama_derive/Cargo.toml
+++ b/askama_derive/Cargo.toml
@@ -22,7 +22,7 @@ name = "derive-template"
 harness = false
 
 [dependencies]
-parser = { package = "askama_parser", version = "=0.15.4", path = "../askama_parser" }
+parser = { package = "askama_parser", version = "=0.15.5", path = "../askama_parser" }
 
 basic-toml = { version = "0.1.1", optional = true }
 pulldown-cmark = { version = "0.13.0", optional = true, default-features = false }

--- a/askama_macros/Cargo.toml
+++ b/askama_macros/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--generate-link-to-definition", "--cfg=docsrs"]
 proc-macro = true
 
 [dependencies]
-askama_derive = { package = "askama_derive", path = "../askama_derive", version = "=0.15.4", default-features = false, features = ["external-sources", "proc-macro"] }
+askama_derive = { package = "askama_derive", path = "../askama_derive", version = "=0.15.5", default-features = false, features = ["external-sources", "proc-macro"] }
 
 [features]
 default = ["config", "derive", "std", "urlencode"]


### PR DESCRIPTION
Small bugfix update before next major release. I'll then backport this commit to the `v0.15` branch and make the release.