### PR TITLE
Switch to `std::path::absolute` to avoid symlinking template paths

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.html text eol=lf
 *.txt text eol=lf
+testing/templates/symlink-target text eol=lf
 fuzzing/fuzz/corpus linguist-vendored

--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -2,7 +2,7 @@ use std::borrow::{Borrow, Cow};
 use std::collections::hash_map::Entry;
 use std::mem::ManuallyDrop;
 use std::ops::Deref;
-use std::path::{Path, PathBuf};
+use std::path::{Path, PathBuf, absolute};
 use std::sync::{Arc, OnceLock};
 use std::{env, fs};
 
@@ -190,7 +190,7 @@ impl Config {
         file_info: Option<FileInfo<'_>>,
         span: Option<proc_macro2::Span>,
     ) -> Result<Arc<Path>, CompileError> {
-        let path = 'find_path: {
+        let resolved = 'find_path: {
             if let Some(root) = start_at {
                 let relative = root.with_file_name(path);
                 if relative.exists() {
@@ -212,10 +212,10 @@ impl Config {
                 span,
             ));
         };
-        match path.canonicalize() {
-            Ok(path) => Ok(path.into()),
+        match absolute(&resolved) {
+            Ok(resolved) => Ok(resolved.into()),
             Err(err) => Err(CompileError::new_with_span(
-                format_args!("could not canonicalize path {path:?}: {err}"),
+                format_args!("could not get absolute path for {path:?}: {err}"),
                 file_info,
                 span,
             )),

--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -391,7 +391,7 @@ static DEFAULT_ESCAPERS: &[(&[&str], &str)] = &[
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::path::{Path, PathBuf, absolute};
 
     use super::*;
 
@@ -413,7 +413,7 @@ mod tests {
     }
 
     fn assert_eq_rooted(actual: &Path, expected: &str) {
-        let mut root = manifest_root().canonicalize().unwrap();
+        let mut root = absolute(manifest_root()).unwrap();
         root.push("templates");
         let mut inner = PathBuf::new();
         inner.push(expected);

--- a/askama_derive/src/config.rs
+++ b/askama_derive/src/config.rs
@@ -190,7 +190,7 @@ impl Config {
         file_info: Option<FileInfo<'_>>,
         span: Option<proc_macro2::Span>,
     ) -> Result<Arc<Path>, CompileError> {
-        let resolved = 'find_path: {
+        let path = 'find_path: {
             if let Some(root) = start_at {
                 let relative = root.with_file_name(path);
                 if relative.exists() {
@@ -212,8 +212,8 @@ impl Config {
                 span,
             ));
         };
-        match absolute(&resolved) {
-            Ok(resolved) => Ok(resolved.into()),
+        match absolute(&path) {
+            Ok(path) => Ok(path.into()),
             Err(err) => Err(CompileError::new_with_span(
                 format_args!("could not get absolute path for {path:?}: {err}"),
                 file_info,

--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -155,14 +155,21 @@ impl TemplateInput<'_> {
         let (source, source_path) = match &self.source {
             Source::Source(s) => (s.clone(), None),
             #[cfg(feature = "external-sources")]
-            Source::Path(_) => (
-                get_template_source(&self.path, None)?,
+            Source::Path(p) => (
+                get_template_source(&self.path, p.as_ref(), None)?,
                 Some(Arc::clone(&self.path)),
             ),
         };
 
         #[cfg(feature = "external-sources")]
         let mut dependency_graph = Vec::new();
+
+        #[cfg(feature = "external-sources")]
+        let mut orig_paths: HashMap<Arc<Path>, String> = HashMap::default();
+        #[cfg(feature = "external-sources")]
+        if let Source::Path(p) = &self.source {
+            orig_paths.insert(Arc::clone(&self.path), p.to_string());
+        }
 
         let mut check = vec![(Arc::clone(&self.path), source, source_path)];
         while let Some((path, source, source_path)) = check.pop() {
@@ -187,7 +194,9 @@ impl TemplateInput<'_> {
             while let Some(nodes) = nested.pop() {
                 for n in nodes {
                     #[cfg(feature = "external-sources")]
-                    let mut add_to_check = |new_path: Arc<Path>| -> Result<(), CompileError> {
+                    let mut add_to_check = |new_path: Arc<Path>,
+                                            orig_path: &str|
+                     -> Result<(), CompileError> {
                         if let std::collections::hash_map::Entry::Vacant(e) = map.entry(new_path) {
                             // Add a dummy entry to `map` in order to prevent adding `path`
                             // multiple times to `check`.
@@ -195,6 +204,7 @@ impl TemplateInput<'_> {
                             let source = parsed.source();
                             let source = get_template_source(
                                 new_path,
+                                orig_path,
                                 Some((
                                     &path,
                                     source,
@@ -219,22 +229,24 @@ impl TemplateInput<'_> {
                             }
                             #[cfg(feature = "external-sources")]
                             {
+                                let extends_orig = extends.path;
                                 let extends = self.config.find_template(
-                                    extends.path,
+                                    extends_orig,
                                     Some(&path),
                                     Some(FileInfo::of(extends.span(), &path, &parsed)),
                                     Some(self.source_span.config_span()),
                                 )?;
+                                orig_paths.insert(Arc::clone(&extends), extends_orig.to_owned());
                                 let dependency_path = (path.clone(), extends.clone());
                                 if path == extends {
                                     // We add the path into the graph to have a better looking error.
                                     dependency_graph.push(dependency_path);
-                                    return cyclic_graph_error(&dependency_graph);
+                                    return cyclic_graph_error(&dependency_graph, &orig_paths);
                                 } else if dependency_graph.contains(&dependency_path) {
-                                    return cyclic_graph_error(&dependency_graph);
+                                    return cyclic_graph_error(&dependency_graph, &orig_paths);
                                 }
                                 dependency_graph.push(dependency_path);
-                                add_to_check(extends)?;
+                                add_to_check(extends, extends_orig)?;
                             }
                         }
                         Node::Macro(m) if top => {
@@ -252,13 +264,15 @@ impl TemplateInput<'_> {
                             }
                             #[cfg(feature = "external-sources")]
                             {
+                                let import_orig = import.path;
                                 let import = self.config.find_template(
-                                    import.path,
+                                    import_orig,
                                     Some(&path),
                                     Some(FileInfo::of(import.span(), &path, &parsed)),
                                     Some(self.source_span.config_span()),
                                 )?;
-                                add_to_check(import)?;
+                                orig_paths.insert(Arc::clone(&import), import_orig.to_owned());
+                                add_to_check(import, import_orig)?;
                             }
                         }
                         Node::FilterBlock(f) => {
@@ -276,13 +290,15 @@ impl TemplateInput<'_> {
                             }
                             #[cfg(feature = "external-sources")]
                             {
+                                let include_orig = include.path;
                                 let include = self.config.find_template(
-                                    include.path,
+                                    include_orig,
                                     Some(&path),
                                     Some(FileInfo::of(include.span(), &path, &parsed)),
                                     Some(self.source_span.config_span()),
                                 )?;
-                                add_to_check(include)?;
+                                orig_paths.insert(Arc::clone(&include), include_orig.to_owned());
+                                add_to_check(include, include_orig)?;
                             }
                         }
                         Node::BlockDef(b) => {
@@ -696,13 +712,20 @@ impl FromStr for Print {
 }
 
 #[cfg(feature = "external-sources")]
-fn cyclic_graph_error(dependency_graph: &[(Arc<Path>, Arc<Path>)]) -> Result<(), CompileError> {
+fn cyclic_graph_error(
+    dependency_graph: &[(Arc<Path>, Arc<Path>)],
+    orig_paths: &HashMap<Arc<Path>, String>,
+) -> Result<(), CompileError> {
+    let fmt_path = |p: &Arc<Path>| match orig_paths.get(p) {
+        Some(orig) => format!("{orig:#?} (absolute path: {:#?})", p.display()),
+        None => format!("{:#?}", p.display()),
+    };
     Err(CompileError::no_file_info(
         format_args!(
             "cyclic dependency in graph {:#?}",
             dependency_graph
                 .iter()
-                .map(|e| format!("{:#?} --> {:#?}", e.0, e.1))
+                .map(|e| format!("{} --> {}", fmt_path(&e.0), fmt_path(&e.1)))
                 .collect::<Vec<String>>()
         ),
         None,
@@ -712,6 +735,7 @@ fn cyclic_graph_error(dependency_graph: &[(Arc<Path>, Arc<Path>)]) -> Result<(),
 #[cfg(feature = "external-sources")]
 pub(crate) fn get_template_source(
     tpl_path: &Arc<Path>,
+    original_path: &str,
     import_from: Option<(&Arc<Path>, &str, &str)>,
 ) -> Result<Arc<str>, CompileError> {
     static CACHE: std::sync::OnceLock<crate::OnceMap<Arc<Path>, Arc<str>>> =
@@ -730,7 +754,8 @@ pub(crate) fn get_template_source(
                 }
                 Err(err) => Err(CompileError::new(
                     format_args!(
-                        "unable to open template file '{}': {err}",
+                        "unable to open template file '{}' (absolute path: '{}'): {err}",
+                        original_path,
                         tpl_path.to_str().unwrap(),
                     ),
                     import_from.map(|(node_file, file_source, node_source)| {
@@ -1100,5 +1125,8 @@ fn get_source() {
     let path = Config::new("", None, None, None, None)
         .and_then(|config| config.find_template("b.html", None, None, None))
         .unwrap();
-    assert_eq!(get_template_source(&path, None).unwrap(), "bar".into());
+    assert_eq!(
+        get_template_source(&path, "test.html", None).unwrap(),
+        "bar".into()
+    );
 }

--- a/askama_derive/src/input.rs
+++ b/askama_derive/src/input.rs
@@ -165,10 +165,10 @@ impl TemplateInput<'_> {
         let mut dependency_graph = Vec::new();
 
         #[cfg(feature = "external-sources")]
-        let mut orig_paths: HashMap<Arc<Path>, String> = HashMap::default();
+        let mut original_paths: HashMap<Arc<Path>, String> = HashMap::default();
         #[cfg(feature = "external-sources")]
         if let Source::Path(p) = &self.source {
-            orig_paths.insert(Arc::clone(&self.path), p.to_string());
+            original_paths.insert(Arc::clone(&self.path), p.to_string());
         }
 
         let mut check = vec![(Arc::clone(&self.path), source, source_path)];
@@ -195,7 +195,7 @@ impl TemplateInput<'_> {
                 for n in nodes {
                     #[cfg(feature = "external-sources")]
                     let mut add_to_check = |new_path: Arc<Path>,
-                                            orig_path: &str|
+                                            original_path: &str|
                      -> Result<(), CompileError> {
                         if let std::collections::hash_map::Entry::Vacant(e) = map.entry(new_path) {
                             // Add a dummy entry to `map` in order to prevent adding `path`
@@ -204,7 +204,7 @@ impl TemplateInput<'_> {
                             let source = parsed.source();
                             let source = get_template_source(
                                 new_path,
-                                orig_path,
+                                original_path,
                                 Some((
                                     &path,
                                     source,
@@ -229,24 +229,25 @@ impl TemplateInput<'_> {
                             }
                             #[cfg(feature = "external-sources")]
                             {
-                                let extends_orig = extends.path;
+                                let original_path = extends.path;
                                 let extends = self.config.find_template(
-                                    extends_orig,
+                                    original_path,
                                     Some(&path),
                                     Some(FileInfo::of(extends.span(), &path, &parsed)),
                                     Some(self.source_span.config_span()),
                                 )?;
-                                orig_paths.insert(Arc::clone(&extends), extends_orig.to_owned());
+                                original_paths
+                                    .insert(Arc::clone(&extends), original_path.to_owned());
                                 let dependency_path = (path.clone(), extends.clone());
                                 if path == extends {
                                     // We add the path into the graph to have a better looking error.
                                     dependency_graph.push(dependency_path);
-                                    return cyclic_graph_error(&dependency_graph, &orig_paths);
+                                    return cyclic_graph_error(&dependency_graph, &original_paths);
                                 } else if dependency_graph.contains(&dependency_path) {
-                                    return cyclic_graph_error(&dependency_graph, &orig_paths);
+                                    return cyclic_graph_error(&dependency_graph, &original_paths);
                                 }
                                 dependency_graph.push(dependency_path);
-                                add_to_check(extends, extends_orig)?;
+                                add_to_check(extends, original_path)?;
                             }
                         }
                         Node::Macro(m) if top => {
@@ -264,15 +265,16 @@ impl TemplateInput<'_> {
                             }
                             #[cfg(feature = "external-sources")]
                             {
-                                let import_orig = import.path;
+                                let original_path = import.path;
                                 let import = self.config.find_template(
-                                    import_orig,
+                                    original_path,
                                     Some(&path),
                                     Some(FileInfo::of(import.span(), &path, &parsed)),
                                     Some(self.source_span.config_span()),
                                 )?;
-                                orig_paths.insert(Arc::clone(&import), import_orig.to_owned());
-                                add_to_check(import, import_orig)?;
+                                original_paths
+                                    .insert(Arc::clone(&import), original_path.to_owned());
+                                add_to_check(import, original_path)?;
                             }
                         }
                         Node::FilterBlock(f) => {
@@ -290,15 +292,16 @@ impl TemplateInput<'_> {
                             }
                             #[cfg(feature = "external-sources")]
                             {
-                                let include_orig = include.path;
+                                let original_path = include.path;
                                 let include = self.config.find_template(
-                                    include_orig,
+                                    original_path,
                                     Some(&path),
                                     Some(FileInfo::of(include.span(), &path, &parsed)),
                                     Some(self.source_span.config_span()),
                                 )?;
-                                orig_paths.insert(Arc::clone(&include), include_orig.to_owned());
-                                add_to_check(include, include_orig)?;
+                                original_paths
+                                    .insert(Arc::clone(&include), original_path.to_owned());
+                                add_to_check(include, original_path)?;
                             }
                         }
                         Node::BlockDef(b) => {
@@ -714,9 +717,9 @@ impl FromStr for Print {
 #[cfg(feature = "external-sources")]
 fn cyclic_graph_error(
     dependency_graph: &[(Arc<Path>, Arc<Path>)],
-    orig_paths: &HashMap<Arc<Path>, String>,
+    original_paths: &HashMap<Arc<Path>, String>,
 ) -> Result<(), CompileError> {
-    let fmt_path = |p: &Arc<Path>| match orig_paths.get(p) {
+    let fmt_path = |p: &Arc<Path>| match original_paths.get(p) {
         Some(orig) => format!("{orig:#?} (absolute path: {:#?})", p.display()),
         None => format!("{:#?}", p.display()),
     };

--- a/askama_derive/src/tests.rs
+++ b/askama_derive/src/tests.rs
@@ -1,7 +1,7 @@
 //! Files containing tests for generated code.
 
 use std::fmt;
-use std::path::Path;
+use std::path::{Path, absolute};
 
 use console::style;
 use prettyplease::unparse;
@@ -344,9 +344,9 @@ fn check_if_let_chain() {
 fn check_includes_only_once() {
     // In this test we make sure that every used template gets referenced exactly once.
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("templates");
-    let path1 = path.join("include1.html").canonicalize().unwrap();
-    let path2 = path.join("include2.html").canonicalize().unwrap();
-    let path3 = path.join("include3.html").canonicalize().unwrap();
+    let path1 = absolute(path.join("include1.html")).unwrap();
+    let path2 = absolute(path.join("include2.html")).unwrap();
+    let path3 = absolute(path.join("include3.html")).unwrap();
     compare(
         r#"{% include "include1.html" %}"#,
         &format!(

--- a/testing/templates/symlink-escape.html
+++ b/testing/templates/symlink-escape.html
@@ -1,0 +1,1 @@
+symlink-target

--- a/testing/templates/symlink-target
+++ b/testing/templates/symlink-target
@@ -1,0 +1,1 @@
+Hello, {{ name }}!

--- a/testing/tests/paths.rs
+++ b/testing/tests/paths.rs
@@ -1,3 +1,5 @@
+use askama::Template;
+
 // This test ensures that template paths work even when created from another file.
 #[test]
 fn cross_file_paths() {
@@ -11,4 +13,19 @@ fn cross_file_paths() {
 
     #[path = "./auxiliary/paths.rs"]
     mod a;
+}
+
+/// When a template is accessed via a symlink (e.g. in content-addressable storage where files
+/// lose their extensions), the HTML escaper must be selected based on the symlink's own
+/// extension, not the extension-less target file.
+#[test]
+fn symlink_preserves_extension_for_escaping() {
+    #[derive(Template)]
+    #[template(path = "symlink-escape.html")]
+    struct SymlinkEscapeTemplate<'a> {
+        name: &'a str,
+    }
+
+    let s = SymlinkEscapeTemplate { name: "<>&\"'" };
+    assert_eq!(s.render().unwrap(), "Hello, &#60;&#62;&#38;&#34;&#39;!");
 }

--- a/testing/tests/ui/cycle.stderr
+++ b/testing/tests/ui/cycle.stderr
@@ -1,6 +1,6 @@
 error: cyclic dependency in graph [
-           "\"$DIR/templates/cycle2.html/" --> \"$DIR/templates/cycle1.html/"",
-           "\"$DIR/templates/cycle1.html/" --> \"$DIR/templates/cycle1.html/"",
+           "\"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle2.html/" --> \"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/"",
+           "\"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/" --> \"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/"",
        ]
  --> tests/ui/cycle.rs:4:19
   |

--- a/testing/tests/ui/cycle.stderr
+++ b/testing/tests/ui/cycle.stderr
@@ -1,6 +1,6 @@
 error: cyclic dependency in graph [
-           "\"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle2.html/" --> \"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/"",
-           "\"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/" --> \"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/"",
+           "\"cycle2.html\" (absolute path: \"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle2.html/") --> \"cycle1.html\" (absolute path: \"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/")",
+           "\"cycle1.html\" (absolute path: \"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/") --> \"cycle1.html\" (absolute path: \"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/")",
        ]
  --> tests/ui/cycle.rs:4:19
   |

--- a/testing/tests/ui/cycle2.stderr
+++ b/testing/tests/ui/cycle2.stderr
@@ -1,5 +1,5 @@
 error: cyclic dependency in graph [
-           "\"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/" --> \"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/"",
+           "\"cycle1.html\" (absolute path: \"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/") --> \"cycle1.html\" (absolute path: \"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/")",
        ]
  --> tests/ui/cycle2.rs:4:19
   |

--- a/testing/tests/ui/cycle2.stderr
+++ b/testing/tests/ui/cycle2.stderr
@@ -1,5 +1,5 @@
 error: cyclic dependency in graph [
-           "\"$DIR/templates/cycle1.html/" --> \"$DIR/templates/cycle1.html/"",
+           "\"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/" --> \"$WORKSPACE/target/tests/trybuild/askama_testing/templates/cycle1.html/"",
        ]
  --> tests/ui/cycle2.rs:4:19
   |

--- a/testing/tests/ui/include-a-folder.stderr
+++ b/testing/tests/ui/include-a-folder.stderr
@@ -1,4 +1,4 @@
-error: unable to open template file '$DIR/templates/a_file_that_is_actually_a_folder.html': Is a directory (os error 21)
+error: unable to open template file '$WORKSPACE/target/tests/trybuild/askama_testing/templates/a_file_that_is_actually_a_folder.html': Is a directory (os error 21)
  --> YouCannotIncludeFolders.txt:1:2
        " include \"a_file_that_is_actually_a_folder.html\" %}"
  --> tests/ui/include-a-folder.rs:4:34

--- a/testing/tests/ui/include-a-folder.stderr
+++ b/testing/tests/ui/include-a-folder.stderr
@@ -1,4 +1,4 @@
-error: unable to open template file '$WORKSPACE/target/tests/trybuild/askama_testing/templates/a_file_that_is_actually_a_folder.html': Is a directory (os error 21)
+error: unable to open template file 'a_file_that_is_actually_a_folder.html' (absolute path: '$WORKSPACE/target/tests/trybuild/askama_testing/templates/a_file_that_is_actually_a_folder.html'): Is a directory (os error 21)
  --> YouCannotIncludeFolders.txt:1:2
        " include \"a_file_that_is_actually_a_folder.html\" %}"
  --> tests/ui/include-a-folder.rs:4:34


### PR DESCRIPTION
In our build system, we use content addressable storage, where the template files lose their extensions. For e.g. for the below

```rust
#[derive(Template)]
#[template(path = "sidebar.html")]
```

Which might become a file such as 

```
path/to/some/location/YGBgcnVzdAojW2Rlcml2ZShUZW1wbGF0ZSldCiNbdGVtcGxhdGUocGF0aCA9ICJzaWRlYmFyLmh0bWwiKV0KUmFuZG9tCmBgYAo=
```

As we have lost the extension, it defaults to empty strings [here](https://github.com/kaepr/askama/blob/1d3679f4259d24e1b342b61ca8bff91e47d6ab9a/askama_derive/src/input.rs#L91). So instead of applying the default HTML filter to escape symbols, it defaults to `None`.

The fix suggested switches to `absolute`, which avoids symlinking the template path. This preserves the file extension and the correct escaper is applied.

I am seeing other issues such as #288, #708 which also revolve around absolute / canonical paths. All the tests do pass with this change, but there are other workarounds to preserve the file path, which can possibly avoid affecting their systems.

For e.g. storing the file extension before passing `config.find_template` in the `TemplateInput::new`.

```rust
        } = args;

        let raw_ext = match &source {
            #[cfg(feature = "external-sources")]
            Source::Path(p) => Path::new(p.as_ref()).extension().and_then(|s| s.to_str()),
            _ => None,
        };

        // ...
        // Match extension against defined output formats

        let escaping = escaping
            .as_deref()
            .or_else(|| path.extension().and_then(|s| s.to_str()))
            .or_else(|| raw_ext) // it might be better to have this check first ?
            .unwrap_or_default();
```