### PR TITLE
Fix compiler error with recursive types on recursive templates by using `dyn` instead of plain generic bounds

### DIFF
--- a/askama/src/filters/alloc.rs
+++ b/askama/src/filters/alloc.rs
@@ -136,9 +136,9 @@ impl<S: fmt::Display> fmt::Display for Lower<S> {
 
 impl<S: FastWritable> FastWritable for Lower<S> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(
+    fn write_into(
         &self,
-        dest: &mut W,
+        dest: &mut dyn fmt::Write,
         values: &dyn crate::Values,
     ) -> crate::Result<()> {
         let mut buffer = String::new();
@@ -223,9 +223,9 @@ impl<S: fmt::Display> fmt::Display for Upper<S> {
 
 impl<S: FastWritable> FastWritable for Upper<S> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(
+    fn write_into(
         &self,
-        dest: &mut W,
+        dest: &mut dyn fmt::Write,
         values: &dyn crate::Values,
     ) -> crate::Result<()> {
         let mut buffer = String::new();
@@ -306,9 +306,9 @@ impl<S: fmt::Display> fmt::Display for Trim<S> {
 
 impl<S: FastWritable> FastWritable for Trim<S> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(
+    fn write_into(
         &self,
-        dest: &mut W,
+        dest: &mut dyn fmt::Write,
         values: &dyn crate::Values,
     ) -> crate::Result<()> {
         let mut collector = TrimCollector(String::new());
@@ -374,9 +374,9 @@ impl<S: fmt::Display> fmt::Display for Capitalize<S> {
 
 impl<S: FastWritable> FastWritable for Capitalize<S> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(
+    fn write_into(
         &self,
-        dest: &mut W,
+        dest: &mut dyn fmt::Write,
         values: &dyn crate::Values,
     ) -> crate::Result<()> {
         let mut buffer = String::new();
@@ -437,9 +437,9 @@ impl<S: fmt::Display> fmt::Display for Title<S> {
 
 impl<S: FastWritable> FastWritable for Title<S> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(
+    fn write_into(
         &self,
-        dest: &mut W,
+        dest: &mut dyn fmt::Write,
         values: &dyn crate::Values,
     ) -> crate::Result<()> {
         let mut buffer = String::new();

--- a/askama/src/filters/core.rs
+++ b/askama/src/filters/core.rs
@@ -51,11 +51,7 @@ impl<S: fmt::Display> fmt::Display for TruncateFilter<S> {
 
 impl<S: FastWritable> FastWritable for TruncateFilter<S> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(
-        &self,
-        dest: &mut W,
-        values: &dyn Values,
-    ) -> crate::Result<()> {
+    fn write_into(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
         self.source
             .write_into(&mut TruncateWriter::new(dest, self.remaining), values)
     }
@@ -448,11 +444,7 @@ impl<L: fmt::Display, R: fmt::Display> fmt::Display for Either<L, R> {
 
 impl<L: FastWritable, R: FastWritable> FastWritable for Either<L, R> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(
-        &self,
-        dest: &mut W,
-        values: &dyn Values,
-    ) -> crate::Result<()> {
+    fn write_into(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
         match self {
             Either::Left(value) => value.write_into(dest, values),
             Either::Right(value) => value.write_into(dest, values),
@@ -573,11 +565,7 @@ impl<S: fmt::Display> fmt::Display for Wordcount<S> {
 
 impl<S: FastWritable> FastWritable for Wordcount<S> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(
-        &self,
-        _: &mut W,
-        values: &dyn crate::Values,
-    ) -> crate::Result<()> {
+    fn write_into(&self, _: &mut dyn fmt::Write, values: &dyn crate::Values) -> crate::Result<()> {
         let mut inner = self.count.get();
         self.source
             .write_into(&mut WordCountWriter(&mut inner), values)?;
@@ -716,9 +704,9 @@ impl<S: fmt::Display> fmt::Display for NewlineCounting<S> {
 }
 
 impl<S: FastWritable> FastWritable for NewlineCounting<S> {
-    fn write_into<W: fmt::Write + ?Sized>(
+    fn write_into(
         &self,
-        dest: &mut W,
+        dest: &mut dyn fmt::Write,
         values: &dyn crate::Values,
     ) -> crate::Result<()> {
         self.run(dest, |f| self.source.write_into(f, values))
@@ -792,9 +780,9 @@ struct LinebreaksbrFormatter<'a, W: ?Sized>(&'a mut W);
 
 impl<S: FastWritable> FastWritable for Linebreaksbr<S> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(
+    fn write_into(
         &self,
-        dest: &mut W,
+        dest: &mut dyn fmt::Write,
         values: &dyn crate::Values,
     ) -> crate::Result<()> {
         self.0.write_into(&mut LinebreaksbrFormatter(dest), values)

--- a/askama/src/filters/escape.rs
+++ b/askama/src/filters/escape.rs
@@ -81,11 +81,7 @@ impl<T: fmt::Display, E: Escaper> fmt::Display for EscapeDisplay<T, E> {
 
 impl<T: FastWritable, E: Escaper> FastWritable for EscapeDisplay<T, E> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(
-        &self,
-        dest: &mut W,
-        values: &dyn Values,
-    ) -> crate::Result<()> {
+    fn write_into(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
         self.0.write_into(&mut EscapeWriter(dest, self.1), values)
     }
 }
@@ -311,11 +307,7 @@ const _: () = {
     // This is the fallback. The filter is not the last element of the filter chain.
     impl<T: FastWritable> FastWritable for MaybeSafe<T> {
         #[inline]
-        fn write_into<W: fmt::Write + ?Sized>(
-            &self,
-            dest: &mut W,
-            values: &dyn Values,
-        ) -> crate::Result<()> {
+        fn write_into(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
             let inner = match self {
                 MaybeSafe::Safe(inner) => inner,
                 MaybeSafe::NeedsEscaping(inner) => inner,
@@ -350,11 +342,7 @@ const _: () = {
     }
 
     impl<T: FastWritable + ?Sized, E: Escaper> FastWritable for Wrapped<'_, T, E> {
-        fn write_into<W: fmt::Write + ?Sized>(
-            &self,
-            dest: &mut W,
-            values: &dyn Values,
-        ) -> crate::Result<()> {
+        fn write_into(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
             match *self {
                 Wrapped::Safe(t) => t.write_into(dest, values),
                 Wrapped::NeedsEscaping(t, e) => EscapeDisplay(t, e).write_into(dest, values),
@@ -426,11 +414,7 @@ const _: () = {
     // This is the fallback. The filter is not the last element of the filter chain.
     impl<T: FastWritable> FastWritable for Safe<T> {
         #[inline]
-        fn write_into<W: fmt::Write + ?Sized>(
-            &self,
-            dest: &mut W,
-            values: &dyn Values,
-        ) -> crate::Result<()> {
+        fn write_into(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
             self.0.write_into(dest, values)
         }
     }
@@ -512,11 +496,7 @@ pub struct Writable<'a, S: ?Sized>(pub &'a S);
 /// Used internally by askama to select the appropriate [`write!()`] mechanism
 pub trait WriteWritable {
     /// Used internally by askama to select the appropriate [`write!()`] mechanism
-    fn askama_write<W: fmt::Write + ?Sized>(
-        &self,
-        dest: &mut W,
-        values: &dyn Values,
-    ) -> crate::Result<()>;
+    fn askama_write(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()>;
 }
 
 #[test]

--- a/askama/src/filters/humansize.rs
+++ b/askama/src/filters/humansize.rs
@@ -42,11 +42,7 @@ impl fmt::Display for FilesizeFormatFilter {
 }
 
 impl FastWritable for FilesizeFormatFilter {
-    fn write_into<W: fmt::Write + ?Sized>(
-        &self,
-        dest: &mut W,
-        values: &dyn Values,
-    ) -> crate::Result<()> {
+    fn write_into(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
         if self.bytes < 1000 {
             (self.bytes as u32).write_into(dest, values)?;
             return Ok(dest.write_str(" B")?);

--- a/askama/src/filters/indent.rs
+++ b/askama/src/filters/indent.rs
@@ -88,9 +88,9 @@ impl<S: fmt::Display, I: AsIndent> fmt::Display for Indent<S, I> {
 }
 
 impl<S: FastWritable, I: AsIndent> FastWritable for Indent<S, I> {
-    fn write_into<W: fmt::Write + ?Sized>(
+    fn write_into(
         &self,
-        dest: &mut W,
+        dest: &mut dyn fmt::Write,
         values: &dyn crate::Values,
     ) -> crate::Result<()> {
         let indent = self.indent.as_indent();

--- a/askama/src/filters/json.rs
+++ b/askama/src/filters/json.rs
@@ -102,7 +102,7 @@ struct ToJsonPretty<S, I> {
 
 impl<S: Serialize> FastWritable for ToJson<S> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(&self, f: &mut W, _: &dyn Values) -> crate::Result<()> {
+    fn write_into(&self, f: &mut dyn fmt::Write, _: &dyn Values) -> crate::Result<()> {
         serialize(f, &self.value, CompactFormatter)
     }
 }
@@ -116,7 +116,7 @@ impl<S: Serialize> fmt::Display for ToJson<S> {
 
 impl<S: Serialize, I: AsIndent> FastWritable for ToJsonPretty<S, I> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(&self, f: &mut W, _: &dyn Values) -> crate::Result<()> {
+    fn write_into(&self, f: &mut dyn fmt::Write, _: &dyn Values) -> crate::Result<()> {
         serialize(
             f,
             &self.value,

--- a/askama/src/filters/urlencode.rs
+++ b/askama/src/filters/urlencode.rs
@@ -111,11 +111,7 @@ impl<T: fmt::Display> fmt::Display for UrlencodeFilter<T> {
 
 impl<T: FastWritable> FastWritable for UrlencodeFilter<T> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(
-        &self,
-        f: &mut W,
-        values: &dyn Values,
-    ) -> crate::Result<()> {
+    fn write_into(&self, f: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
         self.0.write_into(&mut UrlencodeWriter(f, self.1), values)
     }
 }

--- a/askama/src/helpers.rs
+++ b/askama/src/helpers.rs
@@ -243,7 +243,7 @@ impl fmt::Display for Empty {
 
 impl FastWritable for Empty {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(&self, _: &mut W, _: &dyn Values) -> crate::Result<()> {
+    fn write_into(&self, _: &mut dyn fmt::Write, _: &dyn Values) -> crate::Result<()> {
         Ok(())
     }
 }
@@ -277,20 +277,16 @@ impl<L: fmt::Display, R: fmt::Display> fmt::Display for Concat<L, R> {
 
 impl<L: FastWritable, R: FastWritable> FastWritable for Concat<L, R> {
     #[inline]
-    fn write_into<W: fmt::Write + ?Sized>(
-        &self,
-        dest: &mut W,
-        values: &dyn Values,
-    ) -> crate::Result<()> {
+    fn write_into(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
         self.0.write_into(dest, values)?;
         self.1.write_into(dest, values)
     }
 }
 
 pub trait EnumVariantTemplate {
-    fn render_into_with_values<W: fmt::Write + ?Sized>(
+    fn render_into_with_values(
         &self,
-        writer: &mut W,
+        writer: &mut dyn fmt::Write,
         values: &dyn crate::Values,
     ) -> crate::Result<()>;
 }

--- a/askama/src/lib.rs
+++ b/askama/src/lib.rs
@@ -130,29 +130,29 @@ pub trait Template: fmt::Display + FastWritable {
 
     /// Renders the template to the given `writer` fmt buffer.
     #[inline]
-    fn render_into<W: fmt::Write + ?Sized>(&self, writer: &mut W) -> Result<()> {
+    fn render_into(&self, writer: &mut dyn fmt::Write) -> Result<()> {
         self.render_into_with_values(writer, NO_VALUES)
     }
 
     /// Renders the template to the given `writer` fmt buffer with provided [`Values`].
-    fn render_into_with_values<W: fmt::Write + ?Sized>(
+    fn render_into_with_values(
         &self,
-        writer: &mut W,
+        writer: &mut dyn fmt::Write,
         values: &dyn Values,
     ) -> Result<()>;
 
     /// Renders the template to the given `writer` io buffer.
     #[inline]
     #[cfg(feature = "std")]
-    fn write_into<W: io::Write + ?Sized>(&self, writer: &mut W) -> io::Result<()> {
+    fn write_into(&self, writer: &mut dyn io::Write) -> io::Result<()> {
         self.write_into_with_values(writer, NO_VALUES)
     }
 
     /// Renders the template to the given `writer` io buffer with provided [`Values`].
     #[cfg(feature = "std")]
-    fn write_into_with_values<W: io::Write + ?Sized>(
+    fn write_into_with_values(
         &self,
-        writer: &mut W,
+        writer: &mut dyn io::Write,
         values: &dyn Values,
     ) -> io::Result<()> {
         struct Wrapped<W: io::Write> {
@@ -208,14 +208,14 @@ impl<T: Template + ?Sized> Template for &T {
     }
 
     #[inline]
-    fn render_into<W: fmt::Write + ?Sized>(&self, writer: &mut W) -> Result<()> {
+    fn render_into(&self, writer: &mut dyn fmt::Write) -> Result<()> {
         <T as Template>::render_into(self, writer)
     }
 
     #[inline]
-    fn render_into_with_values<W: fmt::Write + ?Sized>(
+    fn render_into_with_values(
         &self,
-        writer: &mut W,
+        writer: &mut dyn fmt::Write,
         values: &dyn Values,
     ) -> Result<()> {
         <T as Template>::render_into_with_values(self, writer, values)
@@ -223,15 +223,15 @@ impl<T: Template + ?Sized> Template for &T {
 
     #[inline]
     #[cfg(feature = "std")]
-    fn write_into<W: io::Write + ?Sized>(&self, writer: &mut W) -> io::Result<()> {
+    fn write_into(&self, writer: &mut dyn io::Write) -> io::Result<()> {
         <T as Template>::write_into(self, writer)
     }
 
     #[inline]
     #[cfg(feature = "std")]
-    fn write_into_with_values<W: io::Write + ?Sized>(
+    fn write_into_with_values(
         &self,
-        writer: &mut W,
+        writer: &mut dyn io::Write,
         values: &dyn Values,
     ) -> io::Result<()> {
         <T as Template>::write_into_with_values(self, writer, values)
@@ -378,20 +378,16 @@ macro_rules! impl_for_ref {
 /// Types implementing this trait can be written without needing to employ an [`fmt::Formatter`].
 pub trait FastWritable {
     /// Used internally by askama to speed up writing some types.
-    fn write_into<W: fmt::Write + ?Sized>(
-        &self,
-        dest: &mut W,
-        values: &dyn Values,
-    ) -> crate::Result<()>;
+    fn write_into(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()>;
 }
 
 const _: () = {
     crate::impl_for_ref! {
         impl FastWritable for T {
             #[inline]
-            fn write_into<W: fmt::Write + ?Sized>(
+            fn write_into(
                 &self,
-                dest: &mut W,
+                dest: &mut dyn fmt::Write,
                 values: &dyn Values,
             ) -> crate::Result<()> {
                 <T>::write_into(self, dest, values)
@@ -405,11 +401,7 @@ const _: () = {
         <T as Deref>::Target: FastWritable,
     {
         #[inline]
-        fn write_into<W: fmt::Write + ?Sized>(
-            &self,
-            dest: &mut W,
-            values: &dyn Values,
-        ) -> crate::Result<()> {
+        fn write_into(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
             self.as_ref().get_ref().write_into(dest, values)
         }
     }
@@ -417,11 +409,7 @@ const _: () = {
     #[cfg(feature = "alloc")]
     impl<T: FastWritable + alloc::borrow::ToOwned + ?Sized> FastWritable for alloc::borrow::Cow<'_, T> {
         #[inline]
-        fn write_into<W: fmt::Write + ?Sized>(
-            &self,
-            dest: &mut W,
-            values: &dyn Values,
-        ) -> crate::Result<()> {
+        fn write_into(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
             T::write_into(self.as_ref(), dest, values)
         }
     }
@@ -431,9 +419,9 @@ const _: () = {
         ($($ty:ty)*) => { $(
             impl FastWritable for $ty {
                 #[inline]
-                fn write_into<W: fmt::Write + ?Sized>(
+                fn write_into(
                     &self,
-                    dest: &mut W,
+                    dest: &mut dyn fmt::Write,
                     values: &dyn Values,
                 ) -> crate::Result<()> {
                     itoa::Buffer::new().format(*self).write_into(dest, values)
@@ -452,9 +440,9 @@ const _: () = {
         ($($id:ident)*) => { $(
             impl FastWritable for core::num::$id {
                 #[inline]
-                fn write_into<W: fmt::Write + ?Sized>(
+                fn write_into(
                     &self,
-                    dest: &mut W,
+                    dest: &mut dyn fmt::Write,
                     values: &dyn Values,
                 ) -> crate::Result<()> {
                     self.get().write_into(dest, values)
@@ -470,11 +458,7 @@ const _: () = {
 
     impl FastWritable for str {
         #[inline]
-        fn write_into<W: fmt::Write + ?Sized>(
-            &self,
-            dest: &mut W,
-            _: &dyn Values,
-        ) -> crate::Result<()> {
+        fn write_into(&self, dest: &mut dyn fmt::Write, _: &dyn Values) -> crate::Result<()> {
             Ok(dest.write_str(self)?)
         }
     }
@@ -482,22 +466,14 @@ const _: () = {
     #[cfg(feature = "alloc")]
     impl FastWritable for alloc::string::String {
         #[inline]
-        fn write_into<W: fmt::Write + ?Sized>(
-            &self,
-            dest: &mut W,
-            values: &dyn Values,
-        ) -> crate::Result<()> {
+        fn write_into(&self, dest: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
             self.as_str().write_into(dest, values)
         }
     }
 
     impl FastWritable for bool {
         #[inline]
-        fn write_into<W: fmt::Write + ?Sized>(
-            &self,
-            dest: &mut W,
-            _: &dyn Values,
-        ) -> crate::Result<()> {
+        fn write_into(&self, dest: &mut dyn fmt::Write, _: &dyn Values) -> crate::Result<()> {
             Ok(dest.write_str(match self {
                 true => "true",
                 false => "false",
@@ -507,22 +483,14 @@ const _: () = {
 
     impl FastWritable for char {
         #[inline]
-        fn write_into<W: fmt::Write + ?Sized>(
-            &self,
-            dest: &mut W,
-            _: &dyn Values,
-        ) -> crate::Result<()> {
+        fn write_into(&self, dest: &mut dyn fmt::Write, _: &dyn Values) -> crate::Result<()> {
             Ok(dest.write_char(*self)?)
         }
     }
 
     impl FastWritable for fmt::Arguments<'_> {
         #[inline]
-        fn write_into<W: fmt::Write + ?Sized>(
-            &self,
-            dest: &mut W,
-            _: &dyn Values,
-        ) -> crate::Result<()> {
+        fn write_into(&self, dest: &mut dyn fmt::Write, _: &dyn Values) -> crate::Result<()> {
             Ok(match self.as_str() {
                 Some(s) => dest.write_str(s),
                 None => dest.write_fmt(*self),
@@ -532,9 +500,9 @@ const _: () = {
 
     impl<S: crate::Template + ?Sized> filters::WriteWritable for &filters::Writable<'_, S> {
         #[inline]
-        fn askama_write<W: fmt::Write + ?Sized>(
+        fn askama_write(
             &self,
-            dest: &mut W,
+            dest: &mut dyn fmt::Write,
             values: &dyn Values,
         ) -> crate::Result<()> {
             self.0.render_into_with_values(dest, values)
@@ -543,9 +511,9 @@ const _: () = {
 
     impl<S: FastWritable + ?Sized> filters::WriteWritable for &&filters::Writable<'_, S> {
         #[inline]
-        fn askama_write<W: fmt::Write + ?Sized>(
+        fn askama_write(
             &self,
-            dest: &mut W,
+            dest: &mut dyn fmt::Write,
             values: &dyn Values,
         ) -> crate::Result<()> {
             self.0.write_into(dest, values)
@@ -554,11 +522,7 @@ const _: () = {
 
     impl<S: fmt::Display + ?Sized> filters::WriteWritable for &&&filters::Writable<'_, S> {
         #[inline]
-        fn askama_write<W: fmt::Write + ?Sized>(
-            &self,
-            dest: &mut W,
-            _: &dyn Values,
-        ) -> crate::Result<()> {
+        fn askama_write(&self, dest: &mut dyn fmt::Write, _: &dyn Values) -> crate::Result<()> {
             Ok(write!(dest, "{}", self.0)?)
         }
     }
@@ -580,9 +544,9 @@ mod tests {
         struct Test;
 
         impl Template for Test {
-            fn render_into_with_values<W: fmt::Write + ?Sized>(
+            fn render_into_with_values(
                 &self,
-                writer: &mut W,
+                writer: &mut dyn fmt::Write,
                 _values: &dyn Values,
             ) -> Result<()> {
                 Ok(writer.write_str("test")?)
@@ -600,11 +564,7 @@ mod tests {
 
         impl FastWritable for Test {
             #[inline]
-            fn write_into<W: fmt::Write + ?Sized>(
-                &self,
-                f: &mut W,
-                values: &dyn Values,
-            ) -> crate::Result<()> {
+            fn write_into(&self, f: &mut dyn fmt::Write, values: &dyn Values) -> crate::Result<()> {
                 self.render_into_with_values(f, values)
             }
         }

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -266,14 +266,11 @@ impl<'a, 'h> Generator<'a, 'h> {
         let var_writer = crate::var_writer();
         let var_values = crate::var_values();
         quote_into!(buf, span, { {
-            fn render_into_with_values<AskamaW>(
+            fn render_into_with_values(
                 &self,
-                #var_writer: &mut AskamaW,
+                #var_writer: &mut dyn askama::helpers::core::fmt::Write,
                 #var_values: &dyn askama::Values,
-            ) -> askama::Result<()>
-            where
-                AskamaW: askama::helpers::core::fmt::Write + ?askama::helpers::core::marker::Sized,
-            {
+            ) -> askama::Result<()> {
                 #[allow(unused_imports)]
                 use askama::{
                     filters::{AutoEscape as _, WriteWritable as _},
@@ -360,14 +357,11 @@ impl<'a, 'h> Generator<'a, 'h> {
                 #template_buf
 
                 pub trait #trait_id {
-                    fn render_into_with_values<AskamaW>(
+                    fn render_into_with_values(
                         &self,
-                        writer: &mut AskamaW,
+                        writer: &mut dyn askama::helpers::core::fmt::Write,
                         values: &dyn askama::Values,
-                    ) -> askama::Result<()>
-                    where
-                        AskamaW:
-                            askama::helpers::core::fmt::Write + ?askama::helpers::core::marker::Sized;
+                    ) -> askama::Result<()>;
                 }
 
                 impl #impl_generics #ident #ty_generics #where_clause {
@@ -391,14 +385,11 @@ impl<'a, 'h> Generator<'a, 'h> {
                 impl #wrapper_impl_generics askama::Template
                 for #wrapper_id #wrapper_ty_generics #wrapper_where_clause {
                     #[inline]
-                    fn render_into_with_values<AskamaW>(
+                    fn render_into_with_values(
                         &self,
-                        writer: &mut AskamaW,
+                        writer: &mut dyn askama::helpers::core::fmt::Write,
                         values: &dyn askama::Values
-                    ) -> askama::Result<()>
-                    where
-                        AskamaW: askama::helpers::core::fmt::Write + ?askama::helpers::core::marker::Sized
-                    {
+                    ) -> askama::Result<()> {
                         <_ as #trait_id>::render_into_with_values(self.this, writer, values)
                     }
 
@@ -409,14 +400,11 @@ impl<'a, 'h> Generator<'a, 'h> {
                 impl #wrapper_impl_generics askama::FastWritable
                 for #wrapper_id #wrapper_ty_generics #wrapper_where_clause {
                     #[inline]
-                    fn write_into<AskamaW>(
+                    fn write_into(
                         &self,
-                        dest: &mut AskamaW,
+                        dest: &mut dyn askama::helpers::core::fmt::Write,
                         values: &dyn askama::Values,
-                    ) -> askama::Result<()>
-                    where
-                        AskamaW: askama::helpers::core::fmt::Write + ?askama::helpers::core::marker::Sized
-                    {
+                    ) -> askama::Result<()> {
                         <_ as askama::Template>::render_into_with_values(self, dest, values)
                     }
                 }

--- a/askama_derive/src/integration.rs
+++ b/askama_derive/src/integration.rs
@@ -70,14 +70,11 @@ fn impl_fast_writable(ast: &DeriveInput, buf: &mut Buffer) {
     quote_into!(buf, span, {
         {
             #[inline]
-            fn write_into<AskamaW>(
+            fn write_into(
                 &self,
-                dest: &mut AskamaW,
+                dest: &mut dyn askama::helpers::core::fmt::Write,
                 values: &dyn askama::Values,
-            ) -> askama::Result<()>
-            where
-                AskamaW: askama::helpers::core::fmt::Write + ?askama::helpers::core::marker::Sized,
-            {
+            ) -> askama::Result<()> {
                 askama::Template::render_into_with_values(self, dest, values)
             }
         }
@@ -396,14 +393,11 @@ pub(crate) fn build_template_enum(
     let var_writer = crate::var_writer();
     let var_values = crate::var_values();
     methods.extend(quote_spanned!(span =>
-        fn render_into_with_values<AskamaW>(
+        fn render_into_with_values(
             &self,
-            #var_writer: &mut AskamaW,
+            #var_writer: &mut dyn askama::helpers::core::fmt::Write,
             #var_values: &dyn askama::Values,
-        ) -> askama::Result<()>
-        where
-            AskamaW: askama::helpers::core::fmt::Write + ?askama::helpers::core::marker::Sized
-        {
+        ) -> askama::Result<()> {
             match *self {
                 #render_into_arms
             }

--- a/askama_derive/src/tests.rs
+++ b/askama_derive/src/tests.rs
@@ -50,14 +50,11 @@ fn compare_ex(
     let expected: syn::File = syn::parse_quote! {
         #[automatically_derived]
         impl askama::Template for Foo {
-            fn render_into_with_values<AskamaW>(
+            fn render_into_with_values(
                 &self,
-                __askama_writer: &mut AskamaW,
+                __askama_writer: &mut dyn askama::helpers::core::fmt::Write,
                 __askama_values: &dyn askama::Values,
-            ) -> askama::Result<()>
-            where
-                AskamaW: askama::helpers::core::fmt::Write + ?askama::helpers::core::marker::Sized,
-            {
+            ) -> askama::Result<()> {
                 #[allow(unused_imports)]
                 use askama::{
                     filters::{AutoEscape as _, WriteWritable as _},
@@ -83,14 +80,11 @@ fn compare_ex(
         #[automatically_derived]
         impl askama::FastWritable for Foo {
             #[inline]
-            fn write_into<AskamaW>(
+            fn write_into(
                 &self,
-                dest: &mut AskamaW,
+                dest: &mut dyn askama::helpers::core::fmt::Write,
                 values: &dyn askama::Values,
-            ) -> askama::Result<()>
-            where
-                AskamaW: askama::helpers::core::fmt::Write + ?askama::helpers::core::marker::Sized,
-            {
+            ) -> askama::Result<()> {
                 askama::Template::render_into_with_values(self, dest, values)
             }
         }

--- a/testing/tests/book_example_performance_fmt_call_fast_writable.rs
+++ b/testing/tests/book_example_performance_fmt_call_fast_writable.rs
@@ -21,9 +21,9 @@ impl fmt::Display for Name<'_> {
 }
 
 impl FastWritable for Name<'_> {
-    fn write_into<W: fmt::Write + ?Sized>(
+    fn write_into(
         &self,
-        dest: &mut W,
+        dest: &mut dyn fmt::Write,
         _values: &dyn askama::Values,
     ) -> askama::Result<()> {
         dest.write_str(self.surname)?;

--- a/testing/tests/recursive-template.rs
+++ b/testing/tests/recursive-template.rs
@@ -1,0 +1,34 @@
+use askama::Template;
+
+// This test ensures that the compiler doesn't fail because of type recursion.
+// This is a regression test for <https://github.com/askama-rs/askama/issues/393>.
+#[test]
+fn test_recursive_template_struct() {
+    #[derive(Template)]
+    #[template(
+        ext = "txt",
+        source = "{{name}}<{% for child in children %}{{ child }},{% endfor %}>"
+    )]
+    struct Person<'a> {
+        name: &'a str,
+        children: &'a [Person<'a>],
+    }
+
+    let a = Person {
+        name: "a",
+        children: &[],
+    };
+    let b = Person {
+        name: "b",
+        children: &[a],
+    };
+    assert_eq!(
+        Person {
+            name: "c",
+            children: &[b]
+        }
+        .render()
+        .unwrap(),
+        "c<b<a<>,>,>"
+    );
+}

--- a/testing/tests/recursive-template.rs
+++ b/testing/tests/recursive-template.rs
@@ -32,3 +32,23 @@ fn test_recursive_template_struct() {
         "c<b<a<>,>,>"
     );
 }
+
+// Same test but on enums.
+#[test]
+fn test_recursive_template_enum() {
+    #[derive(Template)]
+    enum HelloWorld<'a> {
+        #[template(source = r#"Hello, <strong>{{user}}</strong>!"#, ext = "txt")]
+        Primary { user: &'a str },
+        #[template(source = r#"{{subitem}}"#, ext = "txt")]
+        Secondary { subitem: &'a HelloWorld<'a> },
+    }
+
+    let primary = HelloWorld::Primary { user: "georgia" };
+    assert_eq!(
+        HelloWorld::Secondary { subitem: &primary }
+            .render()
+            .unwrap(),
+        "Hello, <strong>georgia</strong>!"
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/askama-rs/askama/issues/393.